### PR TITLE
Introduce SonarCloud quality analysis and tighten CI scope

### DIFF
--- a/.github/instructions/sonarqube_mcp.instructions.md
+++ b/.github/instructions/sonarqube_mcp.instructions.md
@@ -1,0 +1,42 @@
+---
+applyTo: "**/*"
+---
+
+These are some guidelines when using the SonarQube MCP server.
+
+# Important Tool Guidelines
+
+## Basic usage
+- **IMPORTANT**: After you finish generating or modifying any code files at the very end of the task, you MUST call the `analyze_file_list` tool (if it exists) to analyze the files you created or modified.
+- **IMPORTANT**: When starting a new task, you MUST disable automatic analysis with the `toggle_automatic_analysis` tool if it exists.
+- **IMPORTANT**: When you are done generating code at the very end of the task, you MUST re-enable automatic analysis with the `toggle_automatic_analysis` tool if it exists.
+
+## Project Keys
+- When a user mentions a project key, use `search_my_sonarqube_projects` first to find the exact project key
+- Don't guess project keys - always look them up
+
+## Code Language Detection
+- When analyzing code snippets, try to detect the programming language from the code syntax
+- If unclear, ask the user or make an educated guess based on syntax
+
+## Branch and Pull Request Context
+- Many operations support branch-specific analysis
+- If user mentions working on a feature branch, include the branch parameter
+
+## Code Issues and Violations
+- After fixing issues, do not attempt to verify them using `search_sonar_issues_in_projects`, as the server will not yet reflect the updates
+
+# Common Troubleshooting
+
+## Authentication Issues
+- SonarQube requires USER tokens (not project tokens)
+- When the error `SonarQube answered with Not authorized` occurs, verify the token type
+
+## Project Not Found
+- Use `search_my_sonarqube_projects` to find available projects
+- Verify project key spelling and format
+
+## Code Analysis Issues
+- Ensure programming language is correctly specified
+- Remind users that snippet analysis doesn't replace full project scans
+- Provide full file content for better analysis results

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -11,23 +11,31 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.10, 3.11]
+        python-version: ["3.10", "3.11"]
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: "pip"
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest
+          pip install -r requirements-dev.txt -r services/api_gateway/requirements.txt
 
-      - name: Run pytest (only tests/)
+      - name: Run hermetic pytest subset
+        env:
+          PYTHONPATH: .
+          SSF_AUDIO_BASE_DIR: ${{ runner.temp }}/audio
         run: |
-          echo "Running pytest on tests/ (scripts/ are intentionally skipped)"
-          pytest tests/ -q
+          echo "Running hermetic pytest subset on tests/ (integration, load and real-system suites are skipped in CI)"
+          pytest tests/ -q \
+            -m "not integration and not real_system" \
+            --ignore=tests/integration \
+            --ignore=tests/load \
+            --ignore=tests/integration_test_audio_validation.py

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -12,6 +12,7 @@ on:
 env:
   PYTHON_VERSION: '3.12'
   SONAR_HOST_URL: 'https://sonarcloud.io'
+  SONAR_ENABLED: ${{ secrets.SONAR_TOKEN != '' }}
 
 jobs:
   # Job 1: Code Formatting und Linting
@@ -258,7 +259,7 @@ jobs:
     name: SonarCloud Analysis
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    if: ${{ secrets.SONAR_TOKEN != '' }}
+    if: ${{ env.SONAR_ENABLED == 'true' }}
 
     steps:
     - name: Checkout Code

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -320,7 +320,7 @@ jobs:
 
     - name: SonarCloud Scan
       if: steps.sonar-config.outputs.enabled == 'true'
-      uses: SonarSource/sonarqube-scan-action@v5
+      uses: SonarSource/sonarqube-scan-action@v6
       env:
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         SONAR_HOST_URL: ${{ env.SONAR_HOST_URL }}

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Install dependencies
       run: |
         source .venv/bin/activate
-        pip install --upgrade pip
+        pip install --upgrade pip "setuptools<81"
         pip install -r requirements-dev.txt
 
     - name: Check code formatting with Black
@@ -299,15 +299,24 @@ jobs:
       if: steps.sonar-config.outputs.enabled == 'true'
       run: |
         source .venv/bin/activate
-        pip install --upgrade pip
+        pip install --upgrade pip "setuptools<81"
         pip install -r requirements-dev.txt -r services/api_gateway/requirements.txt
 
     - name: Run tests with coverage for Sonar
       if: steps.sonar-config.outputs.enabled == 'true'
+      env:
+        SSF_AUDIO_BASE_DIR: ${{ runner.temp }}/audio
       run: |
         source .venv/bin/activate
         export PYTHONPATH=.
-        pytest tests/ --cov=services --cov-report=xml:coverage.xml --cov-report=term
+        pytest tests/ \
+          -m "not integration and not real_system" \
+          --ignore=tests/integration \
+          --ignore=tests/load \
+          --ignore=tests/integration_test_audio_validation.py \
+          --cov=services \
+          --cov-report=xml:coverage.xml \
+          --cov-report=term
 
     - name: SonarCloud Scan
       if: steps.sonar-config.outputs.enabled == 'true'

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -12,7 +12,6 @@ on:
 env:
   PYTHON_VERSION: '3.12'
   SONAR_HOST_URL: 'https://sonarcloud.io'
-  SONAR_ENABLED: ${{ secrets.SONAR_TOKEN != '' }}
 
 jobs:
   # Job 1: Code Formatting und Linting
@@ -259,21 +258,37 @@ jobs:
     name: SonarCloud Analysis
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    if: ${{ env.SONAR_ENABLED == 'true' }}
+    outputs:
+      enabled: ${{ steps.sonar-config.outputs.enabled }}
 
     steps:
+    - name: Check Sonar configuration
+      id: sonar-config
+      run: |
+        if [ -n "${SONAR_TOKEN}" ]; then
+          echo "enabled=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "enabled=false" >> "$GITHUB_OUTPUT"
+          echo "::warning::SONAR_TOKEN not configured; skipping SonarCloud analysis"
+        fi
+      env:
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
     - name: Checkout Code
+      if: steps.sonar-config.outputs.enabled == 'true'
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
     - name: Setup Python
+      if: steps.sonar-config.outputs.enabled == 'true'
       uses: actions/setup-python@v5
       with:
         python-version: ${{ env.PYTHON_VERSION }}
         cache: 'pip'
 
     - name: Create virtual environment
+      if: steps.sonar-config.outputs.enabled == 'true'
       run: |
         python -m venv .venv
         source .venv/bin/activate
@@ -281,18 +296,21 @@ jobs:
         echo "$VIRTUAL_ENV/bin" >> $GITHUB_PATH
 
     - name: Install dependencies
+      if: steps.sonar-config.outputs.enabled == 'true'
       run: |
         source .venv/bin/activate
         pip install --upgrade pip
         pip install -r requirements-dev.txt -r services/api_gateway/requirements.txt
 
     - name: Run tests with coverage for Sonar
+      if: steps.sonar-config.outputs.enabled == 'true'
       run: |
         source .venv/bin/activate
         export PYTHONPATH=.
         pytest tests/ --cov=services --cov-report=xml:coverage.xml --cov-report=term
 
     - name: SonarCloud Scan
+      if: steps.sonar-config.outputs.enabled == 'true'
       uses: SonarSource/sonarqube-scan-action@v5
       env:
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
@@ -319,10 +337,12 @@ jobs:
         CODE_QUALITY_RESULT="${{ needs.code-quality.result }}"
         SECURITY_RESULT="${{ needs.security-analysis.result }}"
         SONAR_RESULT="${{ needs.sonar-analysis.result }}"
+        SONAR_ENABLED="${{ needs.sonar-analysis.outputs.enabled }}"
 
         echo "Code Quality Result: $CODE_QUALITY_RESULT"
         echo "Security Analysis Result: $SECURITY_RESULT"
         echo "Sonar Result: $SONAR_RESULT"
+        echo "Sonar Enabled: $SONAR_ENABLED"
 
         # Sonar is blocking once configured; missing secrets/vars keep the job skipped.
         if [ "$SONAR_RESULT" = "failure" ]; then
@@ -333,7 +353,7 @@ jobs:
         if [ "$CODE_QUALITY_RESULT" != "success" ] || [ "$SECURITY_RESULT" != "success" ]; then
           echo "::warning::Quality gate checks found issues in non-Sonar jobs"
           echo "Code quality and security should be reviewed."
-        elif [ "$SONAR_RESULT" = "skipped" ]; then
+        elif [ "$SONAR_ENABLED" != "true" ]; then
           echo "::warning::Sonar analysis skipped - configure SONAR_TOKEN (and optional Sonar variables if defaults do not match)"
         else
           echo "✅ Quality gate passed!"
@@ -370,12 +390,14 @@ jobs:
         fi
 
         # SonarCloud
-        if [ "${{ needs.sonar-analysis.result }}" == "success" ]; then
+        if [ "${{ needs.sonar-analysis.outputs.enabled }}" != "true" ]; then
+          echo "| SonarCloud | ⚠️ Skipped | Configure SONAR_TOKEN and optional Sonar variables if needed |" >> $GITHUB_STEP_SUMMARY
+        elif [ "${{ needs.sonar-analysis.result }}" == "success" ]; then
           echo "| SonarCloud | ✅ Passed | Analysis and quality gate successful |" >> $GITHUB_STEP_SUMMARY
         elif [ "${{ needs.sonar-analysis.result }}" == "failure" ]; then
           echo "| SonarCloud | ❌ Failed | Analysis or quality gate failed |" >> $GITHUB_STEP_SUMMARY
         else
-          echo "| SonarCloud | ⚠️ Skipped | Configure SONAR_TOKEN and optional Sonar variables if needed |" >> $GITHUB_STEP_SUMMARY
+          echo "| SonarCloud | ⚠️ Incomplete | Check Sonar job logs and configuration |" >> $GITHUB_STEP_SUMMARY
         fi
 
         # Type Checking (optional)

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -11,6 +11,7 @@ on:
 # Globale Umgebungsvariablen
 env:
   PYTHON_VERSION: '3.12'
+  SONAR_HOST_URL: 'https://sonarcloud.io'
 
 jobs:
   # Job 1: Code Formatting und Linting
@@ -252,11 +253,63 @@ jobs:
           echo "💡 Check requirements.txt files for conflicting or invalid dependencies"
         fi
 
-    # Job 5: Quality Gate Evaluation
+  # Job 5: SonarCloud Analysis
+  sonar-analysis:
+    name: SonarCloud Analysis
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    if: ${{ secrets.SONAR_TOKEN != '' }}
+
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Setup Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ env.PYTHON_VERSION }}
+        cache: 'pip'
+
+    - name: Create virtual environment
+      run: |
+        python -m venv .venv
+        source .venv/bin/activate
+        echo "VIRTUAL_ENV=$VIRTUAL_ENV" >> $GITHUB_ENV
+        echo "$VIRTUAL_ENV/bin" >> $GITHUB_PATH
+
+    - name: Install dependencies
+      run: |
+        source .venv/bin/activate
+        pip install --upgrade pip
+        pip install -r requirements-dev.txt -r services/api_gateway/requirements.txt
+
+    - name: Run tests with coverage for Sonar
+      run: |
+        source .venv/bin/activate
+        export PYTHONPATH=.
+        pytest tests/ --cov=services --cov-report=xml:coverage.xml --cov-report=term
+
+    - name: SonarCloud Scan
+      uses: SonarSource/sonarqube-scan-action@v5
+      env:
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        SONAR_HOST_URL: ${{ env.SONAR_HOST_URL }}
+      with:
+        args: >
+          -Dsonar.organization=${{ vars.SONAR_ORGANIZATION || github.repository_owner }}
+          -Dsonar.projectKey=${{ vars.SONAR_PROJECT_KEY || format('{0}_{1}', github.repository_owner, github.event.repository.name) }}
+          -Dsonar.python.version=${{ env.PYTHON_VERSION }}
+          -Dsonar.python.coverage.reportPaths=coverage.xml
+          -Dsonar.qualitygate.wait=true
+          -Dsonar.qualitygate.timeout=300
+
+  # Job 6: Quality Gate Evaluation
   quality-gate:
     name: Quality Gate
     runs-on: ubuntu-latest
-    needs: [code-quality, security-analysis]
+    needs: [code-quality, security-analysis, sonar-analysis]
     if: always()
 
     steps:
@@ -264,24 +317,33 @@ jobs:
       run: |
         CODE_QUALITY_RESULT="${{ needs.code-quality.result }}"
         SECURITY_RESULT="${{ needs.security-analysis.result }}"
+        SONAR_RESULT="${{ needs.sonar-analysis.result }}"
 
         echo "Code Quality Result: $CODE_QUALITY_RESULT"
         echo "Security Analysis Result: $SECURITY_RESULT"
+        echo "Sonar Result: $SONAR_RESULT"
 
-        # Quality gate is informational for now
-        if [ "$CODE_QUALITY_RESULT" != "success" ] || [ "$SECURITY_RESULT" != "success" ]; then
-          echo "::warning::Quality gate checks found issues"
-          echo "Code quality and security should be reviewed."
-        else
-          echo "✅ Quality gate passed!"
-          echo "All quality checks successful."
+        # Sonar is blocking once configured; missing secrets/vars keep the job skipped.
+        if [ "$SONAR_RESULT" = "failure" ]; then
+          echo "❌ Sonar quality gate failed"
+          exit 1
         fi
 
-  # Job 6: Quality Metrics Summary
+        if [ "$CODE_QUALITY_RESULT" != "success" ] || [ "$SECURITY_RESULT" != "success" ]; then
+          echo "::warning::Quality gate checks found issues in non-Sonar jobs"
+          echo "Code quality and security should be reviewed."
+        elif [ "$SONAR_RESULT" = "skipped" ]; then
+          echo "::warning::Sonar analysis skipped - configure SONAR_TOKEN (and optional Sonar variables if defaults do not match)"
+        else
+          echo "✅ Quality gate passed!"
+          echo "All blocking quality checks successful."
+        fi
+
+  # Job 7: Quality Metrics Summary
   quality-summary:
     name: Quality Summary
     runs-on: ubuntu-latest
-    needs: [code-quality, security-analysis, type-checking, dependency-analysis, quality-gate]
+    needs: [code-quality, security-analysis, type-checking, dependency-analysis, sonar-analysis, quality-gate]
     if: always()
 
     steps:
@@ -304,6 +366,15 @@ jobs:
           echo "| Security | ✅ Passed | No critical security issues found |" >> $GITHUB_STEP_SUMMARY
         else
           echo "| Security | ❌ Failed | Critical security issues detected |" >> $GITHUB_STEP_SUMMARY
+        fi
+
+        # SonarCloud
+        if [ "${{ needs.sonar-analysis.result }}" == "success" ]; then
+          echo "| SonarCloud | ✅ Passed | Analysis and quality gate successful |" >> $GITHUB_STEP_SUMMARY
+        elif [ "${{ needs.sonar-analysis.result }}" == "failure" ]; then
+          echo "| SonarCloud | ❌ Failed | Analysis or quality gate failed |" >> $GITHUB_STEP_SUMMARY
+        else
+          echo "| SonarCloud | ⚠️ Skipped | Configure SONAR_TOKEN and optional Sonar variables if needed |" >> $GITHUB_STEP_SUMMARY
         fi
 
         # Type Checking (optional)

--- a/.sonarlint/connectedMode.json
+++ b/.sonarlint/connectedMode.json
@@ -1,0 +1,5 @@
+{
+    "sonarCloudOrganization": "smart-village-app",
+    "projectKey": "smart-village-solutions_smart-speech-flow",
+    "region": "EU"
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,8 +68,6 @@ open htmlcov/index.html  # Linux/Mac
 start htmlcov/index.html # Windows
 ```
 
-**Test Status:** 234/242 tests passing (96.7%). See [TEST_STATUS.md](TEST_STATUS.md) for details.
-
 **Learn more:** [Testing Guide](docs/testing/TESTING_GUIDE.md)
 
 ## 📝 Code Style
@@ -94,6 +92,23 @@ bandit -r services/
 # Run all quality checks
 ./scripts/quality-check.sh
 ```
+
+### SonarCloud in CI
+
+Pull requests and tracked branches are additionally analyzed in SonarCloud through the GitHub Actions quality workflow.
+
+Repository administrators need to configure:
+
+- `SONAR_TOKEN` as a GitHub Actions secret
+- optional `SONAR_ORGANIZATION` as a repository variable
+- optional `SONAR_PROJECT_KEY` as a repository variable
+
+If the optional variables are omitted, the workflow falls back to:
+
+- organization: GitHub repository owner
+- project key: `<repository_owner>_<repository_name>`
+
+SonarCloud complements the existing local tools. Contributors are not expected to run Sonar locally for normal development, but pull requests should be prepared so that linting, tests, and static analysis pass cleanly.
 
 **Configuration:**
 - Black: line length 100, Python 3.12+

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ docker compose up -d
 curl http://localhost:8000/health
 ```
 
-**Das war's!** Die API ist unter `http://localhost:8000` verfügbar.
+**Das war's!** Die API ist unter `http://localhost:8000` verfuegbar.
 
 > **🔐 Security Notes:**
 > - **Frontend Demo Password:** Set in `.env` → `FRONTEND_DEMO_PASSWORD` (default: `ssf2025kassel`)
@@ -55,13 +55,23 @@ curl http://localhost:8000/health
 ### Erste API-Anfrage
 
 ```bash
-# Pipeline testen: Deutsch → Englisch
+# Legacy/Low-Level Pipeline testen: Deutsch -> Englisch
 curl -F "file=@examples/audio/sample.wav" \
      -F "source_lang=de" \
      -F "target_lang=en" \
      http://localhost:8000/pipeline \
      --output translated.wav
 ```
+
+### Empfohlener Einstieg fuer Frontends
+
+Der aktuelle Haupt-Workflow fuer Admin/Customer-Kommunikation ist sessionbasiert:
+
+1. `POST /api/admin/session/create`
+2. `POST /api/customer/session/activate`
+3. `POST /api/session/{session_id}/message`
+4. `GET /api/session/{session_id}/messages`
+5. `WS /ws/{session_id}/{client_type}`
 
 ## 📚 Documentation
 
@@ -98,7 +108,7 @@ curl -F "file=@examples/audio/sample.wav" \
 - **Port:** 8001
 - **Funktion:** Automatische Spracherkennung für verschiedene Sprachen und Audioformate
 - **Modelle:** Whisper, Wav2Vec, etc. (lokal geladen)
-- **Endpunkte:** `/transcribe` (POST), `/health` (GET), `/metrics` (GET), `/languages` (GET)
+- **Endpunkte:** `/transcribe` (POST), `/health` (GET), `/metrics` (GET), `/supported-languages` (GET)
 - **Beispiel:**
    ```bash
    curl -F "file=@sample.wav" http://localhost:8001/transcribe
@@ -118,7 +128,7 @@ curl -F "file=@examples/audio/sample.wav" \
 ### 3. TTS Service (Text-to-Speech)
 - **Port:** 8003
 - **Funktion:** Sprachsynthese für viele Sprachen mit Coqui-TTS und HuggingFace MMS-TTS
-- **Endpunkte:** `/synthesize` (POST), `/health` (GET), `/metrics` (GET)
+- **Endpunkte:** `/synthesize` (POST), `/health` (GET), `/metrics` (GET), `/supported-languages` (GET)
 - **Beispiel:**
    ```bash
    curl -X POST http://localhost:8003/synthesize \
@@ -129,9 +139,10 @@ curl -F "file=@examples/audio/sample.wav" \
 ### 4. API-Gateway
 - **Port:** 8000
 - **Funktion:** Zentrales REST-API für alle Sprachdienste
-- **Endpunkte:** `/pipeline` (POST), `/upload` (POST), `/health` (GET), `/metrics` (GET)
-- **Pipeline:** Orchestriert die gesamte Pipeline: ASR → Translation → TTS
-- **Beispiel für End-to-End:**
+- **Primaere Endpunkte:** Session- und Messaging-API unter `/api/*`
+- **Legacy/Low-Level Endpunkte:** `/pipeline` (POST), `/upload` (POST), `/health` (GET), `/metrics` (GET)
+- **Session-Workflow:** Admin erstellt Session, Customer aktiviert sie, Nachrichten laufen ueber den Unified Message Endpoint
+- **Beispiel fuer End-to-End Pipeline:**
    ```bash
    curl -F "file=@sample.wav" -F "source_lang=de" -F "target_lang=en" http://localhost:8000/pipeline --output output.wav
    ```
@@ -162,7 +173,7 @@ curl -F "file=@examples/audio/sample.wav" \
 | Service        | Endpunkt         | Methode | Beschreibung                       |
 |----------------|------------------|---------|------------------------------------|
 | ASR            | `/transcribe`    | POST    | Audiodatei → Text                  |
-| ASR            | `/languages`     | GET     | Unterstützte Sprachen              |
+| ASR            | `/supported-languages` | GET | Unterstuetzte Sprachen             |
 | ASR            | `/health`        | GET     | Status, Modellinfos                |
 | ASR            | `/metrics`       | GET     | Monitoring                         |
 | Translation    | `/translate`     | POST    | Textübersetzung                    |
@@ -170,11 +181,16 @@ curl -F "file=@examples/audio/sample.wav" \
 | Translation    | `/health`        | GET     | Status, Modellinfos                |
 | Translation    | `/metrics`       | GET     | Monitoring                         |
 | TTS            | `/synthesize`    | POST    | Text → Sprache (WAV)               |
+| TTS            | `/supported-languages` | GET | Unterstuetzte Sprachen             |
 | TTS            | `/health`        | GET     | Status, Modellinfos                |
 | TTS            | `/metrics`       | GET     | Monitoring                         |
-| API-Gateway    | `/pipeline`      | POST    | End-to-End (ASR → Trans → TTS)     |
-| API-Gateway    | `/upload`        | POST    | Upload mit HTML-Response           |
-| API-Gateway    | `/health`        | GET     | Status aller Services              |
+| API-Gateway    | `/api/admin/session/create` | POST | Neue Admin-Session erstellen |
+| API-Gateway    | `/api/customer/session/activate` | POST | Customer-Session aktivieren |
+| API-Gateway    | `/api/session/{id}/message` | POST | Unified Message Endpoint fuer Text und Audio |
+| API-Gateway    | `/api/session/{id}/messages` | GET | Nachrichtenhistorie einer Session |
+| API-Gateway    | `/api/languages/supported` | GET | Unterstuetzte Frontend-Sprachen |
+| API-Gateway    | `/pipeline`      | POST    | Legacy/Low-Level End-to-End-Pipeline |
+| API-Gateway    | `/health`        | GET     | Status der angebundenen Services   |
 | API-Gateway    | `/metrics`       | GET     | Monitoring                         |
 
 ## 🛠️ Installation & Setup
@@ -243,23 +259,24 @@ pytest --cov=services --cov-report=html
 pytest tests/load/
 ```
 
-**Test Status:** 234/242 tests passing (96.7%) – See [TEST_STATUS.md](TEST_STATUS.md)
+Die Test-Suite umfasst Unit-, Integrations- und Lasttests. Fuer den aktuellen Stand sollte immer `pytest` bzw. die CI-Pipeline als Referenz genutzt werden.
 
 **Learn more:** [Testing Guide](docs/testing/TESTING_GUIDE.md)
 
 
-## � Monitoring & Operations
+## Monitoring & Operations
 
 ### Quick Access
 - **Prometheus:** `http://prometheus-ssf.smart-village.solutions` (metrics aggregation)
 - **Grafana:** `http://grafana-ssf.smart-village.solutions` (dashboards, login: `admin`/`admin`)
 - **Service Metrics:** `http://localhost:8000/metrics` (each service exposes metrics)
 
-### Dashboards
-Pre-built Grafana dashboards in `monitoring/grafana/dashboards/`:
-- `service-health.json` – Service status & uptime
-- `pipeline-performance.json` – Latency & throughput
-- `dcgm-exporter.json` – GPU monitoring (temperature, memory, utilization)
+### Konfiguration
+Monitoring-Konfigurationen liegen unter `monitoring/`, zum Beispiel:
+- `monitoring/prometheus.yml`
+- `monitoring/alert_rules.yml`
+- `monitoring/loki-config.yaml`
+- `monitoring/promtail-config.yaml`
 
 ### Alerting
 Prometheus alerts configured in `monitoring/alert_rules.yml`:

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,6 @@ Welcome to the Smart Speech Flow Backend documentation! This guide helps you fin
 - [Frontend Integration Guide](guides/frontend-integration.md) - How to integrate with the frontend
 - [API Conventions](guides/api-conventions.md) - API design patterns and standards
 - [Code Quality Standards](testing/code-quality.md) - Coding standards and quality checks
-- [Smartspeechflow.de Konzept](smartspeechflow-de-konzept.md) - Product presentation, sitemap and design briefing
 
 ### For Operators
 - [Deployment Rollback Procedure](operations/deployment-rollback-procedure.md) - How to rollback deployments

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ Welcome to the Smart Speech Flow Backend documentation! This guide helps you fin
 - [Frontend Integration Guide](guides/frontend-integration.md) - How to integrate with the frontend
 - [API Conventions](guides/api-conventions.md) - API design patterns and standards
 - [Code Quality Standards](testing/code-quality.md) - Coding standards and quality checks
+- [Smartspeechflow.de Konzept](smartspeechflow-de-konzept.md) - Product presentation, sitemap and design briefing
 
 ### For Operators
 - [Deployment Rollback Procedure](operations/deployment-rollback-procedure.md) - How to rollback deployments

--- a/docs/architecture/SYSTEM_ARCHITECTURE.md
+++ b/docs/architecture/SYSTEM_ARCHITECTURE.md
@@ -357,7 +357,7 @@ Interne Service-Kommunikation erfolgt über das Docker-Netzwerk (`http://api_gat
 
 **API-Endpunkte (intern):**
 - `http://asr:8000/transcribe`: Hauptendpunkt für Audio-zu-Text-Konvertierung
-- `http://asr:8000/languages`: Unterstützte Sprachen abrufen
+- `http://asr:8000/supported-languages`: Unterstuetzte Sprachen abrufen
 - `http://asr:8000/health`: Service-Status und GPU-Informationen
 
 ### **Translation Service** *(Interner Host: `http://translation:8000`)*
@@ -401,7 +401,7 @@ Interne Service-Kommunikation erfolgt über das Docker-Netzwerk (`http://api_gat
 
 **API-Endpunkte (intern):**
 - `http://tts:8000/synthesize`: Text-zu-Audio-Konvertierung (WAV)
-- `http://tts:8000/voices`: Verfügbare Stimmen pro Sprache
+- `http://tts:8000/supported-languages`: Unterstuetzte Sprachcodes abrufen
 - `http://tts:8000/health`: TTS-Model-Status und Verfügbarkeit
 
 ## 📊 Monitoring & Logging-Architektur

--- a/docs/guides/customer-api.md
+++ b/docs/guides/customer-api.md
@@ -87,9 +87,9 @@ Gets session status from customer perspective.
 - `can_send_messages`: `true` if messaging is enabled (same as `is_active`)
 - `customer_language`: Language selected during activation
 
-## GET /api/customer/languages/supported
+## GET /api/languages/supported
 
-Returns supported languages for customer interface.
+Returns the supported language map for the frontend, including default and popular languages.
 
 ### Response (200)
 
@@ -151,7 +151,7 @@ if (status.can_send_messages) {
 
 ### 3. Frontend Integration Points
 
-- **Language Selection**: Use `/api/customer/languages/supported` to populate language picker
+- **Language Selection**: Use `/api/languages/supported` to populate language picker
 - **Session Activation**: Call `/api/customer/session/activate` after language selection
 - **Status Polling**: Use `/api/customer/session/{id}/status` to monitor session state
 - **Error Handling**: Handle 404 (session not found) and 400 (already terminated) appropriately

--- a/docs/guides/frontend-integration.md
+++ b/docs/guides/frontend-integration.md
@@ -42,14 +42,13 @@ const data = await response.json();
 // {
 //   "session_id": "ABC12345",
 //   "status": "pending",
-//   "client_url": "https://ssf.../customer/ABC12345",
-//   "qr_code_data": "https://ssf.../customer/ABC12345",
+//   "client_url": "https://translate.smart-village.solutions/join/ABC12345",
 //   "created_at": "2025-11-05T20:00:00Z",
 //   "message": "Session ABC12345 erfolgreich erstellt"
 // }
 
 const sessionId = data.session_id;
-const qrCodeURL = data.qr_code_data; // Für QR-Code Generator
+const qrCodeURL = data.client_url; // Fuer QR-Code Generator oder Deeplink
 ```
 
 ### 2. Customer: Session aktivieren
@@ -58,7 +57,7 @@ const qrCodeURL = data.qr_code_data; // Für QR-Code Generator
 // Customer scannt QR-Code → extrahiert session_id aus URL
 
 // Sprachen laden
-const langResponse = await fetch(`${CONFIG.API_BASE}/api/customer/languages/supported`);
+const langResponse = await fetch(`${CONFIG.API_BASE}/api/languages/supported`);
 const languages = await langResponse.json();
 // {
 //   "languages": {
@@ -503,11 +502,11 @@ Session wurde beendet.
 ```
 1. [QR-Code scannen]
    ↓
-   URL: https://ssf.../customer/ABC12345
+   URL: https://translate.smart-village.solutions/join/ABC12345
    Extrahiere: session_id
    ↓
 2. [Sprache wählen]
-   GET /api/customer/languages/supported
+   GET /api/languages/supported
    ↓
    Zeige: Sprachauswahl (de, en, ar, tr, ...)
    ↓
@@ -772,7 +771,7 @@ function Chat({ sessionId, userType }) {
 - [ ] Alle Message Types werden behandelt (connection_ack, heartbeat, message, client_joined, session_terminated)
 - [ ] Audio-Player für `audio_url` integriert
 - [ ] Session-Aktivierung für Customer implementiert
-- [ ] QR-Code Generator für Admin (nutze `qr_code_data` aus API)
+- [ ] QR-Code Generator fuer Admin (nutze `client_url` aus API)
 - [ ] Error Handling für API-Fehler (400, 404, 500)
 - [ ] UI zeigt Verbindungsstatus an (🟢/🔴)
 - [ ] Reconnection-Hinweis für User

--- a/docs/testing/TESTING_GUIDE.md
+++ b/docs/testing/TESTING_GUIDE.md
@@ -12,12 +12,13 @@ This guide covers all testing aspects of the Smart Speech Flow Backend project.
 
 ## Test Overview
 
-**Total Tests:** 242
-- ✅ **234 passing** (96.7%)
-- ⚠️ **7 flaky** (2.9%) - intermittent failures
-- ⏭️ **1 skipped** (0.4%)
+The repository contains:
 
-See [TEST_STATUS.md](../TEST_STATUS.md) for detailed analysis.
+- unit tests for service and gateway logic
+- integration tests for session, audio and websocket flows
+- load tests for production-like websocket scenarios
+
+Because the suite changes over time, this guide intentionally does not hardcode pass/fail counts. Use the latest local `pytest` run or CI results as the source of truth.
 
 ## Running Tests
 

--- a/docs/testing/code-quality.md
+++ b/docs/testing/code-quality.md
@@ -27,7 +27,7 @@ Das Projekt verwendet automatisierte Tools zur Sicherstellung von Code-Qualität
 #### flake8 (Linting)
 - **Zweck**: Code-Stil und potenzielle Fehler erkennen
 - **Konfiguration**: `setup.cfg`
-- **Max. Zeilenlaenge**: 100 Zeichen
+- **Max. Zeilenlaenge**: 88 Zeichen
 - **Ausführung**: `flake8 services/`
 - **Ignorierte Regeln**: E203, W503, E501 (Black-Kompatibilität)
 

--- a/docs/testing/code-quality.md
+++ b/docs/testing/code-quality.md
@@ -12,7 +12,7 @@ Das Projekt verwendet automatisierte Tools zur Sicherstellung von Code-Qualität
 
 #### Black (Code Formatter)
 - **Zweck**: Konsistente Python-Code-Formatierung
-- **Konfiguration**: 88 Zeichen Zeilenlänge
+- **Konfiguration**: 100 Zeichen Zeilenlaenge
 - **Ausführung**: `black services/`
 - **Pre-commit**: Automatisch bei jedem Commit
 
@@ -27,7 +27,7 @@ Das Projekt verwendet automatisierte Tools zur Sicherstellung von Code-Qualität
 #### flake8 (Linting)
 - **Zweck**: Code-Stil und potenzielle Fehler erkennen
 - **Konfiguration**: `setup.cfg`
-- **Max. Zeilenlänge**: 88 Zeichen
+- **Max. Zeilenlaenge**: 100 Zeichen
 - **Ausführung**: `flake8 services/`
 - **Ignorierte Regeln**: E203, W503, E501 (Black-Kompatibilität)
 
@@ -49,7 +49,15 @@ Das Projekt verwendet automatisierte Tools zur Sicherstellung von Code-Qualität
 #### pip-audit (Dependency Scanner)
 - **Zweck**: Bekannte Sicherheitslücken in Dependencies
 - **Ausführung**: `pip-audit`
-- **Verhalten**: Blockiert bei bekannten Vulnerabilities
+- **Verhalten**: Der Report wird in CI erzeugt; Blocking-Regeln koennen schrittweise verschaerft werden
+
+### 5. Zentralisierte Qualitaetsanalyse
+
+#### SonarCloud
+- **Zweck**: Zentrale Analyse fuer Maintainability, Code Smells, Duplication und Quality Gates
+- **Ausfuehrung**: In GitHub Actions ueber die Code-Quality-Pipeline
+- **Scope**: Aktive Backend- und relevante Frontend-Quellpfade, keine Archive oder Laufzeitdaten
+- **Qualitaetsgate**: Wird in CI ausgewertet, sobald die SonarCloud-Repository-Konfiguration vorhanden ist
 
 ### 4. Type-Checking (Graduell)
 
@@ -66,7 +74,7 @@ Das Projekt verwendet automatisierte Tools zur Sicherstellung von Code-Qualität
 2. **Import-Sortierung**: Muss isort-Standards erfüllen
 3. **Linting**: Keine kritischen flake8-Fehler
 4. **Sicherheit**: Keine High/Critical Bandit-Issues
-5. **Dependencies**: Keine bekannten Vulnerabilities
+5. **Sonar Quality Gate**: Muss im konfigurierten CI-Setup erfolgreich sein
 
 ### Advisory (Nicht-blockierend)
 1. **Type-Coverage**: Graduelle Verbesserung angestrebt
@@ -99,9 +107,24 @@ pip-audit                     # Dependency-Check
 
 ### CI/CD Pipeline
 - **Trigger**: Push/PR auf main/develop
-- **Jobs**: Code-Quality, Security, Type-Checking, Dependencies
+- **Jobs**: Code-Quality, Security, Type-Checking, Dependencies, SonarCloud
 - **Reports**: Artifacts für alle Tool-Outputs
-- **Quality Gate**: Blockiert Merge bei kritischen Fehlern
+- **Quality Gate**: SonarCloud liefert zentrales Qualitaetsfeedback fuer PRs und Branches
+
+### SonarCloud-Konfiguration
+
+Fuer die GitHub-Integration werden folgende Repository-Einstellungen benoetigt:
+
+- Secret: `SONAR_TOKEN`
+- optional Repository Variable: `SONAR_ORGANIZATION`
+- optional Repository Variable: `SONAR_PROJECT_KEY`
+
+Falls die Variablen nicht gesetzt werden, verwendet der Workflow standardmaessig:
+
+- Sonar-Organisation = GitHub Repository Owner
+- Sonar Project Key = `<repository_owner>_<repository_name>`
+
+Die Scanner-Konfiguration liegt in `sonar-project.properties`.
 
 ## 📊 Metriken und Monitoring
 
@@ -143,6 +166,7 @@ pip-audit                     # Dependency-Check
 ├── pyproject.toml              # Tool-Konfigurationen (Black, isort, mypy)
 ├── setup.cfg                   # flake8-Konfiguration
 ├── requirements-dev.txt        # Entwicklungs-Dependencies
+├── sonar-project.properties    # SonarCloud-Analysekonfiguration
 └── .github/workflows/
     └── code-quality.yml        # CI/CD Quality Pipeline
 ```

--- a/docs/testing/code-quality.md
+++ b/docs/testing/code-quality.md
@@ -51,7 +51,7 @@ Das Projekt verwendet automatisierte Tools zur Sicherstellung von Code-Qualität
 - **Ausführung**: `pip-audit`
 - **Verhalten**: Der Report wird in CI erzeugt; Blocking-Regeln koennen schrittweise verschaerft werden
 
-### 5. Zentralisierte Qualitaetsanalyse
+### 4. Zentralisierte Qualitaetsanalyse
 
 #### SonarCloud
 - **Zweck**: Zentrale Analyse fuer Maintainability, Code Smells, Duplication und Quality Gates
@@ -59,7 +59,7 @@ Das Projekt verwendet automatisierte Tools zur Sicherstellung von Code-Qualität
 - **Scope**: Aktive Backend- und relevante Frontend-Quellpfade, keine Archive oder Laufzeitdaten
 - **Qualitaetsgate**: Wird in CI ausgewertet, sobald die SonarCloud-Repository-Konfiguration vorhanden ist
 
-### 4. Type-Checking (Graduell)
+### 5. Type-Checking (Graduell)
 
 #### MyPy (Type Checker)
 - **Zweck**: Statische Typenprüfung

--- a/openspec/changes/add-sonar-quality-analysis/design.md
+++ b/openspec/changes/add-sonar-quality-analysis/design.md
@@ -1,0 +1,71 @@
+## Context
+
+The project already contains a dedicated GitHub Actions workflow for code quality checks. Sonar should complement that pipeline by adding maintainability and quality-gate visibility without creating redundant or conflicting checks.
+
+The repository is primarily Python-based, with a smaller TypeScript frontend. The initial Sonar integration should focus on practical value and low operational friction.
+
+## Goals / Non-Goals
+
+- Goals:
+  - Add centralized quality analysis and PR feedback
+  - Preserve the current quality toolchain
+  - Minimize CI duplication and maintenance overhead
+  - Support future expansion to coverage and multi-language analysis
+- Non-Goals:
+  - Replace existing lint/security jobs
+  - Enforce every Sonar rule from day one
+  - Build a self-hosted Sonar platform in this change
+
+## Decisions
+
+- Decision: Use **SonarCloud** as the default target.
+  - Why: best fit with the existing GitHub Actions setup, lower operational overhead, easier PR integration.
+
+- Decision: Keep existing CI jobs and add Sonar as an additional analysis stage.
+  - Why: Sonar adds value on top of current tooling but does not replace formatting, security, or type checks.
+
+- Decision: Start with repository-level analysis and a conservative quality gate.
+  - Why: avoids blocking adoption with a large backlog of legacy findings.
+
+- Decision: Scope the first rollout to active source directories and explicitly exclude generated, archived, and operational data paths.
+  - Why: prevents noisy results and keeps analysis relevant.
+
+## Alternatives Considered
+
+- Self-hosted SonarQube first:
+  - rejected as default because it adds infrastructure and credential management complexity immediately.
+
+- Replacing existing checks with Sonar only:
+  - rejected because Sonar is not a drop-in replacement for formatting, Bandit, or pip-audit.
+
+- Frontend-only or backend-only rollout:
+  - rejected because both areas contribute to code health, even if Python remains the main focus.
+
+## Risks / Trade-offs
+
+- Risk: Sonar introduces noisy findings on legacy code.
+  - Mitigation: start with a conservative gate and document remediation phases.
+
+- Risk: CI runtime increases.
+  - Mitigation: add Sonar as a distinct analysis job and reuse existing pipeline outputs where possible.
+
+- Risk: Secret/configuration drift.
+  - Mitigation: document required secrets, project key, organization, and onboarding steps.
+
+- Risk: Hosted-service acceptance may be blocked by policy.
+  - Mitigation: keep configuration portable enough that a later move to SonarQube remains possible.
+
+## Migration Plan
+
+1. Add proposal-approved Sonar configuration
+2. Add Sonar job to GitHub Actions
+3. Configure repository secret(s) and project binding
+4. Run non-blocking validation on a PR
+5. Enable the agreed quality gate behavior
+6. Document onboarding and operational ownership
+
+## Open Questions
+
+- Which Sonar organization/project key should be used?
+- Should the initial quality gate be blocking on pull requests immediately, or only after baseline cleanup?
+- Should test coverage be uploaded in the first rollout or as a follow-up?

--- a/openspec/changes/add-sonar-quality-analysis/proposal.md
+++ b/openspec/changes/add-sonar-quality-analysis/proposal.md
@@ -1,0 +1,37 @@
+# Change: Add Sonar Quality Analysis
+
+## Why
+
+The repository already runs formatting, linting, security checks, and limited type checking in GitHub Actions, but it lacks a unified code-quality dashboard and a review-time quality gate. This makes it harder to track code smells, duplication, maintainability hotspots, and long-term quality trends across the project.
+
+Introducing Sonar improves visibility and creates a single place for quality analysis that complements the existing Python tooling instead of replacing it.
+
+## What Changes
+
+- Add Sonar-based quality analysis to the CI pipeline
+- Use GitHub-integrated pull request analysis and quality gate feedback
+- Define the minimal required project configuration for Sonar analysis
+- Decide and document the default operating model:
+  - recommended default: **SonarCloud with GitHub Actions**
+  - alternative: self-hosted SonarQube for environments with stricter hosting requirements
+- Integrate existing test and static-analysis outputs where useful
+- Document required repository secrets, onboarding, and failure behavior
+
+## Impact
+
+- Affected specs: `cicd-pipeline`
+- Affected code:
+  - `.github/workflows/code-quality.yml`
+  - potential new `sonar-project.properties`
+  - developer and CI documentation
+
+## Non-Goals
+
+- Replacing Black, isort, flake8, Bandit, pip-audit, or MyPy
+- Introducing branch protection rules directly in this change
+- Refactoring existing code purely to satisfy Sonar findings
+- Full self-hosted SonarQube deployment automation
+
+## Decision Summary
+
+This proposal recommends **SonarCloud** as the initial implementation target because the repository already uses GitHub Actions and benefits from simpler setup, hosted analysis infrastructure, and native pull request decoration. If hosting policy later requires a self-managed solution, the CI contract and project configuration defined here should remain largely reusable.

--- a/openspec/changes/add-sonar-quality-analysis/specs/cicd-pipeline/spec.md
+++ b/openspec/changes/add-sonar-quality-analysis/specs/cicd-pipeline/spec.md
@@ -1,0 +1,54 @@
+# CI/CD Pipeline Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Sonar Analysis Integration
+The CI/CD pipeline MUST execute Sonar-based code quality analysis for the repository as part of automated quality validation.
+
+#### Scenario: Pull request analysis runs
+- **WHEN** a pull request is opened or updated
+- **THEN** the CI pipeline runs Sonar analysis for the changed branch or pull request
+- **AND** publishes the results to the configured Sonar project
+- **AND** makes findings visible to reviewers through the GitHub-integrated workflow
+
+#### Scenario: Branch analysis runs
+- **WHEN** code is pushed to a tracked branch
+- **THEN** the CI pipeline runs Sonar analysis for that branch
+- **AND** updates the branch-level quality status in Sonar
+
+### Requirement: Sonar Quality Gate Reporting
+The CI/CD pipeline MUST report the Sonar quality gate outcome in a form that maintainers can use during review and release decisions.
+
+#### Scenario: Quality gate passes
+- **WHEN** Sonar analysis completes successfully and the configured quality gate passes
+- **THEN** the CI workflow reports a successful Sonar result
+- **AND** the pull request or branch analysis is marked as compliant with the configured gate
+
+#### Scenario: Quality gate fails
+- **WHEN** Sonar analysis completes and the configured quality gate fails
+- **THEN** the CI workflow reports a failing Sonar result
+- **AND** maintainers can inspect the linked findings before merge or release
+
+### Requirement: Sonar Scope and Exclusions
+The Sonar configuration MUST analyze active application code and exclude generated, archived, and operational data paths that would distort results.
+
+#### Scenario: Active code is analyzed
+- **WHEN** Sonar analysis runs
+- **THEN** it includes maintained backend and frontend source paths
+- **AND** it excludes archives, runtime data, and other non-source directories
+
+#### Scenario: Historical artifacts are excluded
+- **WHEN** Sonar analysis traverses repository content
+- **THEN** historical documentation archives, monitoring data stores, and similar non-production assets are excluded from quality scoring
+
+## MODIFIED Requirements
+
+### Requirement: Quality Pipeline Integration
+The CI/CD pipeline MUST include dedicated quality assurance stages that run before deployment, including Sonar-based repository analysis in addition to existing static-analysis tools.
+
+#### Scenario: Quality pipeline execution
+- **GIVEN** code is pushed to any tracked branch or submitted through a pull request
+- **WHEN** the CI pipeline triggers
+- **THEN** it runs formatting, linting, security scanning, type checking, and Sonar analysis in the defined workflow
+- **AND** reports their outcomes in a reviewable form
+- **AND** applies the configured quality gate behavior before later delivery steps proceed

--- a/openspec/changes/add-sonar-quality-analysis/tasks.md
+++ b/openspec/changes/add-sonar-quality-analysis/tasks.md
@@ -1,0 +1,29 @@
+## 1. Planning
+
+- [x] 1.1 Confirm Sonar operating model (SonarCloud by default, SonarQube as documented alternative)
+- [x] 1.2 Define the initial quality gate policy for pull requests
+- [x] 1.3 Define repository secrets and ownership for Sonar administration
+
+## 2. Configuration
+
+- [x] 2.1 Add repository-level Sonar project configuration
+- [x] 2.2 Define source, test, exclusion, and report paths for Python and frontend code
+- [x] 2.3 Document required environment variables or secrets
+
+## 3. CI Integration
+
+- [x] 3.1 Extend GitHub Actions to run Sonar analysis
+- [x] 3.2 Integrate Sonar with pull request analysis and branch analysis
+- [x] 3.3 Ensure Sonar execution fits alongside existing code-quality jobs without duplicating their purpose
+
+## 4. Quality Gates
+
+- [x] 4.1 Configure the initial quality gate behavior
+- [ ] 4.2 Validate expected CI behavior for passing and failing analyses
+- [x] 4.3 Document how Sonar findings should be triaged and resolved
+
+## 5. Documentation
+
+- [x] 5.1 Update contributor or quality documentation with Sonar setup and usage
+- [x] 5.2 Document local expectations versus CI-only Sonar execution
+- [x] 5.3 Document follow-up work for coverage integration and rule tightening

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 # Code Quality Tools
+setuptools<81  # flake8-import-order still requires pkg_resources
 black==24.10.0
 isort==5.13.2
 flake8==7.1.1

--- a/services/api_gateway/README.md
+++ b/services/api_gateway/README.md
@@ -2,109 +2,152 @@
 
 ## Beschreibung
 
-Das API Gateway ist die zentrale Schnittstelle für alle Sprachdienste im Smart Speech Flow Backend. Es orchestriert die Verarbeitung von Audio, Text und Übersetzung über die einzelnen Microservices (ASR, Translation, TTS) und bietet ein einheitliches REST-API für Endnutzer und Frontend.
+Das API Gateway ist der zentrale Einstiegspunkt fuer Smart Speech Flow. Es verbindet die Fachservices fuer ASR, Translation und TTS mit der sessionbasierten Admin/Customer-Kommunikation im Frontend.
 
-## Input
+Heute ist das Gateway nicht nur ein einfacher Pipeline-Proxy, sondern vor allem:
 
-- **/pipeline (POST)**
-  - `file`: Audiodatei (WAV, MP3, OGG, FLAC, etc.)
-  - `source_lang`: Ausgangssprache (z. B. `de`, `en`, `ar`, ...)
-  - `target_lang`: Zielsprache (z. B. `en`, `de`, `tr`, ...)
-  - Übergabe als `multipart/form-data`
+- Session-Manager fuer Admin- und Customer-Gespraeche
+- Unified Message API fuer Text und Audio
+- WebSocket-Hub fuer Echtzeitkommunikation
+- Persistenz- und Timeout-Schicht fuer Sessions
+- Fallback- und Monitoring-Schicht fuer produktionsnahe Nutzung
 
-Beispiel mit `curl`:
-```bash
-curl -F "file=@sample.wav" -F "source_lang=de" -F "target_lang=en" https://ssf.smart-village.solutions/pipeline
+## Primaere API-Oberflaeche
+
+Der empfohlene Einstieg fuer Frontends laeuft ueber die sessionbasierten Endpunkte:
+
+- `POST /api/admin/session/create`
+- `GET /api/admin/session/current`
+- `POST /api/customer/session/activate`
+- `GET /api/customer/session/{session_id}/status`
+- `POST /api/session/{session_id}/message`
+- `GET /api/session/{session_id}/messages`
+- `GET /api/languages/supported`
+- `WS /ws/{session_id}/{client_type}`
+
+## Legacy- und Low-Level-Endpunkte
+
+Zusaetzlich existieren weiterhin generische Gateway-Endpunkte:
+
+- `POST /pipeline`
+- `POST /upload`
+- `GET /health`
+- `GET /metrics`
+- `GET /languages`
+
+`/pipeline` ist weiterhin nuetzlich fuer direkte End-to-End-Tests, bildet aber nicht den heutigen Haupt-Workflow des Frontends ab.
+
+## Typischer Frontend-Workflow
+
+1. Admin erstellt eine Session ueber `POST /api/admin/session/create`
+2. Customer waehlt Sprache und aktiviert die Session ueber `POST /api/customer/session/activate`
+3. Beide Seiten verbinden sich per WebSocket an `/ws/{session_id}/{client_type}`
+4. Nachrichten laufen ueber `POST /api/session/{session_id}/message`
+5. Historie und Audio koennen ueber REST-Endpunkte nachgeladen werden
+
+## Unified Message Endpoint
+
+### `POST /api/session/{session_id}/message`
+
+Der Endpoint akzeptiert beide Eingabeformen:
+
+- `application/json` fuer Textnachrichten
+- `multipart/form-data` fuer Audioeingaben
+
+### Text-Beispiel
+
+```json
+{
+  "text": "Guten Tag",
+  "source_lang": "de",
+  "target_lang": "en",
+  "client_type": "admin"
+}
 ```
 
-## Output
+### Audio-Beispiel
 
-- **Erfolgreiche Antwort (JSON):**
-  ```json
-  {
-    "success": true,
-    "originalText": "Hier spricht die Polizei.",
-    "translatedText": "Here the police speak.",
-    "audioBase64": "<base64-kodierte WAV-Datei>"
-  }
-  ```
-  - `originalText`: Transkription des Audios in der Ausgangssprache
-  - `translatedText`: Übersetzung in die Zielsprache
-  - `audioBase64`: Die synthetisierte Sprache als WAV-Datei (Base64-kodiert)
+Multipart-Request mit:
 
-- **Fehlerhafte Antwort (JSON):**
-  ```json
-  {
-    "success": false,
-    "error": "Fehlermeldung"
-  }
-  ```
+- `file`
+- `source_lang`
+- `target_lang`
+- `client_type`
 
-## Weitere Endpunkte
+### Response
 
-- **/health (GET):**
-  - Gibt den Status der angebundenen Services als JSON zurück.
-- **/metrics (GET):**
-  - Prometheus-kompatible Metriken für Monitoring.
-- **/** (GET):**
-  - HTML-Frontend mit Upload-Formular und Health-Status.
+Der Endpoint liefert ein einheitliches Response-Schema mit:
 
-## Typische Nutzung
+- `status`
+- `message_id`
+- `session_id`
+- `original_text`
+- `translated_text`
+- `audio_available`
+- `audio_url`
+- `processing_time_ms`
+- `pipeline_type`
+- `pipeline_metadata`
 
-Das Frontend sendet eine Audiodatei und die gewünschten Sprachen an `/pipeline`. Die Antwort enthält Transkription, Übersetzung und die synthetisierte Sprache als Audio. Fehler werden als JSON mit `success: false` und einer Fehlermeldung zurückgegeben.
+## Weitere wichtige Endpunkte
 
----
+### `GET /api/session/{session_id}/messages`
 
-Weitere Details zur Orchestrierung und zu den unterstützten Formaten siehe Haupt-README im Projektroot.
+Liefert die Nachrichtenhistorie einer Session.
 
-## Features
-- **Zentrales REST-API für alle Sprachdienste**
-- **Routing zu ASR, TTS und Translation Services**
-- **Health- und Metrics-Endpunkte**
-- **Validierung und Fehlerbehandlung**
-- **Docker- und venv-ready**
-- **Erweiterbar für weitere Services**
+### `GET /api/audio/{message_id}.wav`
 
-## Endpunkte
-- `/pipeline` (POST): Orchestriert komplexe Sprachverarbeitungs-Pipelines (z. B. ASR → Translation → TTS)
-- `/health` (GET): Status des Gateways und der angebundenen Services
-- `/metrics` (GET): Prometheus-kompatible Metriken
+Liefert das erzeugte Audio einer Nachricht.
 
-## Architektur & Funktionsweise
-1. **Routing:**
-   - Der Gateway nimmt Anfragen entgegen und leitet sie an die jeweiligen Microservices weiter.
-   - Die Kommunikation erfolgt über HTTP-Requests zu den internen Service-Endpunkten.
-2. **Validierung:**
-   - Eingaben werden geprüft und ggf. normalisiert.
-3. **Fehlerbehandlung:**
-   - Fehler aus den Microservices werden gesammelt und als konsistente API-Fehler zurückgegeben.
-4. **Health-Checks:**
-   - Der Gateway prüft regelmäßig die Erreichbarkeit und den Status der angebundenen Services.
+### `GET /api/audio/input_{message_id}.wav`
 
-## Installation & Betrieb
-### Mit Docker
+Liefert das urspruengliche Eingabe-Audio, sofern es noch innerhalb der Aufbewahrungszeit vorhanden ist.
+
+### `GET /api/languages/supported`
+
+Liefert die vom Frontend verwendete Sprachliste inklusive `admin_default` und `popular`.
+
+### `GET /languages`
+
+Oeffentlicher Alias fuer die Sprachliste ohne `/api`-Praefix.
+
+## Betrieb und Architektur
+
+Das Gateway umfasst unter anderem:
+
+- Session-Management mit optionaler Redis-Persistenz
+- WebSocket-Management mit Heartbeats
+- Polling-Fallback bei Verbindungsproblemen
+- Audio-Validierung und Text-Validierung
+- Circuit Breaker und Graceful Degradation
+- Monitoring ueber Prometheus-Metriken
+
+## Lokale Entwicklung
+
 ```bash
-docker build -t api_gateway .
-docker run -p 8000:8000 api_gateway
-```
-
-### Lokal mit venv
-```bash
-python3.11 -m venv .venv
+python3.12 -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt
-uvicorn app:app --reload
+uvicorn services.api_gateway.app:app --reload --port 8000
+```
+
+## Docker
+
+Der Service wird im Projektkontext ueber das Root-`docker-compose.yml` gestartet:
+
+```bash
+docker compose up -d api_gateway
 ```
 
 ## Testen
+
 ```bash
-pytest tests/
+pytest services/api_gateway/tests/
+pytest tests/test_unified_message_endpoint.py
+pytest tests/test_websocket_manager.py
 ```
 
-## Erweiterung
-- Weitere Services können einfach angebunden werden.
-- Die Endpunkte und Routing-Logik sind in `app.py` und `pipeline.py` konfigurierbar.
-
 ## Hinweise
-- Der Gateway-Service ist für die Integration in größere Systeme und für externe Schnittstellen konzipiert.
-- Monitoring und Health-Checks sind integriert.
+
+- Fuer neue Frontend-Integrationen sollte immer die sessionbasierte API verwendet werden.
+- `/pipeline` bleibt fuer direkte Service-Tests und technische Integrationen sinnvoll, ist aber nicht mehr die alleinige Leit-API.

--- a/services/api_gateway/audio_storage.py
+++ b/services/api_gateway/audio_storage.py
@@ -10,6 +10,7 @@ Manages persistent storage of audio files with automatic cleanup.
 
 import base64
 import logging
+import os
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Optional
@@ -43,7 +44,8 @@ except ImportError:
     logger.warning("Prometheus client not available - metrics disabled")
 
 # Storage paths
-AUDIO_BASE_DIR = Path("/data/audio")
+# Default remains /data/audio for local/Docker parity, but CI can override it.
+AUDIO_BASE_DIR = Path(os.environ.get("SSF_AUDIO_BASE_DIR", "/data/audio"))
 ORIGINAL_AUDIO_DIR = AUDIO_BASE_DIR / "original"
 TRANSLATED_AUDIO_DIR = AUDIO_BASE_DIR / "translated"
 

--- a/services/asr/README.md
+++ b/services/asr/README.md
@@ -52,7 +52,7 @@ Gibt den Status des Dienstes, unterstützte Sprachen und Modellinfos zurück.
 Prometheus-kompatible Metriken für Monitoring.
 
 ### Weitere Endpunkte
-- `/languages` (GET): Gibt alle unterstützten Sprachen zurück.
+- `/supported-languages` (GET): Gibt alle unterstuetzten Sprachen zurueck.
 
 ## Architektur & Funktionsweise
 1. **Modellwahl:**
@@ -72,7 +72,7 @@ docker run -p 8000:8000 asr-service
 
 ### Lokal mit venv
 ```bash
-python3.11 -m venv .venv
+python3.12 -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt
 uvicorn app:app --reload
@@ -88,5 +88,5 @@ pytest tests/
 - Die Modellkonfiguration erfolgt in `app.py`.
 
 ## Hinweise
-- Die unterstützten Sprachen sind in `/languages` abrufbar.
+- Die unterstuetzten Sprachen sind in `/supported-languages` abrufbar.
 - Bei privaten/gated Modellen ist ggf. ein HuggingFace-Token nötig (`huggingface-cli login`).

--- a/services/frontend/README.md
+++ b/services/frontend/README.md
@@ -1,126 +1,94 @@
-# Smart Speech Flow - Frontend# React + TypeScript + Vite
+# Smart Speech Flow Frontend
 
+## Beschreibung
 
+Das Frontend ist eine React-, TypeScript- und Vite-Anwendung fuer die sessionbasierte Nutzung von Smart Speech Flow.
 
-React + TypeScript + Vite Frontend für die Smart Speech Flow Echtzeit-Übersetzungsanwendung.This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+Es stellt drei zentrale Nutzungspfade bereit:
 
+- passwortgeschuetzte Landingpage
+- Admin-Oberflaeche fuer Session-Erstellung und Gespraechsfuehrung
+- Customer-Oberflaeche fuer Deeplinks, Sprachwahl und Nachrichtenversand
 
+## Kernfunktionen
 
-## FeaturesCurrently, two official plugins are available:
+- Session-Erstellung fuer Admins
+- Deeplink-basierter Session-Beitritt fuer Customers
+- Text- und Audioeingaben
+- WebSocket-basierte Echtzeitkommunikation
+- Nachrichtenhistorie und Audio-Wiedergabe
+- responsive Nutzung auf Desktop und Mobilgeraeten
 
+## Routen
 
+- `/` - Landingpage
+- `/admin` - Admin-Bereich
+- `/customer` - Customer-Bereich
+- `/join/:sessionId` - Deeplink fuer Customer-Session-Beitritt
 
-- 🔐 Passwortgeschützte Landing Page- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) (or [oxc](https://oxc.rs) when used in [rolldown-vite](https://vite.dev/guide/rolldown)) for Fast Refresh
+## API-Bezug
 
-- 👨‍💼 Admin-Interface für Session-Verwaltung- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+Das Frontend spricht gegen das API Gateway und nutzt insbesondere:
 
-- 👤 Kunden-Interface mit Session-Beitritt
+- `POST /api/admin/session/create`
+- `POST /api/customer/session/activate`
+- `GET /api/languages/supported`
+- `POST /api/session/{sessionId}/message`
+- `GET /api/session/{sessionId}/messages`
+- `WS /ws/{sessionId}/{clientType}`
 
-- 🎤 Audio-Aufnahme mit WebRTC MediaRecorder## React Compiler
+## Konfiguration
 
-- 💬 Echtzeit-Messaging über WebSocket
+Die wichtigsten Umgebungsvariablen sind:
 
-- 🌐 Mehrsprachige UnterstützungThe React Compiler is not enabled on this template because of its impact on dev & build performances. To add it, see [this documentation](https://react.dev/learn/react-compiler/installation).
-
-- 📱 Responsive Design
-
-## Expanding the ESLint configuration
-
-## Production Deployment
-
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
-
-Das Frontend wird über Docker + Nginx bereitgestellt unter **translate.smart-village.solutions**
-
-```js
-
-### Quick Deployexport default defineConfig([
-
-  globalIgnores(['dist']),
-
-```bash  {
-
-cd /root/projects/ssf-backend    files: ['**/*.{ts,tsx}'],
-
-docker compose build frontend    extends: [
-
-docker compose up -d frontend      // Other configs...
-
+```env
+VITE_API_BASE_URL=https://ssf.smart-village.solutions
+VITE_WS_BASE_URL=wss://ssf.smart-village.solutions
+VITE_APP_PASSWORD=<demo-password>
 ```
 
-      // Remove tseslint.configs.recommended and replace with this
+Im Docker-Betrieb werden diese Werte ueber `docker-compose.yml` gesetzt.
 
-### Verify Deployment      tseslint.configs.recommendedTypeChecked,
-
-      // Alternatively, use this for stricter rules
-
-- Frontend: https://translate.smart-village.solutions      tseslint.configs.strictTypeChecked,
-
-- Health Check: https://translate.smart-village.solutions/health      // Optionally, add this for stylistic rules
-
-      tseslint.configs.stylisticTypeChecked,
-
-## Environment Variables (Production)
-
-      // Other configs...
-
-Werden in `docker-compose.yml` konfiguriert:    ],
-
-    languageOptions: {
-
-```yaml      parserOptions: {
-
-environment:        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-
-  - VITE_API_BASE_URL=https://ssf.smart-village.solutions        tsconfigRootDir: import.meta.dirname,
-
-  - VITE_WS_BASE_URL=wss://ssf.smart-village.solutions      },
-
-  - VITE_APP_PASSWORD=ssf2025kassel      // other options...
-
-```    },
-
-  },
-
-## Development (Optional)])
-
-```
+## Lokale Entwicklung
 
 ```bash
-
-cd services/frontendYou can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
-
+cd services/frontend
 npm install
-
-npm run dev  # http://localhost:5174```js
-
-```// eslint.config.js
-
-import reactX from 'eslint-plugin-react-x'
-
-## Licenseimport reactDom from 'eslint-plugin-react-dom'
-
-
-
-Proprietary - Smart Village Solutionsexport default defineConfig([
-
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-      // Enable lint rules for React
-      reactX.configs['recommended-typescript'],
-      // Enable lint rules for React DOM
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+npm run dev
 ```
+
+Standardmaessig laeuft Vite lokal auf `http://localhost:5173` oder dem naechsten freien Port.
+
+## Build
+
+```bash
+cd services/frontend
+npm run build
+```
+
+## Deployment
+
+Im Projekt wird das Frontend als eigener Container mit Nginx betrieben:
+
+```bash
+docker compose build frontend
+docker compose up -d frontend
+```
+
+Der produktive Einstiegspunkt ist:
+
+- `https://translate.smart-village.solutions`
+
+## Wichtige Quellbereiche
+
+- `src/pages/` - Seiten fuer Landing, Admin, Customer und Not Found
+- `src/components/` - UI-Komponenten
+- `src/contexts/` - Session- und Toast-Context
+- `src/services/` - API- und WebSocket-Anbindung
+- `src/utils/` - Audio-bezogene Hilfslogik
+
+## Hinweise
+
+- Die Anwendung ist auf die sessionbasierte API abgestimmt, nicht auf direkte Nutzung von `/pipeline`.
+- Fuer die Customer-Reise ist die Aktivierung ueber `POST /api/customer/session/activate` ein notwendiger Schritt vor dem Nachrichtenaustausch.
+- Die Frontend-Domain und die API-/WebSocket-Basis-URLs sollten in Deployment und lokaler Entwicklung konsistent gesetzt sein.

--- a/services/tts/README.md
+++ b/services/tts/README.md
@@ -13,7 +13,7 @@ Dieser Service bietet eine robuste Text-zu-Sprache-Schnittstelle für verschiede
 ## Features
 - **Text-to-Speech (TTS) für viele Sprachen**
 - **Automatischer Fallback:** Coqui-TTS für direkt unterstützte Sprachen, HuggingFace MMS-TTS für alle weiteren
-- **REST API mit `/synthesize`, `/health` und `/metrics` Endpunkten**
+- **REST API mit `/synthesize`, `/health`, `/metrics` und `/supported-languages`**
 - **Prometheus-Metriken**
 - **Docker- und venv-ready**
 - **Automatisierte Tests für alle Zielsprachen**
@@ -32,6 +32,7 @@ Erzeugt eine Sprachdatei aus Text.
     "lang": "de"
   }
   ```
+  Alternativ akzeptiert der Service auch `tts_text` statt `text`.
 - **Antwort:**
   - Bei Erfolg: WAV-Datei
   - Bei Fehler: JSON mit Fehlermeldung und Fallback-Status
@@ -41,6 +42,9 @@ Gibt den Status des Dienstes, geladene Modelle und GPU-Infos zurück.
 
 ### `/metrics` (GET)
 Prometheus-kompatible Metriken für Monitoring.
+
+### `/supported-languages` (GET)
+Gibt die verfuegbaren Sprachcodes fuer Coqui-TTS und MMS-Fallback zurueck.
 
 ## Architektur & Funktionsweise
 1. **Modellwahl:**
@@ -61,7 +65,7 @@ docker run -p 8000:8000 tts-service
 
 ### Lokal mit venv
 ```bash
-python3.11 -m venv .venv
+python3.12 -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt
 uvicorn app:app --reload

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,34 @@
+sonar.projectName=Smart Speech Flow Backend
+sonar.sourceEncoding=UTF-8
+
+# Active source directories
+sonar.sources=services
+sonar.tests=tests,services/asr/tests,services/translation/tests,services/tts/tests,services/api_gateway/tests
+
+# Test file classification
+sonar.test.inclusions=tests/**/*.py,services/**/tests/**/*.py
+
+# Exclude runtime data, archives, generated assets and vendored/build output
+sonar.exclusions=\
+  **/__pycache__/**,\
+  **/.pytest_cache/**,\
+  **/.mypy_cache/**,\
+  **/.venv/**,\
+  **/node_modules/**,\
+  **/dist/**,\
+  **/build/**,\
+  docs/archive/**,\
+  docs/reports/**,\
+  monitoring/loki-data/**,\
+  monitoring/promtail-data/**,\
+  monitoring/grafana/grafana.db,\
+  openspec/changes/archive/**,\
+  services/frontend/public/**,\
+  examples/**
+
+# Keep frontend test/build artifacts and archive data out of analysis scope for now.
+sonar.coverage.exclusions=\
+  services/frontend/**,\
+  tests/load/**,\
+  docs/**,\
+  openspec/**

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -8,7 +8,8 @@ sonar.tests=tests,services/asr/tests,services/translation/tests,services/tts/tes
 # Test file classification
 sonar.test.inclusions=tests/**/*.py,services/**/tests/**/*.py
 
-# Exclude runtime data, archives, generated assets and vendored/build output
+# Exclude runtime data, archives, generated assets, helper scripts and
+# non-production test suites so Sonar focuses on the shipped services first.
 sonar.exclusions=\
   **/__pycache__/**,\
   **/.pytest_cache/**,\
@@ -17,6 +18,12 @@ sonar.exclusions=\
   **/node_modules/**,\
   **/dist/**,\
   **/build/**,\
+  scripts/**,\
+  docs/**,\
+  tests/load/**,\
+  tests/integration/**,\
+  tests/integration_test_audio_validation.py,\
+  tests/test_end_to_end_conversation.py,\
   docs/archive/**,\
   docs/reports/**,\
   monitoring/loki-data/**,\
@@ -26,9 +33,11 @@ sonar.exclusions=\
   services/frontend/public/**,\
   examples/**
 
-# Keep frontend test/build artifacts and archive data out of analysis scope for now.
+# Keep frontend build artifacts, archived content and broad non-service paths
+# out of coverage-based quality signals for now.
 sonar.coverage.exclusions=\
   services/frontend/**,\
+  scripts/**,\
   tests/load/**,\
   docs/**,\
   openspec/**

--- a/tests/test_api_contract_integration.py
+++ b/tests/test_api_contract_integration.py
@@ -19,6 +19,8 @@ from pathlib import Path
 from fastapi.testclient import TestClient
 from services.api_gateway.app import app
 
+pytestmark = pytest.mark.integration
+
 
 @pytest.fixture
 def client(monkeypatch):

--- a/tests/test_circuit_breaker_integration.py
+++ b/tests/test_circuit_breaker_integration.py
@@ -306,7 +306,9 @@ class TestCircuitBreakerRealSystem:
 
         # Call sollte mit Timeout fehlschlagen
         start_time = time.time()
-        with pytest.raises((asyncio.TimeoutError, aiohttp.ServerTimeoutError)):
+        with pytest.raises(
+            (TimeoutError, asyncio.TimeoutError, aiohttp.ServerTimeoutError)
+        ):
             await circuit_breaker.call(slow_http_call)
 
         # Prüfe dass Timeout eingetreten ist

--- a/tests/test_openapi_validation.py
+++ b/tests/test_openapi_validation.py
@@ -1,323 +1,320 @@
 """
 OpenAPI Specification Validation Tests
-========================================
+=====================================
 
-Tests that validate the OpenAPI specification against the actual implementation.
-
-This ensures:
-1. All documented endpoints actually exist
-2. Response schemas match the OpenAPI spec
-3. Required fields are present in responses
-4. Field types match the specification
-5. Status codes match documentation
-
-These tests run against the LIVE PRODUCTION API at https://ssf.smart-village.solutions
+Tests that validate the documented OpenAPI specification against the local
+FastAPI implementation. They intentionally avoid live-network dependencies so
+the default CI suite stays hermetic and reliable.
 """
 
-import pytest
-import yaml
-import requests
 from pathlib import Path
 
+from fastapi.testclient import TestClient
+import pytest
+import yaml
 
-# Production API base URL
-PRODUCTION_API_URL = "https://ssf.smart-village.solutions"
+from services.api_gateway.app import app
 
 
 @pytest.fixture(scope="module")
 def openapi_spec():
-    """Load the OpenAPI specification"""
-    # Prefer canonical spec in docs/ to avoid duplicate root file
+    """Load the canonical OpenAPI specification from docs/."""
     spec_path = Path(__file__).parent.parent / "docs" / "openapi.yaml"
-    with open(spec_path, 'r') as f:
+    with open(spec_path, "r") as f:
         return yaml.safe_load(f)
 
 
 @pytest.fixture
-def client():
-    """Returns the production API URL for testing"""
-    return PRODUCTION_API_URL
+def client(monkeypatch):
+    """Return a local FastAPI client with a mocked text pipeline."""
+    mock_pipeline_result = {
+        "translation_text": "Hello",
+        "audio_bytes": None,
+        "debug": {
+            "input": {"text": "Test", "source_lang": "de"},
+            "translation": {"translated_text": "Hello", "duration": 0.4},
+            "tts": {"audio_generated": False, "duration": 0.0},
+        },
+    }
 
+    monkeypatch.setattr(
+        "services.api_gateway.routes.session.process_text_pipeline",
+        lambda *args, **kwargs: mock_pipeline_result,
+    )
+
+    with TestClient(app) as test_client:
+        yield test_client
 
 
 @pytest.fixture
 def active_session(client):
-    """Create and activate a test session"""
-    response = requests.post(f"{client}/api/admin/session/create")
+    """Create and activate a session against the local app."""
+    response = client.post("/api/admin/session/create")
     assert response.status_code == 201
     session_id = response.json()["session_id"]
 
-    requests.post(f"{client}/api/customer/session/activate", json={
-        "session_id": session_id,
-        "customer_language": "en"
-    })
+    activate_response = client.post(
+        "/api/customer/session/activate",
+        json={"session_id": session_id, "customer_language": "en"},
+    )
+    assert activate_response.status_code == 200
 
     return session_id
 
 
 class TestOpenAPIEndpoints:
-    """Test that all OpenAPI endpoints exist and return correct status codes"""
+    """Test that documented endpoints exist and honor the contract."""
 
     def test_admin_session_create_endpoint_exists(self, client, openapi_spec):
-        """Test POST /api/admin/session/create matches OpenAPI spec"""
-        # Get expected response from OpenAPI spec
-        endpoint_spec = openapi_spec['paths']['/api/admin/session/create']['post']
+        endpoint_spec = openapi_spec["paths"]["/api/admin/session/create"]["post"]
 
-        # Call endpoint
-        response = requests.post(f"{client}/api/admin/session/create")
+        response = client.post("/api/admin/session/create")
 
-        # Validate status code
         assert response.status_code == 201, "Should return 201 Created"
-        assert '201' in endpoint_spec['responses'], "OpenAPI should document 201 response"
+        assert "201" in endpoint_spec["responses"], "OpenAPI should document 201 response"
 
-        # Validate response structure
         data = response.json()
-        schema = endpoint_spec['responses']['201']['content']['application/json']['schema']
-        required_fields = schema.get('required', [])
+        schema = endpoint_spec["responses"]["201"]["content"]["application/json"]["schema"]
+        required_fields = schema.get("required", [])
 
         for field in required_fields:
             assert field in data, f"Required field '{field}' missing from response"
 
     def test_customer_session_activate_endpoint_exists(self, client, openapi_spec):
-        """Test POST /api/customer/session/activate matches OpenAPI spec"""
-        endpoint_spec = openapi_spec['paths']['/api/customer/session/activate']['post']
+        endpoint_spec = openapi_spec["paths"]["/api/customer/session/activate"]["post"]
 
-        # Create session first
-        resp = requests.post(f"{client}/api/admin/session/create")
-        session_id = resp.json()["session_id"]
+        create_response = client.post("/api/admin/session/create")
+        assert create_response.status_code == 201
+        session_id = create_response.json()["session_id"]
 
-        # Activate session
-        response = requests.post(f"{client}/api/customer/session/activate", json={
-            "session_id": session_id,
-            "customer_language": "en"
-        })
+        response = client.post(
+            "/api/customer/session/activate",
+            json={"session_id": session_id, "customer_language": "en"},
+        )
 
         assert response.status_code == 200, "Should return 200 OK"
-        assert '200' in endpoint_spec['responses'], "OpenAPI should document 200 response"
+        assert "200" in endpoint_spec["responses"], "OpenAPI should document 200 response"
 
     def test_session_status_endpoint_exists(self, client, active_session, openapi_spec):
-        """Test GET /api/session/{sessionId} matches OpenAPI spec"""
-        endpoint_spec = openapi_spec['paths']['/api/session/{sessionId}']['get']
+        endpoint_spec = openapi_spec["paths"]["/api/session/{sessionId}"]["get"]
 
-        response = requests.get(f"{client}/api/session/{active_session}")
+        response = client.get(f"/api/session/{active_session}")
 
         assert response.status_code == 200, "Should return 200 OK"
-        assert '200' in endpoint_spec['responses'], "OpenAPI should document 200 response"
+        assert "200" in endpoint_spec["responses"], "OpenAPI should document 200 response"
 
-        # Validate response has expected fields
         data = response.json()
-        expected_fields = ['status', 'customer_language', 'admin_language', 'message_count']
+        expected_fields = ["status", "customer_language", "admin_language", "message_count"]
         for field in expected_fields:
             assert field in data, f"Expected field '{field}' in session status response"
 
     def test_unified_message_endpoint_exists(self, client, active_session, openapi_spec):
-        """Test POST /api/session/{sessionId}/message matches OpenAPI spec"""
-        endpoint_spec = openapi_spec['paths']['/api/session/{sessionId}/message']['post']
+        endpoint_spec = openapi_spec["paths"]["/api/session/{sessionId}/message"]["post"]
 
-        # Test with text message
-        response = requests.post(
-            f"{client}/api/session/{active_session}/message",
+        response = client.post(
+            f"/api/session/{active_session}/message",
             json={
                 "text": "Hello",
                 "source_lang": "de",
                 "target_lang": "en",
-                "client_type": "admin"
-            }
+                "client_type": "admin",
+            },
         )
 
         assert response.status_code == 200, "Should return 200 OK"
-        assert '200' in endpoint_spec['responses'], "OpenAPI should document 200 response"
+        assert "200" in endpoint_spec["responses"], "OpenAPI should document 200 response"
 
     def test_message_history_endpoint_exists(self, client, active_session, openapi_spec):
-        """Test GET /api/session/{sessionId}/messages matches OpenAPI spec"""
-        endpoint_spec = openapi_spec['paths']['/api/session/{sessionId}/messages']['get']
+        endpoint_spec = openapi_spec["paths"]["/api/session/{sessionId}/messages"]["get"]
 
-        response = requests.get(f"{client}/api/session/{active_session}/messages")
+        response = client.get(f"/api/session/{active_session}/messages")
 
         assert response.status_code == 200, "Should return 200 OK"
-        assert '200' in endpoint_spec['responses'], "OpenAPI should document 200 response"
+        assert "200" in endpoint_spec["responses"], "OpenAPI should document 200 response"
 
         data = response.json()
-        assert 'messages' in data, "Response should contain 'messages' array"
+        assert "messages" in data, "Response should contain 'messages' array"
 
     def test_supported_languages_endpoint_exists(self, client, openapi_spec):
-        """Test GET /api/languages/supported matches OpenAPI spec"""
-        endpoint_spec = openapi_spec['paths']['/api/languages/supported']['get']
+        endpoint_spec = openapi_spec["paths"]["/api/languages/supported"]["get"]
 
-        response = requests.get(f"{client}/api/languages/supported")
+        response = client.get("/api/languages/supported")
 
         assert response.status_code == 200, "Should return 200 OK"
-        assert '200' in endpoint_spec['responses'], "OpenAPI should document 200 response"
+        assert "200" in endpoint_spec["responses"], "OpenAPI should document 200 response"
 
         data = response.json()
-        assert 'languages' in data, "Response should contain 'languages' object"
+        assert "languages" in data, "Response should contain 'languages' object"
 
 
 class TestMessageResponseSchema:
-    """Test that MessageResponse matches OpenAPI schema"""
+    """Test that MessageResponse matches the OpenAPI schema."""
 
     def test_message_response_has_all_required_fields(self, client, active_session, openapi_spec):
-        """Test that message response contains all required fields from OpenAPI spec"""
-        # Get MessageResponse schema from OpenAPI
-        message_response_schema = openapi_spec['components']['schemas']['MessageResponse']
-        required_fields = message_response_schema.get('required', [])
+        message_response_schema = openapi_spec["components"]["schemas"]["MessageResponse"]
+        required_fields = message_response_schema.get("required", [])
 
-        # Send a message
-        response = requests.post(
-            f"{client}/api/session/{active_session}/message",
+        response = client.post(
+            f"/api/session/{active_session}/message",
             json={
                 "text": "Test message",
                 "source_lang": "en",
                 "target_lang": "de",
-                "client_type": "customer"
-            }
+                "client_type": "customer",
+            },
         )
 
         assert response.status_code == 200
         data = response.json()
 
-        # Check all required fields are present
         missing_fields = [field for field in required_fields if field not in data]
         assert not missing_fields, f"Missing required fields: {missing_fields}"
 
     def test_message_response_field_types(self, client, active_session, openapi_spec):
-        """Test that MessageResponse field types match OpenAPI spec"""
-        message_response_schema = openapi_spec['components']['schemas']['MessageResponse']
-        properties = message_response_schema['properties']
+        message_response_schema = openapi_spec["components"]["schemas"]["MessageResponse"]
+        properties = message_response_schema["properties"]
 
-        # Send a message
-        response = requests.post(
-            f"{client}/api/session/{active_session}/message",
+        response = client.post(
+            f"/api/session/{active_session}/message",
             json={
                 "text": "Test",
                 "source_lang": "de",
                 "target_lang": "en",
-                "client_type": "admin"
-            }
+                "client_type": "admin",
+            },
         )
 
+        assert response.status_code == 200
         data = response.json()
 
-        # Validate field types
         type_mapping = {
-            'string': str,
-            'integer': int,
-            'boolean': bool,
-            'object': dict,
-            'array': list
+            "string": str,
+            "integer": int,
+            "boolean": bool,
+            "object": dict,
+            "array": list,
         }
 
         for field_name, field_spec in properties.items():
             if field_name in data and data[field_name] is not None:
-                expected_type_name = field_spec.get('type')
+                expected_type_name = field_spec.get("type")
                 if expected_type_name in type_mapping:
                     expected_type = type_mapping[expected_type_name]
                     actual_value = data[field_name]
-                    assert isinstance(actual_value, expected_type), \
-                        f"Field '{field_name}' should be {expected_type_name}, got {type(actual_value).__name__}"
+                    assert isinstance(actual_value, expected_type), (
+                        f"Field '{field_name}' should be {expected_type_name}, "
+                        f"got {type(actual_value).__name__}"
+                    )
 
     def test_message_response_status_enum(self, client, active_session, openapi_spec):
-        """Test that status field matches enum values from OpenAPI spec"""
-        message_response_schema = openapi_spec['components']['schemas']['MessageResponse']
-        status_enum = message_response_schema['properties']['status'].get('enum', [])
+        message_response_schema = openapi_spec["components"]["schemas"]["MessageResponse"]
+        status_enum = message_response_schema["properties"]["status"].get("enum", [])
 
-        response = requests.post(
-            f"{client}/api/session/{active_session}/message",
+        response = client.post(
+            f"/api/session/{active_session}/message",
             json={
                 "text": "Test",
                 "source_lang": "de",
                 "target_lang": "en",
-                "client_type": "admin"
-            }
+                "client_type": "admin",
+            },
         )
 
+        assert response.status_code == 200
         data = response.json()
-        assert data['status'] in status_enum, \
+        assert data["status"] in status_enum, (
             f"Status '{data['status']}' not in allowed values: {status_enum}"
+        )
 
     def test_message_response_pipeline_type_enum(self, client, active_session, openapi_spec):
-        """Test that pipeline_type field matches enum values from OpenAPI spec"""
-        message_response_schema = openapi_spec['components']['schemas']['MessageResponse']
-        pipeline_type_enum = message_response_schema['properties']['pipeline_type'].get('enum', [])
+        message_response_schema = openapi_spec["components"]["schemas"]["MessageResponse"]
+        pipeline_type_enum = message_response_schema["properties"]["pipeline_type"].get(
+            "enum", []
+        )
 
-        response = requests.post(
-            f"{client}/api/session/{active_session}/message",
+        response = client.post(
+            f"/api/session/{active_session}/message",
             json={
                 "text": "Test",
                 "source_lang": "de",
                 "target_lang": "en",
-                "client_type": "admin"
-            }
+                "client_type": "admin",
+            },
         )
 
+        assert response.status_code == 200
         data = response.json()
-        assert data['pipeline_type'] in pipeline_type_enum, \
+        assert data["pipeline_type"] in pipeline_type_enum, (
             f"Pipeline type '{data['pipeline_type']}' not in allowed values: {pipeline_type_enum}"
+        )
+
+
 class TestOpenAPICompleteness:
-    """Test that OpenAPI spec is complete and up-to-date"""
+    """Test that OpenAPI spec is complete and up-to-date."""
 
     def test_openapi_version_is_current(self, openapi_spec):
-        """Test that OpenAPI spec version is 1.3.0 or higher"""
-        version = openapi_spec['info']['version']
-        major, minor, patch = map(int, version.split('.'))
+        """Test that OpenAPI spec version is 1.3.0 or higher."""
+        version = openapi_spec["info"]["version"]
+        major, minor, patch = map(int, version.split("."))
 
         assert major >= 1, "Major version should be at least 1"
         assert minor >= 3, "Minor version should be at least 3 (current: 1.3.0 with WebSocket docs)"
 
     def test_all_message_endpoints_documented(self, openapi_spec):
-        """Test that all known message endpoints are documented"""
-        paths = openapi_spec['paths']
+        """Test that all known message endpoints are documented."""
+        paths = openapi_spec["paths"]
 
-        # Check critical endpoints exist
-        assert '/api/admin/session/create' in paths, "Admin session creation should be documented"
-        assert '/api/customer/session/activate' in paths, "Customer activation should be documented"
-        assert '/api/session/{sessionId}' in paths, "Session status should be documented"
-        assert '/api/session/{sessionId}/message' in paths, "Unified message endpoint should be documented"
-        assert '/api/session/{sessionId}/messages' in paths, "Message history should be documented"
-        assert '/api/languages/supported' in paths, "Supported languages should be documented"
+        assert "/api/admin/session/create" in paths, "Admin session creation should be documented"
+        assert "/api/customer/session/activate" in paths, "Customer activation should be documented"
+        assert "/api/session/{sessionId}" in paths, "Session status should be documented"
+        assert "/api/session/{sessionId}/message" in paths, "Unified message endpoint should be documented"
+        assert "/api/session/{sessionId}/messages" in paths, "Message history should be documented"
+        assert "/api/languages/supported" in paths, "Supported languages should be documented"
 
     def test_websocket_endpoints_documented(self, openapi_spec):
-        """Test that WebSocket endpoints are documented"""
-        paths = openapi_spec['paths']
+        """Test that WebSocket endpoints are documented."""
+        paths = openapi_spec["paths"]
 
-        # WebSocket endpoints
-        assert '/ws/{sessionId}/{clientType}' in paths, "WebSocket connection endpoint should be documented"
-        assert '/api/websocket/debug/connection-test' in paths, "WebSocket diagnostics should be documented"
-        assert '/api/websocket/poll/{polling_id}' in paths, "WebSocket polling fallback should be documented"
-
-        # Audio endpoints (including original)
-        assert '/api/audio/{message_id}.wav' in paths, "Translated audio endpoint should be documented"
-        assert '/api/audio/input_{message_id}.wav' in paths, "Original audio input endpoint should be documented"
+        assert "/ws/{sessionId}/{clientType}" in paths, "WebSocket connection endpoint should be documented"
+        assert "/api/websocket/debug/connection-test" in paths, "WebSocket diagnostics should be documented"
+        assert "/api/websocket/poll/{polling_id}" in paths, "WebSocket polling fallback should be documented"
+        assert "/api/audio/{message_id}.wav" in paths, "Translated audio endpoint should be documented"
+        assert "/api/audio/input_{message_id}.wav" in paths, "Original audio input endpoint should be documented"
 
     def test_websocket_message_schema_complete(self, openapi_spec):
-        """Test that WebSocketMessage schema includes all required fields"""
-        ws_schema = openapi_spec['components']['schemas']['WebSocketMessage']
-        required_fields = ws_schema.get('required', [])
+        """Test that WebSocketMessage schema includes all required fields."""
+        ws_schema = openapi_spec["components"]["schemas"]["WebSocketMessage"]
+        required_fields = ws_schema.get("required", [])
 
-        # Critical fields that MUST be in WebSocket messages
         critical_fields = [
-            'type', 'role', 'message_id', 'session_id', 'text',
-            'sender', 'timestamp', 'source_lang', 'target_lang',
-            'audio_available', 'pipeline_metadata'
+            "type",
+            "role",
+            "message_id",
+            "session_id",
+            "text",
+            "sender",
+            "timestamp",
+            "source_lang",
+            "target_lang",
+            "audio_available",
+            "pipeline_metadata",
         ]
 
         for field in critical_fields:
             assert field in required_fields, f"WebSocketMessage should require '{field}'"
 
-        # Check role enum values
-        role_enum = ws_schema['properties']['role'].get('enum', [])
-        assert 'sender_confirmation' in role_enum, "Role should include 'sender_confirmation'"
-        assert 'receiver_message' in role_enum, "Role should include 'receiver_message'"
+        role_enum = ws_schema["properties"]["role"].get("enum", [])
+        assert "sender_confirmation" in role_enum, "Role should include 'sender_confirmation'"
+        assert "receiver_message" in role_enum, "Role should include 'receiver_message'"
 
     def test_deprecated_endpoints_not_documented(self, openapi_spec):
-        """Test that old/deprecated endpoints are not in the spec"""
-        paths = openapi_spec['paths']
+        """Test that old/deprecated endpoints are not in the spec."""
+        paths = openapi_spec["paths"]
 
-        # These endpoints should NOT exist (old API design)
         deprecated = [
-            '/api/session',  # Old session creation
-            '/api/session/{session_id}/audio',  # Separate audio endpoint
-            '/api/session/{session_id}/text',  # Separate text endpoint
+            "/api/session",
+            "/api/session/{session_id}/audio",
+            "/api/session/{session_id}/text",
         ]
 
         for endpoint in deprecated:
@@ -325,49 +322,45 @@ class TestOpenAPICompleteness:
 
 
 class TestWebSocketEndpoints:
-    """Test WebSocket endpoint documentation completeness"""
+    """Test WebSocket endpoint documentation completeness."""
 
     def test_websocket_connection_endpoint_documented(self, openapi_spec):
-        """Test that WebSocket connection endpoint is properly documented"""
-        ws_endpoint = openapi_spec['paths']['/ws/{sessionId}/{clientType}']
+        """Test that WebSocket connection endpoint is properly documented."""
+        ws_endpoint = openapi_spec["paths"]["/ws/{sessionId}/{clientType}"]
 
-        # Check parameters
-        params = {p['name']: p for p in ws_endpoint['get']['parameters']}
-        assert 'sessionId' in params, "sessionId parameter should be documented"
-        assert 'clientType' in params, "clientType parameter should be documented"
+        params = {p["name"]: p for p in ws_endpoint["get"]["parameters"]}
+        assert "sessionId" in params, "sessionId parameter should be documented"
+        assert "clientType" in params, "clientType parameter should be documented"
 
-        # Check clientType enum
-        client_type_enum = params['clientType']['schema'].get('enum', [])
-        assert 'admin' in client_type_enum, "clientType should allow 'admin'"
-        assert 'customer' in client_type_enum, "clientType should allow 'customer'"
+        client_type_enum = params["clientType"]["schema"].get("enum", [])
+        assert "admin" in client_type_enum, "clientType should allow 'admin'"
+        assert "customer" in client_type_enum, "clientType should allow 'customer'"
 
-        # Check responses
-        responses = ws_endpoint['get']['responses']
-        assert '101' in responses, "WebSocket upgrade (101) should be documented"
-        assert '404' in responses, "Session not found (404) should be documented"
+        responses = ws_endpoint["get"]["responses"]
+        assert "101" in responses, "WebSocket upgrade (101) should be documented"
+        assert "404" in responses, "Session not found (404) should be documented"
 
     def test_websocket_fallback_documented(self, openapi_spec):
-        """Test that WebSocket polling fallback is documented"""
-        polling_endpoint = openapi_spec['paths']['/api/websocket/poll/{polling_id}']
+        """Test that WebSocket polling fallback is documented."""
+        polling_endpoint = openapi_spec["paths"]["/api/websocket/poll/{polling_id}"]
 
-        # Check it returns WebSocketMessage array
-        response_schema = polling_endpoint['get']['responses']['200']['content']['application/json']['schema']
-        assert 'messages' in response_schema['properties'], "Polling should return messages array"
+        response_schema = polling_endpoint["get"]["responses"]["200"]["content"]["application/json"]["schema"]
+        assert "messages" in response_schema["properties"], "Polling should return messages array"
 
-        messages_schema = response_schema['properties']['messages']
-        assert '$ref' in messages_schema['items'], "Messages should reference WebSocketMessage schema"
-        assert 'WebSocketMessage' in messages_schema['items']['$ref'], "Should use WebSocketMessage schema"
+        messages_schema = response_schema["properties"]["messages"]
+        assert "$ref" in messages_schema["items"], "Messages should reference WebSocketMessage schema"
+        assert "WebSocketMessage" in messages_schema["items"]["$ref"], "Should use WebSocketMessage schema"
 
     def test_websocket_diagnostics_documented(self, openapi_spec):
-        """Test that WebSocket diagnostics endpoint is documented"""
-        diag_endpoint = openapi_spec['paths']['/api/websocket/debug/connection-test']
+        """Test that WebSocket diagnostics endpoint is documented."""
+        diag_endpoint = openapi_spec["paths"]["/api/websocket/debug/connection-test"]
 
-        response_schema = diag_endpoint['get']['responses']['200']['content']['application/json']['schema']
-        properties = response_schema['properties']
+        response_schema = diag_endpoint["get"]["responses"]["200"]["content"]["application/json"]["schema"]
+        properties = response_schema["properties"]
 
-        assert 'origin_allowed' in properties, "Should check if origin is allowed"
-        assert 'websocket_supported' in properties, "Should check WebSocket support"
-        assert 'suggestions' in properties, "Should provide troubleshooting suggestions"
+        assert "origin_allowed" in properties, "Should check if origin is allowed"
+        assert "websocket_supported" in properties, "Should check WebSocket support"
+        assert "suggestions" in properties, "Should provide troubleshooting suggestions"
 
 
 if __name__ == "__main__":

--- a/tests/test_pipeline_metadata_integration.py
+++ b/tests/test_pipeline_metadata_integration.py
@@ -25,6 +25,8 @@ from services.api_gateway.audio_storage import (
     cleanup_old_audio_files,
 )
 
+pytestmark = pytest.mark.integration
+
 
 @pytest.fixture
 def session_manager():


### PR DESCRIPTION
## Summary
- add SonarCloud analysis to the code quality pipeline
- stabilize the CI path so Sonar runs without changing local test defaults
- narrow Sonar analysis scope to product code first by excluding docs, helper scripts and broad load/integration paths
- refresh related documentation and add SonarLint / MCP guidance

## Included changes
- SonarCloud workflow integration with quality gate handling
- `sonar-project.properties` for project configuration and scoped exclusions
- CI hardening for flake8 / setuptools compatibility
- CI-only audio storage override via `SSF_AUDIO_BASE_DIR` while keeping `/data/audio` as the local default
- integration test marking so the Sonar coverage run stays hermetic
- docs updates for README, API docs and Sonar usage guidance

## Verification
- local hermetic Sonar pytest subset passes
- GitHub Actions workflow runs were exercised on this branch
- SonarCloud organization/project binding was validated against the configured project
- latest branch run is still in progress at PR creation time and should be reviewed in the checks tab

## Notes
- this branch also contains the documentation refresh work that was done alongside the Sonar rollout
- Sonar exclusions are intentionally conservative for the first pass so we can focus on shipped service code before widening scope again
