### PR TITLE
Add fallow frontend audit

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -333,11 +333,44 @@ jobs:
           -Dsonar.qualitygate.wait=true
           -Dsonar.qualitygate.timeout=300
 
-  # Job 6: Quality Gate Evaluation
+  # Job 6: Fallow frontend analysis
+  fallow-analysis:
+    name: Fallow Frontend Audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: github.event_name == 'pull_request'
+
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '22'
+        cache: 'npm'
+        cache-dependency-path: services/frontend/package-lock.json
+
+    - name: Install frontend dependencies
+      working-directory: services/frontend
+      run: npm ci
+
+    - name: Run Fallow audit for changed frontend files
+      uses: fallow-rs/fallow@v3
+      with:
+        command: audit
+        root: services/frontend
+        fail-on-issues: true
+        annotations: true
+        version: ^3.7.1
+
+  # Job 7: Quality Gate Evaluation
   quality-gate:
     name: Quality Gate
     runs-on: ubuntu-latest
-    needs: [code-quality, security-analysis, sonar-analysis]
+    needs: [code-quality, security-analysis, sonar-analysis, fallow-analysis]
     if: always()
 
     steps:
@@ -347,15 +380,22 @@ jobs:
         SECURITY_RESULT="${{ needs.security-analysis.result }}"
         SONAR_RESULT="${{ needs.sonar-analysis.result }}"
         SONAR_ENABLED="${{ needs.sonar-analysis.outputs.enabled }}"
+        FALLOW_RESULT="${{ needs.fallow-analysis.result }}"
 
         echo "Code Quality Result: $CODE_QUALITY_RESULT"
         echo "Security Analysis Result: $SECURITY_RESULT"
         echo "Sonar Result: $SONAR_RESULT"
         echo "Sonar Enabled: $SONAR_ENABLED"
+        echo "Fallow Result: $FALLOW_RESULT"
 
         # Sonar is blocking once configured; missing secrets/vars keep the job skipped.
         if [ "$SONAR_RESULT" = "failure" ]; then
           echo "❌ Sonar quality gate failed"
+          exit 1
+        fi
+
+        if [ "$FALLOW_RESULT" = "failure" ]; then
+          echo "❌ Fallow frontend audit failed"
           exit 1
         fi
 
@@ -369,11 +409,11 @@ jobs:
           echo "All blocking quality checks successful."
         fi
 
-  # Job 7: Quality Metrics Summary
+  # Job 8: Quality Metrics Summary
   quality-summary:
     name: Quality Summary
     runs-on: ubuntu-latest
-    needs: [code-quality, security-analysis, type-checking, dependency-analysis, sonar-analysis, quality-gate]
+    needs: [code-quality, security-analysis, type-checking, dependency-analysis, sonar-analysis, fallow-analysis, quality-gate]
     if: always()
 
     steps:
@@ -407,6 +447,17 @@ jobs:
           echo "| SonarCloud | ❌ Failed | Analysis or quality gate failed |" >> $GITHUB_STEP_SUMMARY
         else
           echo "| SonarCloud | ⚠️ Incomplete | Check Sonar job logs and configuration |" >> $GITHUB_STEP_SUMMARY
+        fi
+
+        # Fallow
+        if [ "${{ github.event_name }}" != "pull_request" ]; then
+          echo "| Fallow | ➖ Skipped | Runs on pull requests for changed frontend files only |" >> $GITHUB_STEP_SUMMARY
+        elif [ "${{ needs.fallow-analysis.result }}" == "success" ]; then
+          echo "| Fallow | ✅ Passed | Changed frontend files passed fallow audit |" >> $GITHUB_STEP_SUMMARY
+        elif [ "${{ needs.fallow-analysis.result }}" == "failure" ]; then
+          echo "| Fallow | ❌ Failed | Changed frontend files introduced fallow findings |" >> $GITHUB_STEP_SUMMARY
+        else
+          echo "| Fallow | ⚠️ Incomplete | Check fallow job logs |" >> $GITHUB_STEP_SUMMARY
         fi
 
         # Type Checking (optional)

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -339,6 +339,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     if: github.event_name == 'pull_request'
+    outputs:
+      frontend_changed: ${{ steps.frontend-changes.outputs.frontend_changed }}
 
     steps:
     - name: Checkout Code
@@ -346,7 +348,18 @@ jobs:
       with:
         fetch-depth: 0
 
+    - name: Detect frontend changes
+      id: frontend-changes
+      run: |
+        if git diff --name-only "origin/${{ github.base_ref }}...HEAD" | grep -q '^services/frontend/'; then
+          echo "frontend_changed=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "frontend_changed=false" >> "$GITHUB_OUTPUT"
+          echo "No frontend changes detected; skipping fallow audit."
+        fi
+
     - name: Setup Node.js
+      if: steps.frontend-changes.outputs.frontend_changed == 'true'
       uses: actions/setup-node@v4
       with:
         node-version: '22'
@@ -354,10 +367,12 @@ jobs:
         cache-dependency-path: services/frontend/package-lock.json
 
     - name: Install frontend dependencies
+      if: steps.frontend-changes.outputs.frontend_changed == 'true'
       working-directory: services/frontend
       run: npm ci
 
     - name: Run Fallow audit for changed frontend files
+      if: steps.frontend-changes.outputs.frontend_changed == 'true'
       uses: fallow-rs/fallow@v3
       with:
         command: audit
@@ -452,6 +467,8 @@ jobs:
         # Fallow
         if [ "${{ github.event_name }}" != "pull_request" ]; then
           echo "| Fallow | ➖ Skipped | Runs on pull requests for changed frontend files only |" >> $GITHUB_STEP_SUMMARY
+        elif [ "${{ needs.fallow-analysis.outputs.frontend_changed }}" != "true" ]; then
+          echo "| Fallow | ➖ Skipped | No frontend changes detected in this pull request |" >> $GITHUB_STEP_SUMMARY
         elif [ "${{ needs.fallow-analysis.result }}" == "success" ]; then
           echo "| Fallow | ✅ Passed | Changed frontend files passed fallow audit |" >> $GITHUB_STEP_SUMMARY
         elif [ "${{ needs.fallow-analysis.result }}" == "failure" ]; then

--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,6 @@ docs-backup-*.tar.gz
 
 # Node
 node_modules/
+
+# Fallow local cache and snapshots
+.fallow/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,6 +110,20 @@ If the optional variables are omitted, the workflow falls back to:
 
 SonarCloud complements the existing local tools. Contributors are not expected to run Sonar locally for normal development, but pull requests should be prepared so that linting, tests, and static analysis pass cleanly.
 
+### Fallow for the Frontend
+
+The frontend TypeScript code in `services/frontend` is additionally checked with `fallow` on pull requests. The workflow runs `fallow audit` against changed frontend files so that new dead-code, duplication, and complexity regressions are caught without blocking on older backlog outside the diff.
+
+Local usage:
+
+```bash
+cd services/frontend
+npm run fallow
+npm run fallow:audit
+```
+
+Current note: the pinned `fallow` version expects Node 22+ in CI, so the GitHub Actions workflow uses Node 22 for this step.
+
 **Configuration:**
 - Black: line length 100, Python 3.12+
 - isort: compatible with black

--- a/docs/testing/code-quality.md
+++ b/docs/testing/code-quality.md
@@ -59,6 +59,12 @@ Das Projekt verwendet automatisierte Tools zur Sicherstellung von Code-Qualität
 - **Scope**: Aktive Backend- und relevante Frontend-Quellpfade, keine Archive oder Laufzeitdaten
 - **Qualitaetsgate**: Wird in CI ausgewertet, sobald die SonarCloud-Repository-Konfiguration vorhanden ist
 
+#### Fallow
+- **Zweck**: TypeScript/JavaScript-spezifische Analyse fuer Dead Code, Duplikate und Komplexitaets-Hotspots
+- **Ausfuehrung**: In GitHub Actions als PR-basierter Audit-Lauf fuer `services/frontend`
+- **Scope**: Geaenderte Frontend-Dateien im Pull Request statt Full-Repo-Blocker
+- **Lokale Nutzung**: `cd services/frontend && npm run fallow` oder `npm run fallow:audit`
+
 ### 5. Type-Checking (Graduell)
 
 #### MyPy (Type Checker)
@@ -75,6 +81,7 @@ Das Projekt verwendet automatisierte Tools zur Sicherstellung von Code-Qualität
 3. **Linting**: Keine kritischen flake8-Fehler
 4. **Sicherheit**: Keine High/Critical Bandit-Issues
 5. **Sonar Quality Gate**: Muss im konfigurierten CI-Setup erfolgreich sein
+6. **Fallow Audit**: Geaenderte Frontend-Dateien duerfen im PR keine neuen `fallow`-Befunde einfuehren
 
 ### Advisory (Nicht-blockierend)
 1. **Type-Coverage**: Graduelle Verbesserung angestrebt
@@ -108,6 +115,7 @@ pip-audit                     # Dependency-Check
 ### CI/CD Pipeline
 - **Trigger**: Push/PR auf main/develop
 - **Jobs**: Code-Quality, Security, Type-Checking, Dependencies, SonarCloud
+- **Frontend-Guard**: `fallow audit` auf Pull Requests fuer geaenderte TypeScript/JavaScript-Dateien
 - **Reports**: Artifacts für alle Tool-Outputs
 - **Quality Gate**: SonarCloud liefert zentrales Qualitaetsfeedback fuer PRs und Branches
 

--- a/docs/testing/code-quality.md
+++ b/docs/testing/code-quality.md
@@ -63,7 +63,7 @@ Das Projekt verwendet automatisierte Tools zur Sicherstellung von Code-Qualität
 - **Zweck**: TypeScript/JavaScript-spezifische Analyse fuer Dead Code, Duplikate und Komplexitaets-Hotspots
 - **Ausfuehrung**: In GitHub Actions als PR-basierter Audit-Lauf fuer `services/frontend`
 - **Scope**: Geaenderte Frontend-Dateien im Pull Request statt Full-Repo-Blocker
-- **Lokale Nutzung**: `cd services/frontend && npm run fallow` oder `npm run fallow:audit`
+- **Lokale Nutzung**: `cd services/frontend && npm run fallow` oder `cd services/frontend && npm run fallow:audit`
 
 ### 5. Type-Checking (Graduell)
 

--- a/services/frontend/.fallowrc.json
+++ b/services/frontend/.fallowrc.json
@@ -1,8 +1,7 @@
 {
   "$schema": "./node_modules/fallow/schema.json",
   "entry": [
-    "src/main.{ts,tsx,js,jsx}",
-    "src/index.{ts,tsx,js,jsx}"
+    "src/main.{ts,tsx,js,jsx}"
   ],
   "ignoreDependencies": [
     "tailwindcss",

--- a/services/frontend/.fallowrc.json
+++ b/services/frontend/.fallowrc.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "./node_modules/fallow/schema.json",
+  "entry": [
+    "src/main.{ts,tsx,js,jsx}",
+    "src/index.{ts,tsx,js,jsx}"
+  ],
+  "ignoreDependencies": [
+    "tailwindcss",
+    "autoprefixer"
+  ],
+  "audit": {
+    "gate": "new-only"
+  }
+}

--- a/services/frontend/package-lock.json
+++ b/services/frontend/package-lock.json
@@ -24,6 +24,7 @@
         "eslint": "^9.36.0",
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.5.2",
+        "fallow": "^3.7.1",
         "globals": "^16.4.0",
         "postcss": "^8.5.8",
         "prettier": "^3.8.1",
@@ -926,6 +927,118 @@
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
+    },
+    "node_modules/@fallow-cli/darwin-arm64": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@fallow-cli/darwin-arm64/-/darwin-arm64-3.7.1.tgz",
+      "integrity": "sha512-gwASCFeJsiBAyT0ULIisC/R92luh8MTWCX7HD4clTgDzmthMqgntFywjNYyGZDnLnYPTLhA3EXrBTK4yL653yQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@fallow-cli/darwin-x64": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@fallow-cli/darwin-x64/-/darwin-x64-3.7.1.tgz",
+      "integrity": "sha512-McifNl36Cq0EMI1WAzifbV10tBgnU/VmDrxGA4PlFLycMFqb6bSchzhq5FB5BKGW1uU4a4EQMeG8aw/fG12Mlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@fallow-cli/linux-arm64-gnu": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@fallow-cli/linux-arm64-gnu/-/linux-arm64-gnu-3.7.1.tgz",
+      "integrity": "sha512-UvGLlXICElSSnr2fkfe9kx9ATrbjwKpHiMzRe/qZL0MXb2KNQBamQEjzJ//9h369sbb994VGIjC5nWa0yrYU6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@fallow-cli/linux-arm64-musl": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@fallow-cli/linux-arm64-musl/-/linux-arm64-musl-3.7.1.tgz",
+      "integrity": "sha512-aL0J2CFYSE8CBvu6E/wlC/9TfY5mEJKteQjxto75/XymYMgYVVXzGY/oW+y/ywf8XJ9X0d+kT4+yP0tk1eMNjw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@fallow-cli/linux-x64-gnu": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@fallow-cli/linux-x64-gnu/-/linux-x64-gnu-3.7.1.tgz",
+      "integrity": "sha512-aXXLuQZf/Ey6TJL8RCnsuZ0VG3VPZRFS3ZQCQn9SYtjMt4ShPAC86GKeVrGCcB7vboggnHxKZCli+F8R/0Un6A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@fallow-cli/linux-x64-musl": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@fallow-cli/linux-x64-musl/-/linux-x64-musl-3.7.1.tgz",
+      "integrity": "sha512-dX1F5efnPaIqCn+OnDE6HSf2YNqBHSkMH3ZW8/K0i7XBPrZYTIr1xdZBXWY/a/CZYjvTwzt9edgHEUDaCAKFmA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@fallow-cli/win32-arm64-msvc": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@fallow-cli/win32-arm64-msvc/-/win32-arm64-msvc-3.7.1.tgz",
+      "integrity": "sha512-v5Icq0GQfsrqseiBqSXfeP+d3/qxt9qbzEVP1ccBl55wycipZ1YHqXDOOItlfAv7Z8nA1KE5eZka9Y5UflsTFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@fallow-cli/win32-x64-msvc": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@fallow-cli/win32-x64-msvc/-/win32-x64-msvc-3.7.1.tgz",
+      "integrity": "sha512-kELPfImgZsV3o1fCcluXZ0gDUdTRrGu0ZZKtgaDKA43T1aMCDkOwoMmNvFdk0r/z13Qyu9i6KkcsCHIR+sXHdA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
@@ -2330,6 +2443,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/didyoumean": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
@@ -2664,6 +2787,34 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fallow": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/fallow/-/fallow-3.7.1.tgz",
+      "integrity": "sha512-AGhFLB6KwoeJmxFHrV89rGrL/FOqAlUofdlXqnBYHhuangmGYyXVSkddcXu4aqXjpIPFIpLvHk30kNL1nKNvkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "2.1.2"
+      },
+      "bin": {
+        "fallow": "bin/fallow",
+        "fallow-lsp": "bin/fallow-lsp",
+        "fallow-mcp": "bin/fallow-mcp"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "optionalDependencies": {
+        "@fallow-cli/darwin-arm64": "3.7.1",
+        "@fallow-cli/darwin-x64": "3.7.1",
+        "@fallow-cli/linux-arm64-gnu": "3.7.1",
+        "@fallow-cli/linux-arm64-musl": "3.7.1",
+        "@fallow-cli/linux-x64-gnu": "3.7.1",
+        "@fallow-cli/linux-x64-musl": "3.7.1",
+        "@fallow-cli/win32-arm64-msvc": "3.7.1",
+        "@fallow-cli/win32-x64-msvc": "3.7.1"
       }
     },
     "node_modules/fast-deep-equal": {

--- a/services/frontend/package.json
+++ b/services/frontend/package.json
@@ -7,6 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
+    "fallow": "fallow",
+    "fallow:audit": "fallow audit",
     "preview": "vite preview"
   },
   "dependencies": {
@@ -26,6 +28,7 @@
     "eslint": "^9.36.0",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.5.2",
+    "fallow": "^3.7.1",
     "globals": "^16.4.0",
     "postcss": "^8.5.8",
     "prettier": "^3.8.1",


### PR DESCRIPTION
## What changed
- added `fallow` to the frontend workspace with local scripts and a committed `.fallowrc.json`
- added a pull-request `fallow audit` job to the shared code-quality workflow
- wired the workflow summary and quality gate to include Fallow results
- documented SonarCloud and Fallow expectations for contributors

## Why
- SonarCloud was already prepared at the repository level, but we also wanted a TypeScript-focused changed-code guard for the frontend
- `fallow audit` catches new dead-code, duplication, and complexity regressions on touched frontend files without forcing an immediate cleanup of the existing frontend backlog

## Impact
- pull requests that touch `services/frontend` now get an additional changed-files audit
- the frontend workspace has explicit `fallow` commands for local validation
- CI uses Node 22 for the Fallow step because the current Fallow release requires it

## Validation
- `cd services/frontend && npm run fallow:audit`
- `cd services/frontend && npm run fallow config`
