### PR TITLE
feat: add internal ClickHouse infrastructure

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,11 @@ AUDIO_CLEANUP_INTERVAL_MINUTES=60
 # Always true for prototype phase
 ENABLE_PIPELINE_METADATA=true
 
+# Internal ClickHouse analytics service
+CLICKHOUSE_DB=ssf_analytics
+CLICKHOUSE_USER=ssf_telemetry
+CLICKHOUSE_PASSWORD=replace_with_a_unique_strong_password
+
 # LLM Refinement Configuration
 # -----------------------------
 # Enable/disable LLM-based translation refinement

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -184,6 +184,29 @@ services:
       - redis-data:/data
     restart: always
 
+  clickhouse:
+    image: clickhouse/clickhouse-server:26.3.17.110
+    restart: always
+    expose:
+      - "8123"
+    environment:
+      - CLICKHOUSE_DB=${CLICKHOUSE_DB:?set CLICKHOUSE_DB in .env}
+      - CLICKHOUSE_USER=${CLICKHOUSE_USER:?set CLICKHOUSE_USER in .env}
+      - CLICKHOUSE_PASSWORD=${CLICKHOUSE_PASSWORD:?required}
+      - CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT=1
+    ulimits:
+      nofile:
+        soft: 262144
+        hard: 262144
+    volumes:
+      - clickhouse-data:/var/lib/clickhouse
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:8123/ping | grep -qx 'Ok.'"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
+
   frontend-archive:
     build:
       context: ../ssf-frontend
@@ -345,3 +368,4 @@ volumes:
   redis-data:
   ollama-data:
   audio-data:
+  clickhouse-data:

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,7 @@ Welcome to the Smart Speech Flow Backend documentation! This guide helps you fin
 - [WebSocket Production Checklist](operations/WEBSOCKET_PRODUCTION_CHECKLIST.md) - Pre-deployment checklist
 - [Audio Recording Rollback Strategy](operations/AUDIO_RECORDING_ROLLBACK_STRATEGY.md) - Rollback procedures
 - [WebSocket Broadcast Failures Runbook](operations/runbooks/websocket-broadcast-failures.md) - Troubleshooting guide
+- [ClickHouse Operations Runbook](operations/runbooks/clickhouse-operations.md) - Internal analytics database operations
 - [Conversation Quality KPI Catalog](operations/conversation-quality-kpis.en.md) - Precise quality, reliability, and privacy-aware telemetry definitions ([German](operations/conversation-quality-kpis.md))
 
 ### For Testers

--- a/docs/deployment/BACKUP_STRATEGY.md
+++ b/docs/deployment/BACKUP_STRATEGY.md
@@ -32,12 +32,18 @@
 - Session metadata
 - Circuit breaker states
 
-### 3. System Configuration (Weekly)
+### 3. ClickHouse Analytics Data (Before Upgrade and Schema Changes)
+- Logical, compressed exports of approved analytics tables only
+- Restore verification into a temporary database before any production restore
+- Archive metadata: image version, table, UTC timestamp, checksum, and restore result
+- Never include credentials, audio, transcripts, translations, or other content data
+
+### 4. System Configuration (Weekly)
 - Docker volumes
 - Traefik certificates
 - Alert rules & monitoring configs
 
-### 4. Models (One-time + updates)
+### 5. Models (One-time + updates)
 - ASR models
 - Translation models
 - TTS models
@@ -117,6 +123,11 @@
 ---
 
 ## Backup Scripts
+
+ClickHouse exports are table-specific and begin only after the future telemetry
+schema is approved. Use the [ClickHouse Operations Runbook](../operations/runbooks/clickhouse-operations.md)
+for the export and temporary-restore procedure; include the resulting encrypted
+archive in the existing retention rotation.
 
 ### 1. Daily Backup Script
 ```bash

--- a/docs/deployment/SECURITY.md
+++ b/docs/deployment/SECURITY.md
@@ -33,6 +33,7 @@ The following services are now **only accessible within Docker network** (not ex
 | Loki | 3100 (public) | `expose: 3100` (internal) | Via Grafana |
 | cAdvisor | 8080 (public) | `expose: 8080` (internal) | Via Prometheus |
 | Ollama | 11434 (public) | `expose: 11434` (internal) | Via API Gateway |
+| ClickHouse | 8123 (public) | `expose: 8123` (internal) | Via authenticated Compose exec only |
 
 **Benefits:**
 - ✅ No direct public access to metrics
@@ -53,6 +54,8 @@ The following services are now **only accessible within Docker network** (not ex
 - [ ] Generate strong Grafana password: `openssl rand -base64 32`
 - [ ] Set `GRAFANA_ADMIN_PASSWORD` in `.env`
 - [ ] Verify `GRAFANA_ADMIN_USER` (default: `admin`)
+- [ ] Generate a ClickHouse password: `openssl rand -base64 32`
+- [ ] Set `CLICKHOUSE_DB`, `CLICKHOUSE_USER`, and `CLICKHOUSE_PASSWORD` in `.env`
 - [ ] Review all other environment variables in `.env`
 
 ### Security Verification
@@ -63,6 +66,7 @@ docker compose config | grep -A 5 "prometheus:"
 docker compose config | grep -A 5 "loki:"
 docker compose config | grep -A 5 "cadvisor:"
 docker compose config | grep -A 5 "ollama:"
+docker compose config | grep -A 20 "clickhouse:"
 
 # 2. Verify Grafana uses environment variables
 docker compose config | grep -A 10 "grafana:" | grep GRAFANA
@@ -109,6 +113,12 @@ curl -u "admin:YOUR_PASSWORD" http://localhost:3000/api/health
 - All monitoring services communicate internally via Docker network
 - Grafana accesses Prometheus/Loki via internal DNS (`prometheus:9090`, `loki:3100`)
 - API Gateway accesses Ollama via internal DNS (`ollama:11434`)
+- ClickHouse is internal-only on `clickhouse:8123`; it has no `ports` entry,
+  no Traefik labels, and no public SQL UI. Its credentials are required through
+  `.env`; never enable `CLICKHOUSE_SKIP_USER_SETUP`.
+
+For start-up, verification, backup, restore, upgrade, rollback, and incident
+procedures, see the [ClickHouse Operations Runbook](../operations/runbooks/clickhouse-operations.md).
 
 ## Default Passwords
 

--- a/docs/operations/runbooks/clickhouse-operations.md
+++ b/docs/operations/runbooks/clickhouse-operations.md
@@ -1,0 +1,113 @@
+# ClickHouse Operations Runbook
+
+## Scope and Security Boundary
+
+ClickHouse is SSF's internal analytical database. It is reachable only through
+the Docker Compose network at clickhouse:8123. It has no host port, Traefik
+route, or public SQL UI. Do not add ports, Traefik labels, or the insecure
+CLICKHOUSE_SKIP_USER_SETUP setting.
+
+This infrastructure installation creates no analytical tables and sends no SSF
+events to ClickHouse. A later approved change owns telemetry schemas and the
+event writer. ClickHouse must contain only pseudonymised quality metadata, never
+recordings, source text, transcripts, translations, IP addresses, or raw error
+messages.
+
+## Prerequisites
+
+Set these untracked .env values before the first start:
+
+    CLICKHOUSE_DB=ssf_analytics
+    CLICKHOUSE_USER=ssf_telemetry
+    CLICKHOUSE_PASSWORD=use_a_unique_strong_password
+
+Generate a password without adding it to a tracked file:
+
+    openssl rand -base64 32
+
+## Start and Verify
+
+Start only ClickHouse. This does not recreate SSF application services:
+
+    docker compose up -d clickhouse
+    docker compose ps clickhouse
+
+Wait for the service to become healthy, then verify HTTP health and authenticated
+database access. The shell expands credentials inside the container, so they do
+not appear in the host command or shell history:
+
+    docker compose exec -T clickhouse wget -qO- http://localhost:8123/ping
+    docker compose exec -T clickhouse sh -ec 'clickhouse-client --user "$CLICKHOUSE_USER" --password "$CLICKHOUSE_PASSWORD" --query "SELECT version()"'
+
+Expected output is Ok. for the health check and one ClickHouse version. For
+diagnostics, use:
+
+    docker compose logs --tail=100 clickhouse
+    docker compose exec -T clickhouse sh -ec 'clickhouse-client --user "$CLICKHOUSE_USER" --password "$CLICKHOUSE_PASSWORD" --query "SELECT name FROM system.databases"'
+
+Confirm that no host port is published:
+
+    docker compose port clickhouse 8123
+
+The command must return no mapping and a non-zero exit status.
+
+## Backup and Restore
+
+Take a logical backup before every ClickHouse upgrade and include the encrypted
+archive in the existing SSF backup rotation. This infrastructure change creates
+no table, so these instructions apply only after a later schema change.
+
+Export an approved analytical table in Native format. Set backup_database and
+backup_table to the approved schema values and use a UTC timestamp:
+
+    backup_database=ssf_analytics
+    backup_table=quality_events
+    backup_timestamp=$(date -u +%Y%m%dT%H%M%SZ)
+    mkdir -p "backups/clickhouse/$backup_timestamp"
+    docker compose exec -T clickhouse sh -ec 'clickhouse-client --user "$CLICKHOUSE_USER" --password "$CLICKHOUSE_PASSWORD" --query "SELECT * FROM '$backup_database.$backup_table' FORMAT Native"' | gzip > "backups/clickhouse/$backup_timestamp/$backup_table.native.gz"
+
+Record the image version, database, table, UTC timestamp, checksum, and
+successful restore-verification result with the archive. Restrict backup access
+and retain it only according to the approved policy.
+
+Never restore directly over production. Restore into a temporary database,
+compare the row count with the source, then delete the temporary database after
+verification:
+
+    restore_database=ssf_restore_check
+    gzip -dc "backups/clickhouse/<timestamp>/$backup_table.native.gz" | docker compose exec -T clickhouse sh -ec 'clickhouse-client --user "$CLICKHOUSE_USER" --password "$CLICKHOUSE_PASSWORD" --query "INSERT INTO '$restore_database.$backup_table' FORMAT Native"'
+    docker compose exec -T clickhouse sh -ec 'clickhouse-client --user "$CLICKHOUSE_USER" --password "$CLICKHOUSE_PASSWORD" --query "SELECT count() FROM '$restore_database.$backup_table'"'
+    docker compose exec -T clickhouse sh -ec 'clickhouse-client --user "$CLICKHOUSE_USER" --password "$CLICKHOUSE_PASSWORD" --query "DROP DATABASE IF EXISTS '$restore_database'"'
+
+## Upgrade and Rollback
+
+1. Confirm a successful backup and restore verification.
+2. Review the desired fixed image tag and the ClickHouse release notes.
+3. Update the pinned image tag in docker-compose.yml through a reviewed change.
+4. Apply only ClickHouse and verify health and authenticated SQL:
+
+       docker compose pull clickhouse
+       docker compose up -d --no-deps clickhouse
+       docker compose ps clickhouse
+
+5. If verification fails, restore the previous pinned image and recreate only
+   ClickHouse. Do not run docker compose down -v and do not remove the
+   clickhouse-data volume:
+
+       docker compose up -d --no-deps --force-recreate clickhouse
+
+## Incident Response
+
+| Symptom | Immediate action |
+| --- | --- |
+| Container is unhealthy | Inspect docker compose logs --tail=100 clickhouse; verify disk space and credentials; do not expose port 8123. |
+| Authentication fails | Confirm the .env user, database, and password match initial deployment; rotate credentials through reviewed maintenance. |
+| Disk pressure | Stop future telemetry ingestion, take a backup, inspect system.parts, and follow the approved retention policy. |
+| Suspected content or credential exposure | Stop the affected writer, preserve audit evidence, rotate credentials, and follow the SSF security incident procedure. |
+| Failed upgrade | Roll back to the previous pinned image after a successful backup; retain the named volume for diagnosis and restore. |
+
+## References
+
+- [ClickHouse Docker installation](https://clickhouse.com/docs/install/docker)
+- [ClickHouse HTTP interface](https://clickhouse.com/docs/concepts/features/interfaces/http)
+- [SSF Conversation Quality KPI Catalogue](../conversation-quality-kpis.en.md)

--- a/docs/operations/runbooks/clickhouse-operations.md
+++ b/docs/operations/runbooks/clickhouse-operations.md
@@ -47,9 +47,9 @@ diagnostics, use:
 
 Confirm that no host port is published:
 
-    docker compose port clickhouse 8123
+    docker inspect "$(docker compose ps -q clickhouse)" --format '{{json .HostConfig.PortBindings}}'
 
-The command must return no mapping and a non-zero exit status.
+The command must return `{}`, which proves that Docker has no host-port binding.
 
 ## Backup and Restore
 

--- a/docs/superpowers/plans/2026-08-25-clickhouse-infrastructure-and-telemetry-proposal.md
+++ b/docs/superpowers/plans/2026-08-25-clickhouse-infrastructure-and-telemetry-proposal.md
@@ -1,0 +1,379 @@
+# ClickHouse Infrastructure and Telemetry Proposal Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Run a secure, internal ClickHouse service on the SSF Docker Compose host, document its operation, and publish an OpenSpec proposal and linked GitHub issue for a colleague to implement quality telemetry later.
+
+**Architecture:** ClickHouse is an internal, persistent analytical service with no host port or Traefik route. It holds only pseudonymised KPI metadata. Consent-governed texts and audio remain out of scope for ClickHouse and must use a separate transactional content store and encrypted object store in a later capability.
+
+**Tech Stack:** Docker Compose, ClickHouse Server, pytest, OpenSpec, GitHub CLI or authenticated GitHub connector.
+
+**Spec:** `docs/superpowers/specs/2026-08-25-clickhouse-telemetry-design.md`
+
+## Global Constraints
+
+- Pin the ClickHouse image to a specific stable or LTS release; do not use `latest`.
+- Expose no ClickHouse host port and add no Traefik label or public SQL UI.
+- Require a non-empty `CLICKHOUSE_PASSWORD` from `.env`; do not use insecure setup bypasses.
+- Store telemetry metadata only; never write content, IP addresses, or free-form errors to ClickHouse.
+- Keep all new or modified project documentation in English.
+- Do not implement the API Gateway telemetry writer in this plan.
+
+---
+
+### Task 1: Add an executable Compose-security contract
+
+**Files:**
+- Create: `tests/test_clickhouse_compose_configuration.py`
+- Modify: `docker-compose.yml`
+
+**Interfaces:**
+- Consumes: Compose configuration parsed from repository-root `docker-compose.yml`.
+- Produces: `test_clickhouse_service_is_internal_and_persistent()` and `test_clickhouse_service_requires_credentials()` as regression checks for the deployment contract.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+from pathlib import Path
+
+import yaml
+
+
+COMPOSE = Path(__file__).parents[1] / "docker-compose.yml"
+
+
+def _clickhouse_service():
+    return yaml.safe_load(COMPOSE.read_text())["services"]["clickhouse"]
+
+
+def test_clickhouse_service_is_internal_and_persistent():
+    service = _clickhouse_service()
+    assert service["image"].startswith("clickhouse/clickhouse-server:")
+    assert service["restart"] == "always"
+    assert service.get("ports") is None
+    assert service["expose"] == ["8123"]
+    assert "clickhouse-data:/var/lib/clickhouse" in service["volumes"]
+    assert service.get("labels") is None
+
+
+def test_clickhouse_service_requires_credentials():
+    environment = _clickhouse_service()["environment"]
+    assert "CLICKHOUSE_PASSWORD=${CLICKHOUSE_PASSWORD:?set CLICKHOUSE_PASSWORD in .env}" in environment
+    assert "CLICKHOUSE_USER=${CLICKHOUSE_USER:?set CLICKHOUSE_USER in .env}" in environment
+    assert "CLICKHOUSE_DB=${CLICKHOUSE_DB:?set CLICKHOUSE_DB in .env}" in environment
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pytest tests/test_clickhouse_compose_configuration.py -v`
+
+Expected: FAIL because the `clickhouse` service does not yet exist.
+
+- [ ] **Step 3: Add the minimal Compose service**
+
+Add the service alongside the internal database/monitoring services:
+
+```yaml
+  clickhouse:
+    image: clickhouse/clickhouse-server:26.3.17.110
+    restart: always
+    expose:
+      - "8123"
+    environment:
+      - CLICKHOUSE_DB=${CLICKHOUSE_DB:?set CLICKHOUSE_DB in .env}
+      - CLICKHOUSE_USER=${CLICKHOUSE_USER:?set CLICKHOUSE_USER in .env}
+      - CLICKHOUSE_PASSWORD=${CLICKHOUSE_PASSWORD:?set CLICKHOUSE_PASSWORD in .env}
+      - CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT=1
+    ulimits:
+      nofile:
+        soft: 262144
+        hard: 262144
+    volumes:
+      - clickhouse-data:/var/lib/clickhouse
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:8123/ping | grep -qx 'Ok.'"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
+```
+
+Add `clickhouse-data:` under the existing top-level `volumes:`. `26.3.17.110` is the currently published LTS version; record the selected version and review it during every upgrade rather than using a floating tag.
+
+- [ ] **Step 4: Run the focused tests and Compose validation**
+
+Run:
+
+```bash
+pytest tests/test_clickhouse_compose_configuration.py -v
+docker compose --env-file .env.example config --quiet
+```
+
+Expected: the tests PASS and the second command succeeds after test-only placeholder credentials are supplied through an isolated temporary env file, never through production `.env`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docker-compose.yml tests/test_clickhouse_compose_configuration.py
+git commit -m "feat: add internal ClickHouse service"
+```
+
+### Task 2: Document credentials, security posture, and operator workflow
+
+**Files:**
+- Modify: `.env.example`
+- Modify: `docs/deployment/SECURITY.md`
+- Create: `docs/operations/runbooks/clickhouse-operations.md`
+- Modify: `docs/README.md`
+
+**Interfaces:**
+- Consumes: the `clickhouse` Compose service from Task 1 and `.env` values.
+- Produces: a self-contained operator runbook whose commands use only internal container access.
+
+- [ ] **Step 1: Write the failing documentation acceptance checklist**
+
+Create the checklist before editing documentation and verify every item manually after edits:
+
+```text
+[ ] .env.example lists CLICKHOUSE_DB, CLICKHOUSE_USER, and CLICKHOUSE_PASSWORD without a real value.
+[ ] SECURITY.md states that ClickHouse has no host port and must not receive Traefik labels.
+[ ] The runbook includes first start, health, authenticated query, logs, upgrade, rollback, backup, restore, and incident commands.
+[ ] docs/README.md links the runbook under operator documentation.
+[ ] No command prints a secret or recommends CLICKHOUSE_SKIP_USER_SETUP.
+```
+
+- [ ] **Step 2: Verify the checklist fails before documentation changes**
+
+Run: `rg -n "CLICKHOUSE_|clickhouse-operations" .env.example docs/deployment/SECURITY.md docs/README.md`
+
+Expected: no ClickHouse configuration or operator-runbook link is present.
+
+- [ ] **Step 3: Add documentation and configuration placeholders**
+
+Add to `.env.example`:
+
+```dotenv
+# Internal ClickHouse analytics service
+CLICKHOUSE_DB=ssf_analytics
+CLICKHOUSE_USER=ssf_telemetry
+CLICKHOUSE_PASSWORD=replace_with_a_unique_strong_password
+```
+
+Document a production password generation command (`openssl rand -base64 32`) without adding credentials to any tracked file. The runbook must include these commands:
+
+```bash
+docker compose up -d clickhouse
+docker compose ps clickhouse
+docker compose exec clickhouse clickhouse-client \
+  --user "$CLICKHOUSE_USER" --password "$CLICKHOUSE_PASSWORD" \
+  --query 'SELECT version()'
+docker compose logs --tail=100 clickhouse
+```
+
+Document a logical backup with `clickhouse-client` format export, a restore into a temporary database, and a rollback that preserves `clickhouse-data`. State clearly that no current table is created by the infrastructure task; the future telemetry change creates its own schema.
+
+- [ ] **Step 4: Verify the documentation acceptance checklist**
+
+Run:
+
+```bash
+rg -n "CLICKHOUSE_(DB|USER|PASSWORD)|clickhouse-operations" .env.example docs/deployment/SECURITY.md docs/README.md
+rg -n "CLICKHOUSE_SKIP_USER_SETUP|ports:|traefik" docs/operations/runbooks/clickhouse-operations.md
+```
+
+Expected: required references are present; the runbook contains no insecure setup command and explicitly prohibits external ports and Traefik labels.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .env.example docs/deployment/SECURITY.md docs/operations/runbooks/clickhouse-operations.md docs/README.md
+git commit -m "docs: add ClickHouse operations runbook"
+```
+
+### Task 3: Validate the installed service without affecting existing SSF services
+
+**Files:**
+- Modify: `docs/operations/runbooks/clickhouse-operations.md` only if validation reveals an inaccurate command.
+
+**Interfaces:**
+- Consumes: the service, credentials configured locally in untracked `.env`, and named volume from Task 1.
+- Produces: verified evidence that internal authenticated queries work and data persists across container recreation.
+
+- [ ] **Step 1: Start only ClickHouse**
+
+Run: `docker compose up -d clickhouse`
+
+Expected: only the ClickHouse container is created or started; no application service is recreated.
+
+- [ ] **Step 2: Verify internal health and authentication**
+
+Run:
+
+```bash
+docker compose exec clickhouse wget -qO- http://localhost:8123/ping
+docker compose exec clickhouse clickhouse-client \
+  --user "$CLICKHOUSE_USER" --password "$CLICKHOUSE_PASSWORD" \
+  --query 'SELECT version()'
+```
+
+Expected: `/ping` returns `Ok.` and the query prints a version. Do not include the password in terminal output, logs, commits, or issue text.
+
+- [ ] **Step 3: Verify no host exposure and persistence**
+
+Run:
+
+```bash
+docker compose port clickhouse 8123
+docker compose exec clickhouse clickhouse-client \
+  --user "$CLICKHOUSE_USER" --password "$CLICKHOUSE_PASSWORD" \
+  --query 'CREATE TABLE IF NOT EXISTS ssf_install_check (id UInt8) ENGINE = MergeTree ORDER BY id'
+docker compose exec clickhouse clickhouse-client \
+  --user "$CLICKHOUSE_USER" --password "$CLICKHOUSE_PASSWORD" \
+  --query 'INSERT INTO ssf_install_check VALUES (1)'
+docker compose up -d --force-recreate clickhouse
+docker compose ps clickhouse
+docker compose exec clickhouse clickhouse-client \
+  --user "$CLICKHOUSE_USER" --password "$CLICKHOUSE_PASSWORD" \
+  --query 'SELECT count() FROM ssf_install_check'
+docker compose exec clickhouse clickhouse-client \
+  --user "$CLICKHOUSE_USER" --password "$CLICKHOUSE_PASSWORD" \
+  --query 'DROP TABLE ssf_install_check'
+```
+
+Expected: `docker compose port` returns no mapping; the container returns healthy; the post-recreation query returns `1`; and the temporary installation-check table is removed. This does not create a future telemetry schema.
+
+- [ ] **Step 4: Run project checks**
+
+Run:
+
+```bash
+docker compose config --quiet
+pytest tests/test_clickhouse_compose_configuration.py -v
+pytest
+```
+
+Expected: Compose configuration is valid; focused configuration tests and the full existing suite pass.
+
+- [ ] **Step 5: Commit any validated runbook correction**
+
+```bash
+git add docs/operations/runbooks/clickhouse-operations.md
+git commit -m "docs: verify ClickHouse operating procedure"
+```
+
+### Task 4: Create the OpenSpec change for future quality telemetry
+
+**Files:**
+- Create: `openspec/changes/add-clickhouse-quality-telemetry/proposal.md`
+- Create: `openspec/changes/add-clickhouse-quality-telemetry/design.md`
+- Create: `openspec/changes/add-clickhouse-quality-telemetry/tasks.md`
+- Create: `openspec/changes/add-clickhouse-quality-telemetry/specs/quality-telemetry/spec.md`
+
+**Interfaces:**
+- Consumes: the approved design and KPI catalogue at `docs/operations/conversation-quality-kpis.en.md`.
+- Produces: an unapproved implementation proposal for a colleague; no API Gateway code.
+
+- [ ] **Step 1: Create proposal and design documents**
+
+`proposal.md` must state why analytical quality telemetry is needed, list the ClickHouse event contract and writer as future changes, and explicitly exclude raw content and content-store implementation. `design.md` must define:
+
+```text
+event_id: UUID; delivery retries are idempotent
+schema_version: integer; required on every event
+writer behavior: bounded queue plus asynchronous batch/async inserts
+failure behavior: record an operational counter/log without delaying or failing message processing
+retention: raw metadata 30 days; pseudonymised daily aggregates 13 months
+content boundary: only content_record_id_hash and consent metadata; no text/audio/content bytes
+```
+
+- [ ] **Step 2: Create a delta specification with scenarios**
+
+Add requirements and scenarios that demonstrate:
+
+```markdown
+#### Scenario: ClickHouse is unavailable
+- **WHEN** the telemetry writer cannot insert a batch
+- **THEN** the message pipeline completes independently and the failed telemetry batch is observable without content leakage
+
+#### Scenario: An event is retried
+- **WHEN** the writer delivers the same `event_id` more than once
+- **THEN** the analytical record is counted once
+
+#### Scenario: Content-bearing metadata is received
+- **WHEN** an event source includes text, an audio URL, raw error text, or bytes
+- **THEN** the telemetry payload excludes it and retains only approved metadata
+```
+
+- [ ] **Step 3: Create implementation tasks for the colleague**
+
+Sequence the tasks: schema and migrations; typed allowlisted event models; writer and retry/batching; gateway lifecycle/pipeline hooks; retention/aggregation; tests; dashboards/runbooks. Include the separate content-store capability as a dependency, not a task to implement in this change.
+
+- [ ] **Step 4: Validate OpenSpec**
+
+Run: `openspec validate add-clickhouse-quality-telemetry --strict`
+
+Expected: validation succeeds with no formatting or scenario errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add openspec/changes/add-clickhouse-quality-telemetry
+git commit -m "docs: propose ClickHouse quality telemetry"
+```
+
+### Task 5: Create and link the GitHub implementation issue
+
+**Files:**
+- Modify: `openspec/changes/add-clickhouse-quality-telemetry/proposal.md` to include the created issue URL.
+
+**Interfaces:**
+- Consumes: validated OpenSpec proposal and authenticated GitHub access to `smart-village-solutions/smart-speech-flow`.
+- Produces: one GitHub issue assigned or ready for the implementation colleague, linked bidirectionally to the OpenSpec change.
+
+- [ ] **Step 1: Verify GitHub identity and repository access**
+
+Run:
+
+```bash
+gh auth status
+gh repo view smart-village-solutions/smart-speech-flow
+```
+
+Expected: the authenticated account can create issues. If GitHub access is not authenticated, stop and request that the user connect the GitHub integration or authenticate `gh`; do not fabricate an issue link.
+
+- [ ] **Step 2: Create the issue from a reviewed body file**
+
+Create an untracked temporary Markdown body containing the change path, acceptance criteria from the delta spec, privacy boundary, non-goals, and validation requirements. Then run:
+
+```bash
+gh issue create \
+  --repo smart-village-solutions/smart-speech-flow \
+  --title "feat: implement ClickHouse quality telemetry" \
+  --body-file /tmp/clickhouse-quality-telemetry-issue.md
+```
+
+Expected: GitHub returns the canonical issue URL. Do not include credentials, pseudonymous production identifiers, or any content example in the issue.
+
+- [ ] **Step 3: Add bidirectional references and validate**
+
+Add a `GitHub issue:` line containing the canonical URL returned in Step 2 to the OpenSpec proposal. Add a comment to the issue linking the committed OpenSpec proposal path and commit SHA. Re-run:
+
+```bash
+openspec validate add-clickhouse-quality-telemetry --strict
+git add openspec/changes/add-clickhouse-quality-telemetry/proposal.md
+git commit -m "docs: link telemetry proposal to implementation issue"
+```
+
+- [ ] **Step 4: Final verification and handoff**
+
+Run:
+
+```bash
+git status --short
+git log --oneline --max-count=5
+docker compose config --quiet
+pytest tests/test_clickhouse_compose_configuration.py -v
+openspec validate add-clickhouse-quality-telemetry --strict
+```
+
+Expected: working tree is clean; infrastructure validation and OpenSpec validation pass; handoff includes the issue URL, OpenSpec change ID, and explicit statement that API Gateway telemetry remains unimplemented.

--- a/docs/superpowers/plans/2026-08-25-clickhouse-infrastructure-and-telemetry-proposal.md
+++ b/docs/superpowers/plans/2026-08-25-clickhouse-infrastructure-and-telemetry-proposal.md
@@ -28,22 +28,39 @@
 - Modify: `docker-compose.yml`
 
 **Interfaces:**
-- Consumes: Compose configuration parsed from repository-root `docker-compose.yml`.
+- Consumes: the resolved Compose configuration emitted by `docker compose config` with an isolated test environment.
 - Produces: `test_clickhouse_service_is_internal_and_persistent()` and `test_clickhouse_service_requires_credentials()` as regression checks for the deployment contract.
 
 - [ ] **Step 1: Write the failing tests**
 
 ```python
+import os
+import subprocess
+import tempfile
 from pathlib import Path
 
 import yaml
 
 
-COMPOSE = Path(__file__).parents[1] / "docker-compose.yml"
+ROOT = Path(__file__).parents[1]
 
 
 def _clickhouse_service():
-    return yaml.safe_load(COMPOSE.read_text())["services"]["clickhouse"]
+    with tempfile.NamedTemporaryFile(mode="w", delete=False) as env_file:
+        env_file.write("CLICKHOUSE_DB=ssf_analytics_test\n")
+        env_file.write("CLICKHOUSE_USER=ssf_telemetry_test\n")
+        env_file.write("CLICKHOUSE_PASSWORD=test-only-password\n")
+    try:
+        result = subprocess.run(
+            ["docker", "compose", "--env-file", env_file.name, "config"],
+            cwd=ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    finally:
+        os.unlink(env_file.name)
+    return yaml.safe_load(result.stdout)["services"]["clickhouse"]
 
 
 def test_clickhouse_service_is_internal_and_persistent():
@@ -58,9 +75,9 @@ def test_clickhouse_service_is_internal_and_persistent():
 
 def test_clickhouse_service_requires_credentials():
     environment = _clickhouse_service()["environment"]
-    assert "CLICKHOUSE_PASSWORD=${CLICKHOUSE_PASSWORD:?set CLICKHOUSE_PASSWORD in .env}" in environment
-    assert "CLICKHOUSE_USER=${CLICKHOUSE_USER:?set CLICKHOUSE_USER in .env}" in environment
-    assert "CLICKHOUSE_DB=${CLICKHOUSE_DB:?set CLICKHOUSE_DB in .env}" in environment
+    assert environment["CLICKHOUSE_PASSWORD"] == "test-only-password"
+    assert environment["CLICKHOUSE_USER"] == "ssf_telemetry_test"
+    assert environment["CLICKHOUSE_DB"] == "ssf_analytics_test"
 ```
 
 - [ ] **Step 2: Run the tests to verify they fail**

--- a/docs/superpowers/plans/2026-08-25-clickhouse-infrastructure-and-telemetry-proposal.md
+++ b/docs/superpowers/plans/2026-08-25-clickhouse-infrastructure-and-telemetry-proposal.md
@@ -240,7 +240,7 @@ Expected: `/ping` returns `Ok.` and the query prints a version. Do not include t
 Run:
 
 ```bash
-docker compose port clickhouse 8123
+docker inspect "$(docker compose ps -q clickhouse)" --format '{{json .HostConfig.PortBindings}}'
 docker compose exec clickhouse clickhouse-client \
   --user "$CLICKHOUSE_USER" --password "$CLICKHOUSE_PASSWORD" \
   --query 'CREATE TABLE IF NOT EXISTS ssf_install_check (id UInt8) ENGINE = MergeTree ORDER BY id'
@@ -248,6 +248,7 @@ docker compose exec clickhouse clickhouse-client \
   --user "$CLICKHOUSE_USER" --password "$CLICKHOUSE_PASSWORD" \
   --query 'INSERT INTO ssf_install_check VALUES (1)'
 docker compose up -d --force-recreate clickhouse
+until docker compose exec -T clickhouse wget -qO- http://localhost:8123/ping | grep -qx 'Ok.'; do sleep 3; done
 docker compose ps clickhouse
 docker compose exec clickhouse clickhouse-client \
   --user "$CLICKHOUSE_USER" --password "$CLICKHOUSE_PASSWORD" \
@@ -257,7 +258,7 @@ docker compose exec clickhouse clickhouse-client \
   --query 'DROP TABLE ssf_install_check'
 ```
 
-Expected: `docker compose port` returns no mapping; the container returns healthy; the post-recreation query returns `1`; and the temporary installation-check table is removed. This does not create a future telemetry schema.
+Expected: Docker inspection returns `{}` for host port bindings; the container returns healthy; the post-recreation query returns `1`; and the temporary installation-check table is removed. This does not create a future telemetry schema.
 
 - [ ] **Step 4: Run project checks**
 

--- a/docs/superpowers/specs/2026-08-25-clickhouse-telemetry-design.md
+++ b/docs/superpowers/specs/2026-08-25-clickhouse-telemetry-design.md
@@ -1,0 +1,110 @@
+# ClickHouse Telemetry and Consent-Governed Content Storage Design
+
+## Context
+
+SSF needs an internal analytical store for the conversation-quality KPI catalogue.
+ClickHouse will run on the existing production-like Docker Compose host. The
+installation must not expose a new public service or change the request path.
+
+Some users may later give purpose-specific consent for SSF to retain source
+text, ASR results, translations, and input or output audio. That content has
+different privacy, access-control, retention, and deletion requirements from
+analytics data.
+
+## Goals
+
+- Operate ClickHouse as a persistent, internal-only Docker Compose service.
+- Document installation, verification, upgrade, backup, restore, rollback, and
+  incident handling in English runbooks.
+- Make ClickHouse ready for a future quality-telemetry implementation without
+  creating tables or emitting events in this infrastructure change.
+- Specify a separate future implementation change for KPI telemetry and
+  consent-governed content storage.
+
+## Non-Goals
+
+- No API Gateway event emitter, ClickHouse schema, dashboard, or production
+  telemetry data is introduced by the infrastructure change.
+- No raw audio, text, transcripts, translations, IP addresses, or free-form
+  errors are stored in ClickHouse.
+- No public ClickHouse endpoint, Traefik route, or browser-accessible SQL UI is
+  introduced.
+- No content-storage implementation is included in the telemetry change.
+
+## Decisions
+
+### Internal ClickHouse deployment
+
+Add a `clickhouse` service to `docker-compose.yml`, using a pinned
+`clickhouse/clickhouse-server` image, `restart: always`, and an internal
+`expose: 8123` declaration only. The service has no `ports` or Traefik labels.
+It stores its data in the `clickhouse-data` named volume and uses
+`ulimit nofile=262144`.
+
+Database name, service user, and password are configured via `.env`; only
+non-secret placeholders are added to `.env.example`. A missing password must
+make Compose configuration invalid rather than falling back to a default. The
+server is checked with `GET /ping` and administration is performed with
+`docker compose exec clickhouse clickhouse-client`.
+
+### Operational controls
+
+The runbook will require a backup before an image update. Backups are logical,
+compressed exports and follow the existing backup rotation. Restore is first
+validated into a temporary database. Rollback stops or recreates the service
+with the previous pinned image without removing the data volume.
+
+### Telemetry and content boundary
+
+ClickHouse is the analytical store only. The later telemetry capability writes
+append-only, pseudonymised quality records with `event_id` and
+`schema_version`. It records only the metadata needed by the KPI catalogue,
+including an opaque `content_record_id_hash` where content exists.
+
+Consented content uses a separate, tenant-isolated and encrypted content
+store:
+
+| Content class | Storage |
+| --- | --- |
+| Quality events, technical measurements, consent snapshots, opaque content references | ClickHouse |
+| Source text, ASR results, translations, TTS text | Separate transactional content database |
+| Input and output audio | Encrypted object store |
+| Consent ledger, access audit, retention and deletion jobs | Transactional consent/content system |
+
+Access to content must be purpose-, role-, and audit-controlled. Consent is
+granular by purpose and content category, is never preselected, and is
+withdrawable. On withdrawal, new content capture stops and existing content is
+identified through the opaque reference and queued for deletion. ClickHouse
+retains no content copies.
+
+### Future OpenSpec change
+
+Create `add-clickhouse-quality-telemetry` with a design document and delta
+specifications. It will define the event contract, bounded taxonomy, async and
+idempotent writes, failure isolation from the message path, retention, and test
+coverage. It will also state the content-store boundary as a prerequisite, not
+as an implementation task.
+
+The implementation issue for a colleague must link to the OpenSpec proposal,
+use the change ID as a label or title prefix, and list the proposal's acceptance
+criteria. The issue cannot be considered complete until consent redaction,
+deduplication, and a non-blocking ClickHouse failure path are tested.
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| ClickHouse outage delays messages | Future writer is asynchronous and best-effort; it never blocks the message path. |
+| Unauthorised database access | No public port, dedicated password-protected user, credentials only in `.env`. |
+| Content leaks into analytics | Contract allowlist, automated redaction tests, and separate content-store boundary. |
+| Irrecoverable data or unsafe upgrade | Named volume, pre-upgrade backup, restore verification, pinned image, documented rollback. |
+| Consent withdrawal is incomplete | Content references, deletion queue, deletion audit, and separate access-controlled content store. |
+
+## Verification
+
+The infrastructure change is accepted when Compose validates without exposing
+ClickHouse externally; the service answers `/ping`; authenticated internal SQL
+access works; the data survives recreation; and the runbook's backup and
+restore verification commands succeed. The telemetry change has separate
+automated tests for event allowlisting, consent redaction, idempotency, and
+ClickHouse failure isolation.

--- a/openspec/changes/add-clickhouse-quality-telemetry/design.md
+++ b/openspec/changes/add-clickhouse-quality-telemetry/design.md
@@ -1,0 +1,31 @@
+## Context
+
+The installed internal ClickHouse service is ready for analytical data but has
+no telemetry schema. The KPI catalogue defines two durable quality records,
+session_quality and translation_quality, and requires a strict separation
+between analytical metadata and consented content.
+
+## Decisions
+
+- Every event has a UUID event_id and integer schema_version.
+- Writers use a bounded in-memory queue and asynchronous batches. Insertion
+  retries preserve event_id so duplicate deliveries count once.
+- A ClickHouse failure is observable through an operational metric and
+  structured, content-free log but never delays, cancels, or fails a message.
+- Raw metadata expires after 30 days. Pseudonymised daily aggregates expire
+  after 13 months.
+- The event allowlist excludes source text, ASR text, translations, TTS text,
+  audio bytes, audio URLs, IP addresses, full user agents, raw errors, and
+  debug payloads. It permits only content_record_id_hash and consent metadata.
+- Text and consent-ledger data require a separate transactional content system;
+  audio requires an encrypted, tenant-isolated object store.
+
+## Risks
+
+- Small event inserts can create excessive parts. Use batching or ClickHouse
+  asynchronous inserts with durable acknowledgement.
+- Retry ambiguity can duplicate analytics. Deduplicate by event_id.
+- Pipeline metadata can contain content. Convert it through explicit typed
+  allowlists rather than serialising source dictionaries.
+- Consent withdrawal must stop future content capture and trigger deletion in
+  the separate content store; ClickHouse holds only an opaque reference.

--- a/openspec/changes/add-clickhouse-quality-telemetry/proposal.md
+++ b/openspec/changes/add-clickhouse-quality-telemetry/proposal.md
@@ -26,6 +26,7 @@ metrics system; ClickHouse is the analytical event store.
   deployment schema assets, Grafana dashboards, and tests.
 - Dependency: the internal ClickHouse service is installed separately.
 - Dependency: consent-governed content storage is a separate future capability.
+- GitHub issue: https://github.com/smart-village-solutions/smart-speech-flow/issues/199
 
 ## Non-Goals
 

--- a/openspec/changes/add-clickhouse-quality-telemetry/proposal.md
+++ b/openspec/changes/add-clickhouse-quality-telemetry/proposal.md
@@ -1,0 +1,35 @@
+# Change: Add ClickHouse Quality Telemetry
+
+## Why
+
+SSF needs durable, privacy-aware analytical records to calculate the
+conversation-quality KPIs, identify reliability and latency regressions, and
+compare releases and model configurations. Prometheus remains the operational
+metrics system; ClickHouse is the analytical event store.
+
+## What Changes
+
+- Add an allowlisted, versioned quality-event contract and ClickHouse schema.
+- Add a bounded, asynchronous telemetry writer that cannot delay or fail the
+  message and session paths.
+- Record pseudonymised session, pipeline, delivery, failure, and release/model
+  metadata with idempotent event delivery.
+- Add retention, aggregates, dashboards, operational metrics, and tests.
+- Record only opaque content references and consent snapshots; do not store
+  text, transcripts, translations, recordings, audio URLs, IP addresses, or
+  free-form errors in ClickHouse.
+
+## Impact
+
+- Affected capability: quality-telemetry.
+- Affected code: API Gateway lifecycle and pipeline hooks, telemetry module,
+  deployment schema assets, Grafana dashboards, and tests.
+- Dependency: the internal ClickHouse service is installed separately.
+- Dependency: consent-governed content storage is a separate future capability.
+
+## Non-Goals
+
+- Implementing the separate transactional content database or encrypted object
+  store.
+- Capturing content without granular, purpose-specific, withdrawable consent.
+- Replacing Prometheus or changing public API contracts.

--- a/openspec/changes/add-clickhouse-quality-telemetry/specs/quality-telemetry/spec.md
+++ b/openspec/changes/add-clickhouse-quality-telemetry/specs/quality-telemetry/spec.md
@@ -1,0 +1,56 @@
+## ADDED Requirements
+
+### Requirement: Versioned privacy-aware quality events
+
+The system SHALL emit quality telemetry through a versioned, allowlisted event
+contract. Every event SHALL include a unique event_id, schema_version, UTC
+timestamp, pseudonymised identifiers where necessary, and no content-bearing
+field.
+
+#### Scenario: Content-bearing metadata is received
+
+- **WHEN** an event source includes text, an audio URL, raw error text, audio
+  bytes, an IP address, or a debug payload
+- **THEN** the telemetry payload excludes those values and retains only
+  approved metadata
+
+#### Scenario: Consented content exists
+
+- **WHEN** a message has valid consented content in the separate content store
+- **THEN** ClickHouse records at most an opaque content_record_id_hash and
+  consent metadata
+
+### Requirement: Non-blocking idempotent telemetry delivery
+
+The system SHALL batch telemetry delivery asynchronously and deduplicate
+retries by event_id. Telemetry delivery SHALL not change message, session, or
+delivery outcomes.
+
+#### Scenario: ClickHouse is unavailable
+
+- **WHEN** the telemetry writer cannot insert a batch
+- **THEN** the message pipeline completes independently and the failed batch is
+  observable without content leakage
+
+#### Scenario: An event is retried
+
+- **WHEN** the writer delivers the same event_id more than once
+- **THEN** the analytical record is counted once
+
+### Requirement: Retention and analytical comparability
+
+The system SHALL retain raw pseudonymised quality metadata for 30 days and
+pseudonymised daily aggregates for 13 months. Quality records SHALL retain
+effective release, pipeline, provider, model, and configuration comparison
+metadata.
+
+#### Scenario: Raw-event retention expires
+
+- **WHEN** a raw quality record reaches 30 days of age
+- **THEN** ClickHouse removes it according to the configured TTL while
+  preserving eligible daily aggregates
+
+#### Scenario: Model comparison is requested
+
+- **WHEN** an operator queries quality results by model or release
+- **THEN** the results can be segmented by the recorded comparison metadata

--- a/openspec/changes/add-clickhouse-quality-telemetry/tasks.md
+++ b/openspec/changes/add-clickhouse-quality-telemetry/tasks.md
@@ -1,0 +1,25 @@
+## 1. Schema and Contract
+
+- [ ] 1.1 Define versioned, typed allowlisted event models and stable error taxonomy.
+- [ ] 1.2 Create ClickHouse schema migrations for raw session and translation quality records.
+- [ ] 1.3 Add monthly partitioning, event_id deduplication, 30-day raw-data TTL, and 13-month daily aggregate TTL.
+
+## 2. Writer and Gateway Integration
+
+- [ ] 2.1 Implement a bounded asynchronous writer with batched, acknowledged inserts and operational metrics.
+- [ ] 2.2 Implement retry and idempotency behavior keyed by event_id.
+- [ ] 2.3 Emit allowed lifecycle, pipeline, delivery, and terminal-outcome metadata from API Gateway hooks.
+- [ ] 2.4 Ensure unavailable ClickHouse never changes message, session, or WebSocket outcomes.
+
+## 3. Privacy and Operations
+
+- [ ] 3.1 Redact content-bearing pipeline metadata through an explicit allowlist.
+- [ ] 3.2 Persist only opaque content references and consent snapshots; do not implement content storage here.
+- [ ] 3.3 Add dashboards, writer-health alerts, retention verification, and operational runbook updates.
+
+## 4. Verification
+
+- [ ] 4.1 Add unit tests for allowlisting, redaction, and stable error classification.
+- [ ] 4.2 Add tests for duplicate event delivery and retry idempotency.
+- [ ] 4.3 Add tests proving a ClickHouse outage does not affect successful or failed message processing.
+- [ ] 4.4 Add integration tests for schema, TTL configuration, and aggregate correctness.

--- a/tests/test_clickhouse_compose_configuration.py
+++ b/tests/test_clickhouse_compose_configuration.py
@@ -1,0 +1,58 @@
+"""Regression tests for the internal ClickHouse Compose security contract."""
+
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).parents[1]
+
+
+def _clickhouse_service() -> dict:
+    """Return the resolved ClickHouse service using isolated test credentials."""
+    with tempfile.NamedTemporaryFile(mode="w", delete=False) as env_file:
+        env_file.write("CLICKHOUSE_DB=ssf_analytics_test\n")
+        env_file.write("CLICKHOUSE_USER=ssf_telemetry_test\n")
+        env_file.write("CLICKHOUSE_PASSWORD=test-only-password\n")
+
+    try:
+        result = subprocess.run(
+            ["docker", "compose", "--env-file", env_file.name, "config"],
+            cwd=ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    finally:
+        os.unlink(env_file.name)
+
+    return yaml.safe_load(result.stdout)["services"]["clickhouse"]
+
+
+def test_clickhouse_service_is_internal_and_persistent() -> None:
+    """Fail if ClickHouse becomes public or loses durable storage."""
+    service = _clickhouse_service()
+
+    assert service["image"] == "clickhouse/clickhouse-server:26.3.17.110"
+    assert service["restart"] == "always"
+    assert service.get("ports") is None
+    assert service["expose"] == ["8123"]
+    assert {
+        "type": "volume",
+        "source": "clickhouse-data",
+        "target": "/var/lib/clickhouse",
+        "volume": {},
+    } in service["volumes"]
+    assert service.get("labels") is None
+
+
+def test_clickhouse_service_receives_required_credentials() -> None:
+    """Fail if resolved ClickHouse credentials are omitted from the service."""
+    environment = _clickhouse_service()["environment"]
+
+    assert environment["CLICKHOUSE_PASSWORD"] == "test-only-password"
+    assert environment["CLICKHOUSE_USER"] == "ssf_telemetry_test"
+    assert environment["CLICKHOUSE_DB"] == "ssf_analytics_test"

--- a/tests/test_frontend_container_build.py
+++ b/tests/test_frontend_container_build.py
@@ -25,6 +25,9 @@ def _docker_build(tag: str, *build_args: str) -> subprocess.CompletedProcess[str
 def _compose_build(project_name: str) -> subprocess.CompletedProcess[str]:
     environment = os.environ.copy()
     environment["FRONTEND_DEMO_PASSWORD"] = "container-build-test-password"
+    environment["CLICKHOUSE_DB"] = "ssf_analytics_test"
+    environment["CLICKHOUSE_USER"] = "ssf_telemetry_test"
+    environment["CLICKHOUSE_PASSWORD"] = "test-only-password"
     return subprocess.run(
         [
             "docker",


### PR DESCRIPTION
## Description

Installs ClickHouse as an internal persistent Docker Compose service and adds
operational documentation. It also provides the validated OpenSpec proposal for
the later API Gateway quality-telemetry implementation.

## Type of Change

- [x] New feature
- [x] Documentation update
- [x] Test update
- [x] Security fix

## Related Issues

Related to #199.

## Changes Made

- Added ClickHouse 26.3.17.110 with a named data volume, required credentials,
  health check, and no host-port or Traefik exposure.
- Added a resolved-Compose security regression test and adjusted the existing
  Compose frontend-build fixture with non-production ClickHouse values.
- Added security guidance, backup guidance, and the ClickHouse operations
  runbook.
- Added and validated the OpenSpec change add-clickhouse-quality-telemetry.

## Testing

- [x] Full test suite: 374 passed, 33 skipped.
- [x] Resolved Compose security test: 2 passed.
- [x] OpenSpec strict validation passed.
- [x] Live internal deployment verified: health endpoint, authenticated query,
  no host port bindings, and data-volume persistence across recreation.

## Security and Privacy

ClickHouse remains internal-only and contains no content data. The follow-up
telemetry proposal permits only pseudonymised metadata and opaque content
references; consented content requires separate storage.

## Deployment Notes

- [x] Requires configuration changes.
- [x] Requires a service start or restart.

Set CLICKHOUSE_DB, CLICKHOUSE_USER, and CLICKHOUSE_PASSWORD in untracked .env,
then run docker compose up -d clickhouse.
