### PR TITLE
fix(gateway): allow customer UI correlation header

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,13 @@ CLICKHOUSE_DB=ssf_analytics
 CLICKHOUSE_USER=ssf_telemetry
 CLICKHOUSE_PASSWORD=replace_with_a_unique_strong_password
 
+# Keycloak identity provider and private PostgreSQL database
+KEYCLOAK_DB_NAME=keycloak
+KEYCLOAK_DB_USER=keycloak
+KEYCLOAK_DB_PASSWORD=replace_with_a_unique_strong_database_password
+KEYCLOAK_BOOTSTRAP_ADMIN_USERNAME=keycloak_admin
+KEYCLOAK_BOOTSTRAP_ADMIN_PASSWORD=replace_with_a_unique_strong_admin_password
+
 # LLM Refinement Configuration
 # -----------------------------
 # Enable/disable LLM-based translation refinement

--- a/services/api_gateway/app.py
+++ b/services/api_gateway/app.py
@@ -328,6 +328,7 @@ def setup_cors_for_websockets():
             "User-Agent",
             "Cache-Control",
             "Pragma",
+            "X-Correlation-Id",
             # WebSocket-specific headers
             "Upgrade",
             "Connection",

--- a/services/api_gateway/tests/test_endpoints.py
+++ b/services/api_gateway/tests/test_endpoints.py
@@ -26,3 +26,19 @@ def test_public_languages_endpoint():
     assert "languages" in payload
     assert isinstance(payload["languages"], dict)
     assert "de" in payload["languages"]
+
+
+def test_cors_preflight_allows_correlation_id_from_customer_ui():
+    response = client.options(
+        "/api/session/D311FB67",
+        headers={
+            "Origin": "https://translate.smart-village.solutions",
+            "Access-Control-Request-Method": "GET",
+            "Access-Control-Request-Headers": "X-Correlation-Id",
+        },
+    )
+
+    assert response.status_code == 200
+    assert (
+        "x-correlation-id" in response.headers["access-control-allow-headers"].lower()
+    )


### PR DESCRIPTION
## Summary

- allow the customer UI’s `X-Correlation-Id` request header in the API Gateway CORS configuration
- add a regression test for the production customer-origin preflight request
- add Keycloak database and bootstrap-admin examples to `.env.example`

## Verification

- `pytest services/api_gateway/tests/test_endpoints.py -q`
- public CORS preflight to the deployed gateway returns HTTP 200 and grants `X-Correlation-Id`

## Notes

The broader gateway suite has existing pipeline-test failures outside Docker because `asr:8000` cannot be resolved from the host environment; the focused CORS regression tests pass.