### PR TITLE
fix(ops): use ClickHouse allowed backup path

### DIFF
--- a/scripts/backup-production.sh
+++ b/scripts/backup-production.sh
@@ -64,8 +64,8 @@ if [[ ! "$clickhouse_database" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
   exit 1
 fi
 production_compose exec -T clickhouse clickhouse-client --query \
-  "BACKUP DATABASE \`${clickhouse_database}\` TO File('/tmp/ssf-clickhouse-backup.zip')"
-production_compose exec -T clickhouse cat /tmp/ssf-clickhouse-backup.zip \
+  "BACKUP DATABASE \`${clickhouse_database}\` TO File('backups/ssf-clickhouse-backup.zip')"
+production_compose exec -T clickhouse cat /var/lib/clickhouse/backups/ssf-clickhouse-backup.zip \
   > "$staging_dir/clickhouse-native-backup.zip"
 
 tar -C "$SSF_PROJECT_ROOT" -czf "$staging_dir/configuration.tar.gz" \

--- a/scripts/restore-production-drill.sh
+++ b/scripts/restore-production-drill.sh
@@ -30,7 +30,7 @@ cleanup() {
 trap cleanup EXIT
 
 docker run --detach --pull=never --network none --name "$container" \
-  --volume "$backup_dir:/backup:ro" "$clickhouse_image" >/dev/null
+  --volume "$backup_dir:/var/lib/clickhouse/backups:ro" "$clickhouse_image" >/dev/null
 
 for _ in $(seq 1 30); do
   if docker exec "$container" clickhouse-client --query 'SELECT 1' >/dev/null 2>&1; then
@@ -40,7 +40,7 @@ for _ in $(seq 1 30); do
 done
 docker exec "$container" clickhouse-client --query 'SELECT 1' >/dev/null
 docker exec "$container" clickhouse-client --query \
-  "RESTORE DATABASE \`${source_database}\` AS \`${target_database}\` FROM File('/backup/clickhouse-native-backup.zip')"
+  "RESTORE DATABASE \`${source_database}\` AS \`${target_database}\` FROM File('clickhouse-native-backup.zip')"
 docker exec "$container" clickhouse-client --query \
   "EXISTS DATABASE \`${target_database}\`" | grep -qx 1
 printf 'Isolated ClickHouse restore drill passed for %s.\n' "$backup_dir"

--- a/tests/operations/test_production_scripts.py
+++ b/tests/operations/test_production_scripts.py
@@ -77,3 +77,10 @@ def test_backup_verifier_rejects_empty_required_artifact(tmp_path):
 
     assert result.returncode == 1
     assert "empty" in result.stderr
+
+
+def test_clickhouse_backup_uses_the_configured_allowed_backup_path():
+    script = (ROOT / "scripts/backup-production.sh").read_text()
+
+    assert "File('backups/ssf-clickhouse-backup.zip')" in script
+    assert "/tmp/ssf-clickhouse-backup.zip" not in script


### PR DESCRIPTION
Fix the production backup and isolated restore drill to use ClickHouse `backups.allowed_path` instead of the rejected `/tmp` path. Includes a regression test.