### PR TITLE
fix(ops): copy ClickHouse native backup from allowed path

### DIFF
--- a/scripts/backup-production.sh
+++ b/scripts/backup-production.sh
@@ -64,8 +64,8 @@ if [[ ! "$clickhouse_database" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
   exit 1
 fi
 production_compose exec -T clickhouse clickhouse-client --query \
-  "BACKUP DATABASE \`${clickhouse_database}\` TO File('backups/ssf-clickhouse-backup.zip')"
-production_compose exec -T clickhouse cat /var/lib/clickhouse/backups/ssf-clickhouse-backup.zip \
+  "BACKUP DATABASE \`${clickhouse_database}\` TO File('ssf-clickhouse-backup.zip')"
+production_compose exec -T clickhouse cat /var/lib/clickhouse/backups/backups/ssf-clickhouse-backup.zip \
   > "$staging_dir/clickhouse-native-backup.zip"
 
 tar -C "$SSF_PROJECT_ROOT" -czf "$staging_dir/configuration.tar.gz" \

--- a/scripts/restore-production-drill.sh
+++ b/scripts/restore-production-drill.sh
@@ -30,7 +30,7 @@ cleanup() {
 trap cleanup EXIT
 
 docker run --detach --pull=never --network none --name "$container" \
-  --volume "$backup_dir:/var/lib/clickhouse/backups:ro" "$clickhouse_image" >/dev/null
+  --volume "$backup_dir:/var/lib/clickhouse/backups/backups:ro" "$clickhouse_image" >/dev/null
 
 for _ in $(seq 1 30); do
   if docker exec "$container" clickhouse-client --query 'SELECT 1' >/dev/null 2>&1; then

--- a/tests/operations/test_production_scripts.py
+++ b/tests/operations/test_production_scripts.py
@@ -82,5 +82,6 @@ def test_backup_verifier_rejects_empty_required_artifact(tmp_path):
 def test_clickhouse_backup_uses_the_configured_allowed_backup_path():
     script = (ROOT / "scripts/backup-production.sh").read_text()
 
-    assert "File('backups/ssf-clickhouse-backup.zip')" in script
+    assert "File('ssf-clickhouse-backup.zip')" in script
+    assert "/var/lib/clickhouse/backups/backups/ssf-clickhouse-backup.zip" in script
     assert "/tmp/ssf-clickhouse-backup.zip" not in script


### PR DESCRIPTION
Use the exact nested path ClickHouse creates below its configured `backups.allowed_path`; align the isolated restore mount. Includes a regression test.