### PR TITLE
fix(ops): use unique ClickHouse backup files

### DIFF
--- a/scripts/backup-production.sh
+++ b/scripts/backup-production.sh
@@ -59,14 +59,16 @@ production_compose exec -T redis redis-cli --rdb /tmp/ssf-backup.rdb >/dev/null
 production_compose exec -T redis cat /tmp/ssf-backup.rdb > "$staging_dir/redis.rdb"
 
 clickhouse_database="${SSF_CLICKHOUSE_DATABASE:-$(grep '^CLICKHOUSE_DB=' "$SSF_PROJECT_ROOT/.env" | head -n 1 | cut -d= -f2-)}"
+clickhouse_backup_filename="ssf-clickhouse-${timestamp}.zip"
 if [[ ! "$clickhouse_database" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
   printf 'CLICKHOUSE_DB must be a simple SQL identifier for native backups.\n' >&2
   exit 1
 fi
 production_compose exec -T clickhouse clickhouse-client --query \
-  "BACKUP DATABASE \`${clickhouse_database}\` TO File('ssf-clickhouse-backup.zip')"
-production_compose exec -T clickhouse cat /var/lib/clickhouse/backups/backups/ssf-clickhouse-backup.zip \
+  "BACKUP DATABASE \`${clickhouse_database}\` TO File('${clickhouse_backup_filename}')"
+production_compose exec -T clickhouse cat "/var/lib/clickhouse/backups/backups/${clickhouse_backup_filename}" \
   > "$staging_dir/clickhouse-native-backup.zip"
+production_compose exec -T clickhouse rm -f "/var/lib/clickhouse/backups/backups/${clickhouse_backup_filename}"
 
 tar -C "$SSF_PROJECT_ROOT" -czf "$staging_dir/configuration.tar.gz" \
   deploy/production monitoring letsencrypt models

--- a/tests/operations/test_production_scripts.py
+++ b/tests/operations/test_production_scripts.py
@@ -82,6 +82,8 @@ def test_backup_verifier_rejects_empty_required_artifact(tmp_path):
 def test_clickhouse_backup_uses_the_configured_allowed_backup_path():
     script = (ROOT / "scripts/backup-production.sh").read_text()
 
-    assert "File('ssf-clickhouse-backup.zip')" in script
-    assert "/var/lib/clickhouse/backups/backups/ssf-clickhouse-backup.zip" in script
+    assert 'clickhouse_backup_filename="ssf-clickhouse-${timestamp}.zip"' in script
+    assert "File('${clickhouse_backup_filename}')" in script
+    assert "/var/lib/clickhouse/backups/backups/${clickhouse_backup_filename}" in script
+    assert 'rm -f "/var/lib/clickhouse/backups/backups/${clickhouse_backup_filename}"' in script
     assert "/tmp/ssf-clickhouse-backup.zip" not in script


### PR DESCRIPTION
Create native ClickHouse backup artifacts with the UTC backup timestamp and remove the temporary server-side file only after it is copied into the manifest-verified backup. Prevents collisions after interrupted runs.