### PR TITLE
fix(ops): copy ClickHouse backup from direct allowed path

### DIFF
--- a/scripts/backup-production.sh
+++ b/scripts/backup-production.sh
@@ -66,9 +66,9 @@ if [[ ! "$clickhouse_database" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
 fi
 production_compose exec -T clickhouse clickhouse-client --query \
   "BACKUP DATABASE \`${clickhouse_database}\` TO File('${clickhouse_backup_filename}')"
-production_compose exec -T clickhouse cat "/var/lib/clickhouse/backups/backups/${clickhouse_backup_filename}" \
+production_compose exec -T clickhouse cat "/var/lib/clickhouse/backups/${clickhouse_backup_filename}" \
   > "$staging_dir/clickhouse-native-backup.zip"
-production_compose exec -T clickhouse rm -f "/var/lib/clickhouse/backups/backups/${clickhouse_backup_filename}"
+production_compose exec -T clickhouse rm -f "/var/lib/clickhouse/backups/${clickhouse_backup_filename}"
 
 tar -C "$SSF_PROJECT_ROOT" -czf "$staging_dir/configuration.tar.gz" \
   deploy/production monitoring letsencrypt models

--- a/tests/operations/test_production_scripts.py
+++ b/tests/operations/test_production_scripts.py
@@ -84,6 +84,6 @@ def test_clickhouse_backup_uses_the_configured_allowed_backup_path():
 
     assert 'clickhouse_backup_filename="ssf-clickhouse-${timestamp}.zip"' in script
     assert "File('${clickhouse_backup_filename}')" in script
-    assert "/var/lib/clickhouse/backups/backups/${clickhouse_backup_filename}" in script
-    assert 'rm -f "/var/lib/clickhouse/backups/backups/${clickhouse_backup_filename}"' in script
+    assert "/var/lib/clickhouse/backups/${clickhouse_backup_filename}" in script
+    assert 'rm -f "/var/lib/clickhouse/backups/${clickhouse_backup_filename}"' in script
     assert "/tmp/ssf-clickhouse-backup.zip" not in script


### PR DESCRIPTION
Correct the copy and cleanup path for the unique ClickHouse native backup. The live ClickHouse instance confirms `File(filename)` is created directly below `/var/lib/clickhouse/backups/`.