### PR TITLE
fix(ops): omit Ollama model weights from backups

### DIFF
--- a/docs/operations/production-recovery.md
+++ b/docs/operations/production-recovery.md
@@ -38,9 +38,13 @@ Redis, and ClickHouse.
 
 Daily, weekly, and monthly timers create complete local backups under
 `backups/<tier>/<UTC timestamp>`. Retention is seven daily, four weekly, and
-twelve monthly backups. Every backup contains all production Docker volumes,
-a logical Keycloak PostgreSQL export, Redis snapshot, configuration and state
-directories, checksum manifests, and archive readability validation.
+twelve monthly backups. Every backup contains the stateful production Docker
+volumes (except reproducible Ollama model weights), a logical Keycloak
+PostgreSQL export, Redis snapshot, configuration and state directories,
+checksum manifests, and archive readability validation. `ollama-models.txt`
+records the installed model identifiers; after recovery, pull those models
+again from the configured Ollama registry. This keeps recurring backups small
+while retaining the information needed to restore the service configuration.
 The monthly job also restores the ClickHouse native backup into a temporary,
 network-isolated ClickHouse container and fails if that drill cannot complete.
 The backup directory stores `.env` with mode `0600` and the Git revision needed

--- a/scripts/backup-production.sh
+++ b/scripts/backup-production.sh
@@ -34,10 +34,10 @@ required=(
   configuration.tar.gz
   environment.env
   git-revision.txt
+  ollama-models.txt
   volumes/ssf-backend_audio-data.tar.gz
   volumes/ssf-backend_clickhouse-data.tar.gz
   volumes/ssf-backend_keycloak-postgres-data.tar.gz
-  volumes/ssf-backend_ollama-data.tar.gz
   volumes/ssf-backend_redis-data.tar.gz
   volumes/prometheus-data.tar.gz
 )
@@ -57,6 +57,10 @@ production_compose exec -T keycloak-postgres sh -ec \
 
 production_compose exec -T redis redis-cli --rdb /tmp/ssf-backup.rdb >/dev/null
 production_compose exec -T redis cat /tmp/ssf-backup.rdb > "$staging_dir/redis.rdb"
+
+# Ollama model weights are reproducible downloads. Preserve the requested model
+# identifiers for recovery without retaining a large duplicate of their volume.
+production_compose exec -T ollama ollama list > "$staging_dir/ollama-models.txt"
 
 clickhouse_database="${SSF_CLICKHOUSE_DATABASE:-$(grep '^CLICKHOUSE_DB=' "$SSF_PROJECT_ROOT/.env" | head -n 1 | cut -d= -f2-)}"
 clickhouse_backup_filename="ssf-clickhouse-${timestamp}.zip"
@@ -79,7 +83,6 @@ for volume in \
   ssf-backend_audio-data \
   ssf-backend_clickhouse-data \
   ssf-backend_keycloak-postgres-data \
-  ssf-backend_ollama-data \
   ssf-backend_redis-data \
   1980baddd3a6bd8bcade314d6f81d3716e73ae9bba6655b90d4179ff7b1990a7; do
   docker volume inspect "$volume" >/dev/null

--- a/tests/operations/test_production_scripts.py
+++ b/tests/operations/test_production_scripts.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import json
 from pathlib import Path
 
 
@@ -87,3 +88,81 @@ def test_clickhouse_backup_uses_the_configured_allowed_backup_path():
     assert "/var/lib/clickhouse/backups/${clickhouse_backup_filename}" in script
     assert 'rm -f "/var/lib/clickhouse/backups/${clickhouse_backup_filename}"' in script
     assert "/tmp/ssf-clickhouse-backup.zip" not in script
+
+
+def test_backup_records_ollama_models_without_archiving_model_volume(tmp_path):
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    docker_log = tmp_path / "docker.log"
+    fake_docker = fake_bin / "docker"
+    fake_docker.write_text(
+        """#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> "$FAKE_DOCKER_LOG"
+arguments="$*"
+if [[ "$arguments" == *"exec -T keycloak-postgres"* ]]; then
+  printf 'postgres dump\\n'
+elif [[ "$arguments" == *"exec -T redis cat /tmp/ssf-backup.rdb"* ]]; then
+  printf 'redis dump\\n'
+elif [[ "$arguments" == *"exec -T clickhouse cat /var/lib/clickhouse/backups/"* ]]; then
+  printf 'clickhouse dump\\n'
+elif [[ "$arguments" == *"exec -T ollama ollama list"* ]]; then
+  printf 'NAME ID SIZE MODIFIED\\ngpt-oss:20b abc 13 GB now\\n'
+elif [[ "${1:-}" == "run" ]]; then
+  backup_mount=''
+  for argument in "$@"; do
+    if [[ "$argument" == *":/backup" ]]; then
+      backup_mount="${argument%:/backup}"
+    fi
+  done
+  archive="${arguments##*/backup/volumes/}"
+  archive="${archive%% *}"
+  mkdir -p "$backup_mount/volumes"
+  /usr/bin/tar -C /tmp -czf "$backup_mount/volumes/$archive" --files-from /dev/null
+fi
+"""
+    )
+    fake_docker.chmod(0o755)
+    fake_tar = fake_bin / "tar"
+    fake_tar.write_text(
+        """#!/usr/bin/env bash
+set -euo pipefail
+for ((index = 1; index <= $#; index++)); do
+  if [[ "${!index}" == "-czf" ]]; then
+    next_index=$((index + 1))
+    /usr/bin/tar -C /tmp -czf "${!next_index}" --files-from /dev/null
+    exit 0
+  fi
+done
+exec /usr/bin/tar "$@"
+"""
+    )
+    fake_tar.chmod(0o755)
+    fake_git = fake_bin / "git"
+    fake_git.write_text("#!/usr/bin/env bash\nprintf 'test-revision\\n'\n")
+    fake_git.chmod(0o755)
+
+    project_root = tmp_path / "project"
+    for directory in ("deploy/production", "monitoring", "letsencrypt", "models"):
+        (project_root / directory).mkdir(parents=True, exist_ok=True)
+    (project_root / ".env").write_text("CLICKHOUSE_DB=ssf\n")
+
+    backup_root = tmp_path / "backups"
+    result = run_script(
+        "scripts/backup-production.sh",
+        environment={
+            "PATH": f"{fake_bin}:{os.environ['PATH']}",
+            "FAKE_DOCKER_LOG": str(docker_log),
+            "SSF_BACKUP_ROOT": str(backup_root),
+            "SSF_CLICKHOUSE_DATABASE": "ssf",
+            "SSF_PROJECT_ROOT": str(project_root),
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    backup = next(path for path in backup_root.iterdir() if path.is_dir())
+    manifest = json.loads((backup / "manifest.json").read_text())
+    assert "ollama-models.txt" in manifest["required"]
+    assert "volumes/ssf-backend_ollama-data.tar.gz" not in manifest["required"]
+    assert "gpt-oss:20b" in (backup / "ollama-models.txt").read_text()
+    assert "ssf-backend_ollama-data" not in docker_log.read_text()


### PR DESCRIPTION
## Summary
- exclude reproducible Ollama model weights from recurring volume archives
- record installed Ollama models in each verified backup
- document the recovery pull step and cover it with an executed backup-flow test

## Verification
- docker compose --env-file /root/projects/ssf-backend/.env -f deploy/production/docker-compose.production.yml config --quiet
- bash -n scripts/backup-production.sh
- pytest -q tests/operations