### PR TITLE
fix(ops): snapshot Grafana state consistently

### DIFF
--- a/docs/operations/production-recovery.md
+++ b/docs/operations/production-recovery.md
@@ -45,6 +45,15 @@ checksum manifests, and archive readability validation. `ollama-models.txt`
 records the installed model identifiers; after recovery, pull those models
 again from the configured Ollama registry. This keeps recurring backups small
 while retaining the information needed to restore the service configuration.
+The Grafana SQLite database is captured separately using a consistent SQLite
+snapshot. Loki log chunks and Promtail read positions are intentionally not
+backed up: they change continuously and are not required to restore the
+application or monitoring configuration.
+
+To restore Grafana state, stop Grafana, replace
+`monitoring/grafana/grafana.db` with the backup's `grafana.db`, remove any
+stale `grafana.db-wal` and `grafana.db-shm` files, then start Grafana again.
+Do not restore Loki history or Promtail positions.
 The monthly job also restores the ClickHouse native backup into a temporary,
 network-isolated ClickHouse container and fails if that drill cannot complete.
 The backup directory stores `.env` with mode `0600` and the Git revision needed

--- a/scripts/backup-production.sh
+++ b/scripts/backup-production.sh
@@ -34,6 +34,7 @@ required=(
   configuration.tar.gz
   environment.env
   git-revision.txt
+  grafana.db
   ollama-models.txt
   volumes/ssf-backend_audio-data.tar.gz
   volumes/ssf-backend_clickhouse-data.tar.gz
@@ -62,6 +63,22 @@ production_compose exec -T redis cat /tmp/ssf-backup.rdb > "$staging_dir/redis.r
 # identifiers for recovery without retaining a large duplicate of their volume.
 production_compose exec -T ollama ollama list > "$staging_dir/ollama-models.txt"
 
+# Grafana stores its mutable state in SQLite. Use SQLite's backup API for a
+# consistent snapshot instead of copying a live database and its WAL files.
+python3 - "$SSF_PROJECT_ROOT/monitoring/grafana/grafana.db" "$staging_dir/grafana.db" <<'PY'
+import sqlite3
+import sys
+from pathlib import Path
+
+source = sqlite3.connect(f"{Path(sys.argv[1]).resolve().as_uri()}?mode=ro", uri=True)
+destination = sqlite3.connect(sys.argv[2])
+try:
+    source.backup(destination)
+finally:
+    destination.close()
+    source.close()
+PY
+
 clickhouse_database="${SSF_CLICKHOUSE_DATABASE:-$(grep '^CLICKHOUSE_DB=' "$SSF_PROJECT_ROOT/.env" | head -n 1 | cut -d= -f2-)}"
 clickhouse_backup_filename="ssf-clickhouse-${timestamp}.zip"
 if [[ ! "$clickhouse_database" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
@@ -75,6 +92,13 @@ production_compose exec -T clickhouse cat "/var/lib/clickhouse/backups/${clickho
 production_compose exec -T clickhouse rm -f "/var/lib/clickhouse/backups/${clickhouse_backup_filename}"
 
 tar -C "$SSF_PROJECT_ROOT" -czf "$staging_dir/configuration.tar.gz" \
+  --exclude='monitoring/grafana/grafana.db' \
+  --exclude='monitoring/grafana/grafana.db-shm' \
+  --exclude='monitoring/grafana/grafana.db-wal' \
+  --exclude='monitoring/loki-data' \
+  --exclude='monitoring/loki-data/*' \
+  --exclude='monitoring/promtail-data' \
+  --exclude='monitoring/promtail-data/*' \
   deploy/production monitoring letsencrypt models
 install -m 0600 "$SSF_PROJECT_ROOT/.env" "$staging_dir/environment.env"
 git -C "$SSF_PROJECT_ROOT" rev-parse HEAD > "$staging_dir/git-revision.txt"

--- a/tests/operations/test_production_scripts.py
+++ b/tests/operations/test_production_scripts.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 import json
+import sqlite3
 from pathlib import Path
 
 
@@ -123,21 +124,6 @@ fi
 """
     )
     fake_docker.chmod(0o755)
-    fake_tar = fake_bin / "tar"
-    fake_tar.write_text(
-        """#!/usr/bin/env bash
-set -euo pipefail
-for ((index = 1; index <= $#; index++)); do
-  if [[ "${!index}" == "-czf" ]]; then
-    next_index=$((index + 1))
-    /usr/bin/tar -C /tmp -czf "${!next_index}" --files-from /dev/null
-    exit 0
-  fi
-done
-exec /usr/bin/tar "$@"
-"""
-    )
-    fake_tar.chmod(0o755)
     fake_git = fake_bin / "git"
     fake_git.write_text("#!/usr/bin/env bash\nprintf 'test-revision\\n'\n")
     fake_git.chmod(0o755)
@@ -145,24 +131,63 @@ exec /usr/bin/tar "$@"
     project_root = tmp_path / "project"
     for directory in ("deploy/production", "monitoring", "letsencrypt", "models"):
         (project_root / directory).mkdir(parents=True, exist_ok=True)
+    (project_root / "monitoring/loki-data").mkdir()
+    (project_root / "monitoring/promtail-data").mkdir()
+    (project_root / "monitoring/loki-data/live.log").write_text("live log data\n")
+    (project_root / "monitoring/promtail-data/positions.yaml").write_text("positions\n")
+    (project_root / "monitoring/prometheus.yml").write_text("global: {}\n")
+    grafana_database = project_root / "monitoring/grafana/grafana.db"
+    grafana_database.parent.mkdir()
+    source_connection = sqlite3.connect(grafana_database)
+    source_connection.execute("PRAGMA journal_mode=WAL")
+    source_connection.execute("CREATE TABLE backup_check (value TEXT)")
+    source_connection.execute("INSERT INTO backup_check VALUES ('consistent snapshot')")
+    source_connection.commit()
+    assert grafana_database.with_name("grafana.db-wal").exists()
     (project_root / ".env").write_text("CLICKHOUSE_DB=ssf\n")
 
     backup_root = tmp_path / "backups"
-    result = run_script(
-        "scripts/backup-production.sh",
-        environment={
-            "PATH": f"{fake_bin}:{os.environ['PATH']}",
-            "FAKE_DOCKER_LOG": str(docker_log),
-            "SSF_BACKUP_ROOT": str(backup_root),
-            "SSF_CLICKHOUSE_DATABASE": "ssf",
-            "SSF_PROJECT_ROOT": str(project_root),
-        },
-    )
+    environment = {
+        "PATH": f"{fake_bin}:{os.environ['PATH']}",
+        "FAKE_DOCKER_LOG": str(docker_log),
+        "SSF_BACKUP_ROOT": str(backup_root),
+        "SSF_CLICKHOUSE_DATABASE": "ssf",
+        "SSF_PROJECT_ROOT": str(project_root),
+    }
+    try:
+        result = run_script("scripts/backup-production.sh", environment=environment)
+    finally:
+        source_connection.close()
 
     assert result.returncode == 0, result.stderr
     backup = next(path for path in backup_root.iterdir() if path.is_dir())
     manifest = json.loads((backup / "manifest.json").read_text())
+    assert "grafana.db" in manifest["required"]
     assert "ollama-models.txt" in manifest["required"]
     assert "volumes/ssf-backend_ollama-data.tar.gz" not in manifest["required"]
     assert "gpt-oss:20b" in (backup / "ollama-models.txt").read_text()
     assert "ssf-backend_ollama-data" not in docker_log.read_text()
+    with sqlite3.connect(backup / "grafana.db") as connection:
+        assert connection.execute("SELECT value FROM backup_check").fetchone() == (
+            "consistent snapshot",
+        )
+    configuration_listing = subprocess.run(
+        ["tar", "-tzf", backup / "configuration.tar.gz"],
+        text=True,
+        capture_output=True,
+        check=True,
+    ).stdout
+    assert "monitoring/prometheus.yml" in configuration_listing
+    assert "monitoring/loki-data/live.log" not in configuration_listing
+    assert "monitoring/promtail-data/positions.yaml" not in configuration_listing
+    assert "monitoring/grafana/grafana.db" not in configuration_listing
+
+    grafana_database.unlink()
+    grafana_database.with_name("grafana.db-wal").unlink(missing_ok=True)
+    grafana_database.with_name("grafana.db-shm").unlink(missing_ok=True)
+    missing_database_root = tmp_path / "missing-database-backups"
+    missing_database_result = run_script(
+        "scripts/backup-production.sh",
+        environment={**environment, "SSF_BACKUP_ROOT": str(missing_database_root)},
+    )
+    assert missing_database_result.returncode == 1


### PR DESCRIPTION
## Summary
- exclude continuously changing Loki and Promtail runtime data from configuration archives
- capture Grafana state using SQLite's consistent backup API and fail if its source is absent
- document Grafana restoration and cover WAL-backed data in the backup-flow test

## Verification
- docker compose --env-file /root/projects/ssf-backend/.env -f deploy/production/docker-compose.production.yml config --quiet
- bash -n scripts/backup-production.sh
- pytest -q tests/operations