### PR TITLE
fix(ops): rely on consistent database backups

### DIFF
--- a/docs/operations/production-recovery.md
+++ b/docs/operations/production-recovery.md
@@ -39,9 +39,11 @@ Redis, and ClickHouse.
 Daily, weekly, and monthly timers create complete local backups under
 `backups/<tier>/<UTC timestamp>`. Retention is seven daily, four weekly, and
 twelve monthly backups. Every backup contains the stateful production Docker
-volumes (except reproducible Ollama model weights), a logical Keycloak
-PostgreSQL export, Redis snapshot, configuration and state directories,
-checksum manifests, and archive readability validation. `ollama-models.txt`
+audio volume, a logical Keycloak PostgreSQL export, Redis snapshot, ClickHouse
+native backup, configuration and state directories, checksum manifests, and
+archive readability validation. The database and Prometheus raw volumes are
+intentionally not archived because they are actively written and their
+consistent native snapshots are the recovery source. `ollama-models.txt`
 records the installed model identifiers; after recovery, pull those models
 again from the configured Ollama registry. This keeps recurring backups small
 while retaining the information needed to restore the service configuration.

--- a/scripts/backup-production.sh
+++ b/scripts/backup-production.sh
@@ -37,10 +37,6 @@ required=(
   grafana.db
   ollama-models.txt
   volumes/ssf-backend_audio-data.tar.gz
-  volumes/ssf-backend_clickhouse-data.tar.gz
-  volumes/ssf-backend_keycloak-postgres-data.tar.gz
-  volumes/ssf-backend_redis-data.tar.gz
-  volumes/prometheus-data.tar.gz
 )
 
 cleanup() {
@@ -104,21 +100,13 @@ install -m 0600 "$SSF_PROJECT_ROOT/.env" "$staging_dir/environment.env"
 git -C "$SSF_PROJECT_ROOT" rev-parse HEAD > "$staging_dir/git-revision.txt"
 
 for volume in \
-  ssf-backend_audio-data \
-  ssf-backend_clickhouse-data \
-  ssf-backend_keycloak-postgres-data \
-  ssf-backend_redis-data \
-  1980baddd3a6bd8bcade314d6f81d3716e73ae9bba6655b90d4179ff7b1990a7; do
+  ssf-backend_audio-data; do
   docker volume inspect "$volume" >/dev/null
-  archive_name="$volume"
-  if [[ "$volume" == 1980baddd3a6bd8bcade314d6f81d3716e73ae9bba6655b90d4179ff7b1990a7 ]]; then
-    archive_name=prometheus-data
-  fi
   docker run --rm --pull=never \
     --volume "$volume:/source:ro" \
     --volume "$staging_dir:/backup" \
     ssf-backup-helper:prod-e409a06 \
-    tar -C /source -czf "/backup/volumes/${archive_name}.tar.gz" .
+    tar -C /source -czf "/backup/volumes/${volume}.tar.gz" .
 done
 
 python3 - "$staging_dir/manifest.json" "${required[@]}" <<'PY'

--- a/tests/operations/test_production_scripts.py
+++ b/tests/operations/test_production_scripts.py
@@ -164,9 +164,19 @@ fi
     manifest = json.loads((backup / "manifest.json").read_text())
     assert "grafana.db" in manifest["required"]
     assert "ollama-models.txt" in manifest["required"]
+    assert "volumes/ssf-backend_audio-data.tar.gz" in manifest["required"]
     assert "volumes/ssf-backend_ollama-data.tar.gz" not in manifest["required"]
     assert "gpt-oss:20b" in (backup / "ollama-models.txt").read_text()
-    assert "ssf-backend_ollama-data" not in docker_log.read_text()
+    docker_calls = docker_log.read_text()
+    for volume in (
+        "ssf-backend_ollama-data",
+        "ssf-backend_clickhouse-data",
+        "ssf-backend_keycloak-postgres-data",
+        "ssf-backend_redis-data",
+        "1980baddd3a6bd8bcade314d6f81d3716e73ae9bba6655b90d4179ff7b1990a7",
+    ):
+        assert volume not in manifest["required"]
+        assert volume not in docker_calls
     with sqlite3.connect(backup / "grafana.db") as connection:
         assert connection.execute("SELECT value FROM backup_check").fetchone() == (
             "consistent snapshot",


### PR DESCRIPTION
## Summary
- archive only user audio files as a raw Docker volume
- rely on consistent PostgreSQL, Redis, ClickHouse, and Grafana snapshots for stateful services
- omit live database and Prometheus volumes that cannot be safely tarred

## Verification
- docker compose --env-file /root/projects/ssf-backend/.env -f deploy/production/docker-compose.production.yml config --quiet
- bash -n scripts/backup-production.sh
- pytest -q tests/operations