### PR TITLE
Guard the production Keycloak realm mount

### DIFF
--- a/deploy/production/docker-compose.production.yml
+++ b/deploy/production/docker-compose.production.yml
@@ -243,7 +243,7 @@ services:
       KC_HTTP_ENABLED: 'true'
       KC_HEALTH_ENABLED: 'true'
     volumes:
-    - ./keycloak/ssf-realm.json:/opt/keycloak/data/import/ssf-realm.json:ro
+    - ./deploy/production/keycloak/ssf-realm.json:/opt/keycloak/data/import/ssf-realm.json:ro
     depends_on:
       keycloak-postgres:
         condition: service_healthy

--- a/deploy/production/docker-compose.production.yml
+++ b/deploy/production/docker-compose.production.yml
@@ -243,7 +243,7 @@ services:
       KC_HTTP_ENABLED: 'true'
       KC_HEALTH_ENABLED: 'true'
     volumes:
-    - ./deploy/production/keycloak/ssf-realm.json:/opt/keycloak/data/import/ssf-realm.json:ro
+    - ./keycloak/ssf-realm.json:/opt/keycloak/data/import/ssf-realm.json:ro
     depends_on:
       keycloak-postgres:
         condition: service_healthy

--- a/tests/operations/test_production_compose.py
+++ b/tests/operations/test_production_compose.py
@@ -64,9 +64,10 @@ def test_keycloak_realm_mount_resolves_to_the_versioned_file():
         for volume in keycloak["volumes"]
         if volume.endswith(":/opt/keycloak/data/import/ssf-realm.json:ro")
     )
-    source = Path(realm_mount.split(":", maxsplit=1)[0])
+    source = (COMPOSE_PATH.parent / realm_mount.split(":", maxsplit=1)[0]).resolve()
+    expected_source = Path("deploy/production/keycloak/ssf-realm.json").resolve()
 
-    assert source == Path("deploy/production/keycloak/ssf-realm.json")
+    assert source == expected_source
     assert source.is_file()
 
 

--- a/tests/operations/test_production_compose.py
+++ b/tests/operations/test_production_compose.py
@@ -57,6 +57,19 @@ def test_production_compose_preserves_the_existing_prometheus_volume():
     assert compose["volumes"]["prometheus-data"]["external"] is True
 
 
+def test_keycloak_realm_mount_resolves_to_the_versioned_file():
+    keycloak = load_production_compose()["services"]["keycloak"]
+    realm_mount = next(
+        volume
+        for volume in keycloak["volumes"]
+        if volume.endswith(":/opt/keycloak/data/import/ssf-realm.json:ro")
+    )
+    source = Path(realm_mount.split(":", maxsplit=1)[0])
+
+    assert source == Path("deploy/production/keycloak/ssf-realm.json")
+    assert source.is_file()
+
+
 def test_recovery_unit_never_recreates_existing_containers():
     unit = Path("deploy/systemd/ssf-production.service").read_text()
     assert "up --detach --no-build --pull never --no-recreate" in unit


### PR DESCRIPTION
## Summary
- preserve the canonical single-file production Compose mount (which resolves relative to `deploy/production`)
- add a regression test that resolves the source using the same base directory
- require that the resolved source is the versioned regular realm file

## Rollout finding
A manual two-file Compose invocation changed the relative-path base and caused Docker to mount a directory. Production was restored using the correct absolute source. The canonical systemd and operations helpers already invoke only `deploy/production/docker-compose.production.yml`; this PR prevents a future path change from breaking that contract.

## Validation
- canonical rendered mount: `/root/projects/ssf-backend/deploy/production/keycloak/ssf-realm.json`
- canonical resolved source matches the running container mount
- production Compose tests: 6 passed
- hermetic backend suite: 370 passed, 25 skipped
- production health check and public authentication probes passed