### PR TITLE
fix(ops): avoid Compose reconciliation during boot

### DIFF
--- a/deploy/systemd/ssf-production.service
+++ b/deploy/systemd/ssf-production.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Smart Speech Flow production workload
+Description=Verify Smart Speech Flow production recovery
 Wants=network-online.target
 After=network-online.target docker.service nvidia-persistenced.service
 Requires=docker.service
@@ -13,11 +13,9 @@ RemainAfterExit=yes
 WorkingDirectory=/root/projects/ssf-backend
 ExecStartPre=/usr/bin/docker info
 ExecStartPre=/usr/bin/nvidia-smi -L
-ExecStart=/usr/bin/docker compose --project-name ssf-backend --env-file /root/projects/ssf-backend/.env --file /root/projects/ssf-backend/deploy/production/docker-compose.production.yml up --detach --no-build --pull never --no-recreate
+ExecStart=/usr/bin/true
 ExecStartPost=/root/projects/ssf-backend/scripts/production-health-check.sh --timeout-seconds 300
-ExecStop=/usr/bin/docker compose --project-name ssf-backend --env-file /root/projects/ssf-backend/.env --file /root/projects/ssf-backend/deploy/production/docker-compose.production.yml stop
 TimeoutStartSec=330
-TimeoutStopSec=120
 Restart=on-failure
 RestartSec=10s
 

--- a/docs/operations/production-recovery.md
+++ b/docs/operations/production-recovery.md
@@ -17,9 +17,11 @@ sudo systemctl start ssf-production-health.timer
 sudo systemctl start ssf-backup-daily.timer ssf-backup-weekly.timer ssf-backup-monthly.timer
 ```
 
-`ssf-production.service` only starts locally available pinned images
-(`--pull never`, `--no-build`) and then applies the five-minute health gate.
-It must be enabled only after the controlled activation procedure below.
+`ssf-production.service` relies on Docker's `unless-stopped` restart policies
+to recover existing containers and then applies the five-minute health gate.
+It deliberately does not run `docker compose up`, so a reboot cannot reconcile
+or replace running containers from a changed Compose definition. Controlled
+Compose deployments remain a separate, reviewed operation.
 
 ## Verify recovery
 
@@ -80,10 +82,20 @@ docker compose --env-file .env -f deploy/production/docker-compose.production.ym
 ./scripts/production-health-check.sh --timeout-seconds 300
 ```
 
-Make a verified backup first. Start the canonical workload with the systemd
-unit, then run the health gate. If it does not pass within five minutes, stop
-the unit and restore the last known-good container set and backup data; do not
-pull images or use the mutable root Compose definition while investigating.
+Make a verified backup first. Apply the reviewed canonical definition with:
+
+```bash
+docker compose --project-name ssf-backend --env-file .env \
+  -f deploy/production/docker-compose.production.yml \
+  up --detach --no-build --pull never
+sudo systemctl restart ssf-production.service
+```
+
+The systemd unit only verifies Docker-managed recovery; it does not deploy or
+stop containers. If the health gate does not pass within five minutes, restore
+the last known-good Compose definition and backup data, then run the same
+explicit Compose activation and health gate. Do not pull images or use the
+mutable root Compose definition while investigating.
 
 ## Operating-system updates
 

--- a/tests/operations/test_production_compose.py
+++ b/tests/operations/test_production_compose.py
@@ -71,7 +71,10 @@ def test_keycloak_realm_mount_resolves_to_the_versioned_file():
     assert source.is_file()
 
 
-def test_recovery_unit_never_recreates_existing_containers():
+def test_recovery_unit_relies_on_docker_restart_policies_without_compose_reconciliation():
     unit = Path("deploy/systemd/ssf-production.service").read_text()
-    assert "up --detach --no-build --pull never --no-recreate" in unit
+    assert "ExecStart=/usr/bin/true" in unit
+    assert "docker compose" not in unit
+    assert "ExecStop=" not in unit
+    assert "ExecStartPost=/root/projects/ssf-backend/scripts/production-health-check.sh --timeout-seconds 300" in unit
     assert "Restart=on-failure" in unit


### PR DESCRIPTION
## Summary
- rely on Docker  policies for existing container recovery
- restrict the systemd production unit to Docker/NVIDIA preflight and health verification
- document explicit reviewed Compose activation separately from boot recovery

## Verification
- pytest -q tests/operations
- systemd-analyze verify deploy/systemd/ssf-production.service