### PR TITLE
feat: add project steward agent

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "personal",
+  "interface": {
+    "displayName": "Personal"
+  },
+  "plugins": [
+    {
+      "name": "project-steward",
+      "source": {
+        "source": "local",
+        "path": "./plugins/project-steward"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    }
+  ]
+}

--- a/apps/project-report/package.json
+++ b/apps/project-report/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "test": "vitest run"
+    "test": "vitest run",
+    "sync:github-project": "node scripts/project-status-sync.mjs"
   },
   "dependencies": {
     "react": "^19.2.0",

--- a/apps/project-report/scripts/project-status-sync.mjs
+++ b/apps/project-report/scripts/project-status-sync.mjs
@@ -41,18 +41,19 @@ const healthSeverity = {
   blocked: 3,
 };
 
-const statusFor = (items) => {
-  if (items.every((item) => item.status === 'Done')) return statusByProjectStatus.Done;
-  return items
-    .map((item) => statusByProjectStatus[item.status])
-    .filter(Boolean)
-    .reduce((leastAdvanced, status) => progressByStatus[status] < progressByStatus[leastAdvanced] ? status : leastAdvanced, 'done');
+const statusFor = (items, fallback) => {
+  const statuses = items.map((item) => statusByProjectStatus[item.status]);
+  if (statuses.some((status) => !status)) return fallback;
+  return statuses.reduce((leastAdvanced, status) => progressByStatus[status] < progressByStatus[leastAdvanced] ? status : leastAdvanced);
 };
 
-const healthFor = (items, fallback) => items
-  .map((item) => healthByProjectHealth[item.health])
-  .filter(Boolean)
-  .reduce((current, health) => healthSeverity[health] > healthSeverity[current] ? health : current, fallback);
+const healthFor = (items, fallback) => {
+  const healths = items
+    .map((item) => healthByProjectHealth[item.health])
+    .filter(Boolean);
+  if (healths.length === 0) return fallback;
+  return healths.reduce((current, health) => healthSeverity[health] > healthSeverity[current] ? health : current);
+};
 
 const matchesWorkPackage = (workPackage, item) =>
   item.workPackageId === workPackage.id ||
@@ -67,7 +68,7 @@ export const applyProjectSnapshot = (report, projectItems, updatedAt) => {
     for (const workPackage of milestone.workPackages) {
       const matches = projectItems.filter((item) => matchesWorkPackage(workPackage, item));
       if (matches.length === 0) continue;
-      workPackage.status = statusFor(matches);
+      workPackage.status = statusFor(matches, workPackage.status);
       workPackage.health = healthFor(matches, workPackage.health);
     }
   }

--- a/apps/project-report/scripts/project-status-sync.mjs
+++ b/apps/project-report/scripts/project-status-sync.mjs
@@ -1,0 +1,115 @@
+import { execFileSync } from 'node:child_process';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const statusByProjectStatus = {
+  Idea: 'idea',
+  Commissioned: 'commissioned',
+  Planned: 'planned',
+  Prototype: 'prototype',
+  Implementation: 'implementation',
+  Optimization: 'optimization',
+  Testing: 'testing',
+  Acceptance: 'acceptance',
+  Done: 'done',
+};
+
+const progressByStatus = {
+  idea: 0,
+  commissioned: 0,
+  planned: 10,
+  prototype: 20,
+  implementation: 45,
+  optimization: 70,
+  testing: 80,
+  acceptance: 90,
+  done: 100,
+};
+
+const healthByProjectHealth = {
+  'On track': 'on_track',
+  'Needs attention': 'needs_attention',
+  'At risk': 'at_risk',
+  Blocked: 'blocked',
+};
+
+const healthSeverity = {
+  on_track: 0,
+  needs_attention: 1,
+  at_risk: 2,
+  blocked: 3,
+};
+
+const statusFor = (items) => {
+  if (items.every((item) => item.status === 'Done')) return statusByProjectStatus.Done;
+  return items
+    .map((item) => statusByProjectStatus[item.status])
+    .filter(Boolean)
+    .reduce((leastAdvanced, status) => progressByStatus[status] < progressByStatus[leastAdvanced] ? status : leastAdvanced, 'done');
+};
+
+const healthFor = (items, fallback) => items
+  .map((item) => healthByProjectHealth[item.health])
+  .filter(Boolean)
+  .reduce((current, health) => healthSeverity[health] > healthSeverity[current] ? health : current, fallback);
+
+const matchesWorkPackage = (workPackage, item) =>
+  item.workPackageId === workPackage.id ||
+  item.workPackageIds?.includes(workPackage.id) ||
+  workPackage.tracking?.githubIssues?.includes(item.issueNumber);
+
+export const applyProjectSnapshot = (report, projectItems, updatedAt) => {
+  const result = structuredClone(report);
+  result.meta.updatedAt = updatedAt;
+
+  for (const milestone of result.milestones) {
+    for (const workPackage of milestone.workPackages) {
+      const matches = projectItems.filter((item) => matchesWorkPackage(workPackage, item));
+      if (matches.length === 0) continue;
+      workPackage.status = statusFor(matches);
+      workPackage.health = healthFor(matches, workPackage.health);
+    }
+  }
+
+  return result;
+};
+
+export const projectItemsFrom = (payload) => payload.items.map((item) => ({
+  issueNumber: typeof item.content?.number === 'number' ? item.content.number : undefined,
+  workPackageId: item['work Package'],
+  workPackageIds: String(item['roadmap links'] ?? item['roadmap Links'] ?? item['Roadmap links'] ?? '')
+    .split(',')
+    .map((value) => value.trim())
+    .filter(Boolean),
+  status: item.status,
+  health: item.health,
+}));
+
+const argumentValue = (name, fallback) => {
+  const index = process.argv.indexOf(name);
+  return index === -1 ? fallback : process.argv[index + 1];
+};
+
+export const syncProjectStatus = ({ owner, projectNumber, reportPath }) => {
+  const payload = JSON.parse(execFileSync('gh', [
+    'project', 'item-list', projectNumber, '--owner', owner, '--limit', '100', '--format', 'json',
+  ], { encoding: 'utf8' }));
+  const report = JSON.parse(readFileSync(reportPath, 'utf8'));
+  const today = new Date().toISOString().slice(0, 10);
+  const result = applyProjectSnapshot(report, projectItemsFrom(payload), today);
+  writeFileSync(reportPath, `${JSON.stringify(result, null, 2)}\n`);
+  return result;
+};
+
+const isMainModule = process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (isMainModule) {
+  const appRoot = resolve(fileURLToPath(new URL('..', import.meta.url)));
+  const result = syncProjectStatus({
+    owner: argumentValue('--owner', 'smart-village-solutions'),
+    projectNumber: argumentValue('--project', '7'),
+    reportPath: argumentValue('--report', resolve(appRoot, 'src/data/project-status.json')),
+  });
+  console.log(`Synced ${result.milestones.flatMap((milestone) => milestone.workPackages).length} work packages.`);
+}

--- a/apps/project-report/scripts/project-status-sync.test.mjs
+++ b/apps/project-report/scripts/project-status-sync.test.mjs
@@ -35,6 +35,26 @@ describe('applyProjectSnapshot', () => {
     expect(result.milestones[0].workPackages[0]).toMatchObject({ status: 'planned', health: 'needs_attention' });
   });
 
+  it('reflects a recovered Project health instead of retaining a stale blocked snapshot', () => {
+    const recovered = report();
+    recovered.milestones[0].workPackages[0].health = 'blocked';
+
+    const result = applyProjectSnapshot(recovered, [
+      { issueNumber: 189, status: 'Implementation', health: 'On track' },
+    ], '2026-08-31');
+
+    expect(result.milestones[0].workPackages[0]).toMatchObject({ health: 'on_track' });
+  });
+
+  it('preserves the current status when a matching Project item has no recognized status', () => {
+    const result = applyProjectSnapshot(report(), [
+      { issueNumber: 189, status: 'Done', health: 'On track' },
+      { issueNumber: 189, status: undefined, health: 'On track' },
+    ], '2026-08-31');
+
+    expect(result.milestones[0].workPackages[0]).toMatchObject({ status: 'planned' });
+  });
+
   it('preserves the roadmap-specific Prototype state from a Project item', () => {
     const result = applyProjectSnapshot(report(), [
       { workPackageId: 'WP-002', status: 'Prototype', health: 'On track' },

--- a/apps/project-report/scripts/project-status-sync.test.mjs
+++ b/apps/project-report/scripts/project-status-sync.test.mjs
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import { applyProjectSnapshot, projectItemsFrom } from './project-status-sync.mjs';
+
+const report = () => ({
+  meta: { version: '1.5.0', updatedAt: '2026-08-30', source: 'roadmap' },
+  milestones: [{
+    id: 'M1',
+    workPackages: [
+      { id: 'WP-001', status: 'planned', health: 'on_track', tracking: { githubIssues: [189] } },
+      { id: 'WP-002', status: 'planned', health: 'on_track' },
+    ],
+  }],
+});
+
+describe('applyProjectSnapshot', () => {
+  it('derives work-package status and health from matching issue and draft Project items', () => {
+    const result = applyProjectSnapshot(report(), [
+      { issueNumber: 189, status: 'Implementation', health: 'At risk' },
+      { workPackageId: 'WP-002', status: 'Done', health: 'On track' },
+    ], '2026-08-31');
+
+    expect(result.milestones[0].workPackages).toMatchObject([
+      { id: 'WP-001', status: 'implementation', health: 'at_risk' },
+      { id: 'WP-002', status: 'done', health: 'on_track' },
+    ]);
+    expect(result.meta.updatedAt).toBe('2026-08-31');
+  });
+
+  it('does not regress a package to done until every matching item is done', () => {
+    const result = applyProjectSnapshot(report(), [
+      { issueNumber: 189, status: 'Done', health: 'On track' },
+      { issueNumber: 189, status: 'Planned', health: 'Needs attention' },
+    ], '2026-08-31');
+
+    expect(result.milestones[0].workPackages[0]).toMatchObject({ status: 'planned', health: 'needs_attention' });
+  });
+
+  it('preserves the roadmap-specific Prototype state from a Project item', () => {
+    const result = applyProjectSnapshot(report(), [
+      { workPackageId: 'WP-002', status: 'Prototype', health: 'On track' },
+    ], '2026-08-31');
+
+    expect(result.milestones[0].workPackages[1]).toMatchObject({ status: 'prototype', health: 'on_track' });
+  });
+
+  it('updates every work package named in a multi-package Project link', () => {
+    const result = applyProjectSnapshot(report(), [
+      { workPackageIds: ['WP-001', 'WP-002'], status: 'Testing', health: 'On track' },
+    ], '2026-08-31');
+
+    expect(result.milestones[0].workPackages).toMatchObject([
+      { id: 'WP-001', status: 'testing' },
+      { id: 'WP-002', status: 'testing' },
+    ]);
+  });
+});
+
+describe('projectItemsFrom', () => {
+  it('reads comma-separated roadmap links from GitHub Project output', () => {
+    expect(projectItemsFrom({ items: [{
+      content: { number: 232 },
+      'roadmap links': 'WP-015, WP-016, WP-017',
+      status: 'Planned',
+      health: 'On track',
+    }] })).toEqual([{
+      issueNumber: 232,
+      workPackageId: undefined,
+      workPackageIds: ['WP-015', 'WP-016', 'WP-017'],
+      status: 'Planned',
+      health: 'On track',
+    }]);
+  });
+});

--- a/apps/project-report/src/data/project-status.json
+++ b/apps/project-report/src/data/project-status.json
@@ -1,8 +1,8 @@
 {
   "meta": {
-    "version": "1.4.1",
-    "updatedAt": "2026-08-09",
-    "source": "docs/local-notes/konzept.md (Leistungskonzept KasselDIALOG); Kundenplanung mit Mehrorganisationsbetrieb ab 2026-10"
+    "version": "1.6.0",
+    "updatedAt": "2026-08-30",
+    "source": "Generated snapshot of GitHub Project #7 (Smart Speech Flow Delivery). Roadmap structure and acceptance criteria originate from docs/local-notes/konzept.md and the architecture reviews of 20.08.2026."
   },
   "statusModel": {
     "idea": 0,
@@ -15,7 +15,12 @@
     "acceptance": 90,
     "done": 100
   },
-  "healthModel": ["on_track", "needs_attention", "at_risk", "blocked"],
+  "healthModel": [
+    "on_track",
+    "needs_attention",
+    "at_risk",
+    "blocked"
+  ],
   "priorityModel": {
     "must": "1: Muss sein",
     "replacement_required": "2: Notwendig für die Ablösung des Alt-Systems",
@@ -42,7 +47,9 @@
           "status": "done",
           "health": "on_track",
           "dependsOn": [],
-          "acceptanceCriteria": ["Der aktualisierte Serverstand ist erfolgreich in Betrieb genommen."],
+          "acceptanceCriteria": [
+            "Der aktualisierte Serverstand ist erfolgreich in Betrieb genommen."
+          ],
           "featureSummary": "Der technische Ausgangsstand für die weitere Entwicklung ist aktualisiert."
         },
         {
@@ -55,7 +62,9 @@
           "status": "done",
           "health": "on_track",
           "dependsOn": [],
-          "acceptanceCriteria": ["Aktuellere Modelloptionen und ihre Eignung für SSF sind dokumentiert."],
+          "acceptanceCriteria": [
+            "Aktuellere Modelloptionen und ihre Eignung für SSF sind dokumentiert."
+          ],
           "featureSummary": "Die weitere Modellauswahl kann auf einem aktuellen Markt- und Technologiestand aufbauen."
         },
         {
@@ -68,8 +77,13 @@
           "status": "prototype",
           "health": "on_track",
           "dependsOn": [],
-          "acceptanceCriteria": ["Ein demonstrierbarer UI-Prototyp liegt zum Kundenmeeting vor."],
-          "todos": ["Prototyp im Kundenmeeting vorstellen.", "Feedback und Änderungswünsche erfassen."],
+          "acceptanceCriteria": [
+            "Ein demonstrierbarer UI-Prototyp liegt zum Kundenmeeting vor."
+          ],
+          "todos": [
+            "Prototyp im Kundenmeeting vorstellen.",
+            "Feedback und Änderungswünsche erfassen."
+          ],
           "featureSummary": "Der Prototyp macht den geplanten Gesprächsfluss und die Bedienung vor dem Ausbau des Produktkerns sichtbar."
         },
         {
@@ -79,12 +93,19 @@
           "area": "Recht und Compliance",
           "priority": "must",
           "effortPt": 2,
-          "status": "planned",
-          "health": "on_track",
+          "status": "implementation",
+          "health": "blocked",
           "dependsOn": [],
-          "acceptanceCriteria": ["Die rechtliche Prüfung startet am 13.08.2026.", "Die Ergebnisse liegen voraussichtlich bis zum 27.08.2026 vor."],
-          "todos": ["Prüfungsumfang und Ansprechpartner festlegen.", "Rechtliche Prüfung begleiten.", "Ergebnisse und Auflagen dokumentieren."],
-          "featureSummary": "Die rechtliche Prüfung begleitet die technische Entwicklung parallel und schafft eine belastbare Grundlage für den späteren Regelbetrieb."
+          "acceptanceCriteria": [
+            "Die rechtliche Prüfung startet am 13.08.2026.",
+            "Die Ergebnisse liegen voraussichtlich bis zum 27.08.2026 vor."
+          ],
+          "todos": [
+            "Konkrete Prüfungsaufträge und die Beauftragung abwarten.",
+            "Rechtliche Prüfung nach Beauftragung begleiten.",
+            "Ergebnisse und Auflagen nach Abschluss dokumentieren."
+          ],
+          "featureSummary": "Die rechtliche Prüfung ist eingeleitet. Die weitere Bearbeitung wartet auf konkrete Prüfungsaufträge und die Beauftragung."
         },
         {
           "id": "WP-018",
@@ -93,12 +114,22 @@
           "area": "Architektur und Produktreife",
           "priority": "must",
           "effortPt": 6,
-          "status": "planned",
+          "status": "done",
           "health": "on_track",
-          "dependsOn": ["WP-001"],
-          "acceptanceCriteria": ["Bestehende Komponenten, Schnittstellen und Betriebsartefakte sind bewertet.", "Zielarchitektur und Migrationspfad sind dokumentiert und abgestimmt."],
-          "todos": ["MVP-Architektur reviewen.", "Zielarchitektur dokumentieren.", "Migrationsrisiken und -schritte festlegen."],
-          "featureSummary": "Das Arbeitspaket schafft die abgestimmte technische Grundlage für die weitere Produktreifung und Nachnutzbarkeit."
+          "dependsOn": [
+            "WP-001"
+          ],
+          "tracking": {
+            "githubIssues": [],
+            "openSpecChanges": [
+              "refactor-api-gateway-boundaries"
+            ]
+          },
+          "acceptanceCriteria": [
+            "Bestehende Komponenten, Schnittstellen und Betriebsartefakte sind bewertet.",
+            "Zielarchitektur und Migrationspfad sind dokumentiert und abgestimmt."
+          ],
+          "featureSummary": "Die drei Architektur-Reviews, die Zielarchitektur und der Migrationspfad liegen vor; ihre Umsetzung wird über die verknüpften Folgepakete gesteuert."
         }
       ]
     },
@@ -117,9 +148,28 @@
           "effortPt": 16,
           "status": "planned",
           "health": "on_track",
-          "dependsOn": ["WP-003"],
-          "acceptanceCriteria": ["Admin und Customer können ein Gespräch zuverlässig starten, führen und beenden.", "Kritische Session- und WebSocket-Pfade sind automatisiert getestet."],
-          "todos": ["Session-Erstellung, -Beitritt und -Beendigung vereinheitlichen.", "Nachrichtenfluss absichern.", "WebSocket-Reconnect und Cleanup stabilisieren.", "Verwaiste Sessions bereinigen."],
+          "dependsOn": [
+            "WP-003"
+          ],
+          "tracking": {
+            "githubIssues": [
+              189,
+              191
+            ],
+            "openSpecChanges": [
+              "refactor-api-gateway-boundaries"
+            ]
+          },
+          "acceptanceCriteria": [
+            "Admin und Customer können ein Gespräch zuverlässig starten, führen und beenden.",
+            "Kritische Session- und WebSocket-Pfade sind automatisiert getestet."
+          ],
+          "todos": [
+            "Session-Erstellung, -Beitritt und -Beendigung vereinheitlichen.",
+            "Nachrichtenfluss absichern.",
+            "WebSocket-Reconnect und Cleanup stabilisieren.",
+            "Verwaiste Sessions bereinigen."
+          ],
           "featureSummary": "Der zentrale Gesprächsfluss funktioniert stabil in realen Nutzungssituationen."
         },
         {
@@ -131,9 +181,29 @@
           "effortPt": 14,
           "status": "planned",
           "health": "on_track",
-          "dependsOn": ["WP-004"],
-          "acceptanceCriteria": ["Fehlerhafte, unvollständige und zu große Audiodateien werden nachvollziehbar behandelt.", "Ausfälle in ASR-, Übersetzungs- und TTS-Pipeline führen zu klaren Fehlerzuständen."],
-          "todos": ["Audioeingaben und Formate validieren.", "Timeouts in der Pipeline abfangen.", "Verhalten bei Verbindungsabbrüchen verbessern.", "Audio-End-to-End-Tests ergänzen."],
+          "dependsOn": [
+            "WP-004"
+          ],
+          "tracking": {
+            "githubIssues": [
+              190,
+              219
+            ],
+            "openSpecChanges": [
+              "add-phi-refinement-benchmarking",
+              "refactor-api-gateway-boundaries"
+            ]
+          },
+          "acceptanceCriteria": [
+            "Fehlerhafte, unvollständige und zu große Audiodateien werden nachvollziehbar behandelt.",
+            "Ausfälle in ASR-, Übersetzungs- und TTS-Pipeline führen zu klaren Fehlerzuständen."
+          ],
+          "todos": [
+            "Audioeingaben und Formate validieren.",
+            "Timeouts in der Pipeline abfangen.",
+            "Verhalten bei Verbindungsabbrüchen verbessern.",
+            "Audio-End-to-End-Tests ergänzen."
+          ],
           "featureSummary": "Die Audio-Pipeline bleibt auch bei ungünstigen Eingaben und Netzsituationen zuverlässig."
         },
         {
@@ -145,9 +215,21 @@
           "effortPt": 10,
           "status": "planned",
           "health": "on_track",
-          "dependsOn": ["WP-003", "WP-004"],
-          "acceptanceCriteria": ["Die Oberflächen unterstützen barrierearme Bedienung und verständliche Status- und Fehlermeldungen.", "Mobile und Ein-Gerät-Szenarien sind als nutzbare Varianten erprobt.", "Wiederholung, erneute Ausgabe und Recovery sind bedienbar."],
-          "todos": ["BITV-relevante Anforderungen prüfen.", "Mobile und Ein-Gerät-Szenario umsetzen.", "Sprachwahl und Gesprächseinrichtung vereinfachen.", "Interaktions- und Recovery-Muster testen."],
+          "dependsOn": [
+            "WP-003",
+            "WP-004"
+          ],
+          "acceptanceCriteria": [
+            "Die Oberflächen unterstützen barrierearme Bedienung und verständliche Status- und Fehlermeldungen.",
+            "Mobile und Ein-Gerät-Szenarien sind als nutzbare Varianten erprobt.",
+            "Wiederholung, erneute Ausgabe und Recovery sind bedienbar."
+          ],
+          "todos": [
+            "BITV-relevante Anforderungen prüfen.",
+            "Mobile und Ein-Gerät-Szenario umsetzen.",
+            "Sprachwahl und Gesprächseinrichtung vereinfachen.",
+            "Interaktions- und Recovery-Muster testen."
+          ],
           "featureSummary": "Die Gesprächsoberflächen werden für zeitkritische kommunale Beratungssituationen einfacher, zugänglicher und robuster."
         },
         {
@@ -159,9 +241,19 @@
           "effortPt": 6,
           "status": "planned",
           "health": "on_track",
-          "dependsOn": ["WP-002", "WP-005"],
-          "acceptanceCriteria": ["Deutsch, Englisch, Arabisch, Türkisch, Italienisch, Persisch, Russisch und Ukrainisch sind als Grundausbaustufe geprüft.", "Sprach- und Einsatzprofile sind konfigurierbar dokumentiert."],
-          "todos": ["Sprachprofile konfigurieren.", "Qualität je geforderter Sprache prüfen.", "Erweiterungsprozess für zusätzliche Sprachen dokumentieren."],
+          "dependsOn": [
+            "WP-002",
+            "WP-005"
+          ],
+          "acceptanceCriteria": [
+            "Deutsch, Englisch, Arabisch, Türkisch, Italienisch, Persisch, Russisch und Ukrainisch sind als Grundausbaustufe geprüft.",
+            "Sprach- und Einsatzprofile sind konfigurierbar dokumentiert."
+          ],
+          "todos": [
+            "Sprachprofile konfigurieren.",
+            "Qualität je geforderter Sprache prüfen.",
+            "Erweiterungsprozess für zusätzliche Sprachen dokumentieren."
+          ],
           "featureSummary": "Die geforderte Sprachabdeckung wird nachvollziehbar geprüft und für weitere Einsatzkontexte konfigurierbar gemacht."
         }
       ]
@@ -181,9 +273,29 @@
           "effortPt": 10,
           "status": "planned",
           "health": "on_track",
-          "dependsOn": ["WP-004", "WP-005"],
-          "acceptanceCriteria": ["Statusübergänge sind für beide Gesprächsrollen nachvollziehbar.", "Technische Fehler werden verständlich und handlungsorientiert kommuniziert."],
-          "todos": ["Einheitliches Zustandsmodell definieren.", "Statusübergänge sichtbar machen.", "Fehler im Monitoring sichtbar machen."],
+          "dependsOn": [
+            "WP-004",
+            "WP-005"
+          ],
+          "tracking": {
+            "githubIssues": [
+              219,
+              220
+            ],
+            "openSpecChanges": [
+              "refactor-api-gateway-boundaries",
+              "stabilize-production-operations"
+            ]
+          },
+          "acceptanceCriteria": [
+            "Statusübergänge sind für beide Gesprächsrollen nachvollziehbar.",
+            "Technische Fehler werden verständlich und handlungsorientiert kommuniziert."
+          ],
+          "todos": [
+            "Einheitliches Zustandsmodell definieren.",
+            "Statusübergänge sichtbar machen.",
+            "Fehler im Monitoring sichtbar machen."
+          ],
           "featureSummary": "Nutzende und Betriebsteam können Zustand und Fehlerursachen nachvollziehen."
         },
         {
@@ -195,9 +307,29 @@
           "effortPt": 12,
           "status": "planned",
           "health": "on_track",
-          "dependsOn": ["WP-004"],
-          "acceptanceCriteria": ["Kernverantwortlichkeiten sind klar getrennt.", "Refactorings sind durch Tests abgesichert."],
-          "todos": ["Technische Schulden priorisieren.", "Stark gekoppelte Module entkoppeln.", "Logging konsolidieren."],
+          "dependsOn": [
+            "WP-004"
+          ],
+          "tracking": {
+            "githubIssues": [
+              225,
+              228,
+              229,
+              230
+            ],
+            "openSpecChanges": [
+              "refactor-api-gateway-boundaries"
+            ]
+          },
+          "acceptanceCriteria": [
+            "Kernverantwortlichkeiten sind klar getrennt.",
+            "Refactorings sind durch Tests abgesichert."
+          ],
+          "todos": [
+            "Technische Schulden priorisieren.",
+            "Stark gekoppelte Module entkoppeln.",
+            "Logging konsolidieren."
+          ],
           "featureSummary": "Die Kernlogik des API-Gateways bleibt veränderbar und testbar."
         },
         {
@@ -209,9 +341,26 @@
           "effortPt": 8,
           "status": "planned",
           "health": "on_track",
-          "dependsOn": ["WP-013"],
-          "acceptanceCriteria": ["Tenant-Kontext, Datenzugriffsgrenzen und Rollenmodell sind verbindlich definiert.", "Die rechtlichen Anforderungen sind im technischen Mandantenmodell berücksichtigt."],
-          "todos": ["Tenant-Identifikation und Lebenszyklus festlegen.", "Daten-, Session-, Audio- und Log-Isolation definieren.", "Rollen, Betreibergrenzen und Provisionierungskonzept festlegen."],
+          "dependsOn": [
+            "WP-013"
+          ],
+          "tracking": {
+            "githubIssues": [
+              232
+            ],
+            "openSpecChanges": [
+              "add-multi-tenant-operations"
+            ]
+          },
+          "acceptanceCriteria": [
+            "Tenant-Kontext, Datenzugriffsgrenzen und Rollenmodell sind verbindlich definiert.",
+            "Die rechtlichen Anforderungen sind im technischen Mandantenmodell berücksichtigt."
+          ],
+          "todos": [
+            "Tenant-Identifikation und Lebenszyklus festlegen.",
+            "Daten-, Session-, Audio- und Log-Isolation definieren.",
+            "Rollen, Betreibergrenzen und Provisionierungskonzept festlegen."
+          ],
           "featureSummary": "Das Mandantenmodell schafft die fachliche und technische Grundlage dafür, mehrere Organisationen sicher auf einer SSF-Instanz zu betreiben."
         },
         {
@@ -223,9 +372,28 @@
           "effortPt": 6,
           "status": "planned",
           "health": "on_track",
-          "dependsOn": ["WP-007", "WP-018"],
-          "acceptanceCriteria": ["Schnittstellen, Datenflüsse und Integrationspunkte sind dokumentiert.", "Container-Bereitstellung und Deployment-Wege sind reproduzierbar beschrieben."],
-          "todos": ["API- und Datenflussdokumentation aktualisieren.", "Deployment- und Integrationsleitfäden erstellen.", "Nachnutzungsartefakte prüfen."],
+          "dependsOn": [
+            "WP-007",
+            "WP-018"
+          ],
+          "tracking": {
+            "githubIssues": [
+              226,
+              231
+            ],
+            "openSpecChanges": [
+              "refactor-api-gateway-boundaries"
+            ]
+          },
+          "acceptanceCriteria": [
+            "Schnittstellen, Datenflüsse und Integrationspunkte sind dokumentiert.",
+            "Container-Bereitstellung und Deployment-Wege sind reproduzierbar beschrieben."
+          ],
+          "todos": [
+            "API- und Datenflussdokumentation aktualisieren.",
+            "Deployment- und Integrationsleitfäden erstellen.",
+            "Nachnutzungsartefakte prüfen."
+          ],
           "featureSummary": "KasselDIALOG wird für Fachverfahren, weitere Einrichtungen und kommunale Nachnutzung technisch nachvollziehbar."
         },
         {
@@ -237,9 +405,37 @@
           "effortPt": 10,
           "status": "planned",
           "health": "on_track",
-          "dependsOn": ["WP-004", "WP-005", "WP-007", "WP-016"],
-          "acceptanceCriteria": ["Last- und Performance-Tests decken mindestens 250 gleichzeitige Zugriffe ab.", "Monitoring, Kapazitätsbetrachtung und dokumentierte Betriebsplanung liegen vor."],
-          "todos": ["Last- und Chaos-Tests ergänzen.", "Kapazitätsgrenzen messen.", "Monitoring für Lastzustände vervollständigen.", "Betriebsplanung dokumentieren."],
+          "dependsOn": [
+            "WP-004",
+            "WP-005",
+            "WP-007",
+            "WP-016"
+          ],
+          "tracking": {
+            "githubIssues": [
+              189,
+              190,
+              191,
+              220,
+              224,
+              227
+            ],
+            "openSpecChanges": [
+              "add-phi-refinement-benchmarking",
+              "refactor-api-gateway-boundaries",
+              "stabilize-production-operations"
+            ]
+          },
+          "acceptanceCriteria": [
+            "Last- und Performance-Tests decken mindestens 250 gleichzeitige Zugriffe ab.",
+            "Monitoring, Kapazitätsbetrachtung und dokumentierte Betriebsplanung liegen vor."
+          ],
+          "todos": [
+            "Last- und Chaos-Tests ergänzen.",
+            "Kapazitätsgrenzen messen.",
+            "Monitoring für Lastzustände vervollständigen.",
+            "Betriebsplanung dokumentieren."
+          ],
           "featureSummary": "Die Lösung weist ihre Belastbarkeit unter realistischen Mehrorganisations- und Lastbedingungen nach."
         }
       ]
@@ -259,9 +455,30 @@
           "effortPt": 10,
           "status": "planned",
           "health": "on_track",
-          "dependsOn": ["WP-004", "WP-005", "WP-006", "WP-007"],
-          "acceptanceCriteria": ["Kritische End-to-End-Flows sind als Testfälle dokumentiert und automatisiert.", "Flaky Tests sind identifiziert und priorisiert."],
-          "todos": ["End-to-End-Flows definieren.", "Regressionstests ausbauen.", "Flaky Tests stabilisieren.", "Abnahmekriterien festlegen."],
+          "dependsOn": [
+            "WP-004",
+            "WP-005",
+            "WP-006",
+            "WP-007"
+          ],
+          "tracking": {
+            "githubIssues": [
+              223
+            ],
+            "openSpecChanges": [
+              "add-code-quality-standards"
+            ]
+          },
+          "acceptanceCriteria": [
+            "Kritische End-to-End-Flows sind als Testfälle dokumentiert und automatisiert.",
+            "Flaky Tests sind identifiziert und priorisiert."
+          ],
+          "todos": [
+            "End-to-End-Flows definieren.",
+            "Regressionstests ausbauen.",
+            "Flaky Tests stabilisieren.",
+            "Abnahmekriterien festlegen."
+          ],
           "featureSummary": "Die wesentlichen Nutzerpfade sind regressionsgesichert."
         },
         {
@@ -272,11 +489,21 @@
           "priority": "must",
           "effortPt": 4,
           "status": "planned",
-          "health": "on_track",
-          "dependsOn": ["WP-013"],
-          "acceptanceCriteria": ["Rechtliche Ergebnisse und Auflagen sind bewertet.", "Notwendige Anpassungen sind umgesetzt oder als verbindliche Folgeaufgaben eingeplant."],
-          "todos": ["Prüfungsergebnisse auswerten.", "Auswirkungen auf Produkt, Betrieb und Kommunikation bewerten.", "Erforderliche Anpassungen umsetzen oder priorisieren."],
-          "featureSummary": "Die Erkenntnisse aus der zweiwöchigen Prüfung werden vor der öffentlichen Optimierungsrunde in Produkt und Betrieb überführt."
+          "health": "blocked",
+          "dependsOn": [
+            "WP-013"
+          ],
+          "acceptanceCriteria": [
+            "Rechtliche Ergebnisse und Auflagen sind bewertet.",
+            "Notwendige Anpassungen sind umgesetzt oder als verbindliche Folgeaufgaben eingeplant."
+          ],
+          "todos": [
+            "Auf konkrete Prüfungsaufträge und Ergebnisse aus WP-013 warten.",
+            "Prüfungsergebnisse nach Vorliegen auswerten.",
+            "Auswirkungen auf Produkt, Betrieb und Kommunikation bewerten.",
+            "Erforderliche Anpassungen umsetzen oder priorisieren."
+          ],
+          "featureSummary": "Die Überführung rechtlicher Ergebnisse beginnt erst nach Abschluss der eingeleiteten Prüfung und dem Vorliegen konkreter Auflagen."
         },
         {
           "id": "WP-016",
@@ -287,9 +514,31 @@
           "effortPt": 14,
           "status": "planned",
           "health": "on_track",
-          "dependsOn": ["WP-004", "WP-007", "WP-014", "WP-015"],
-          "acceptanceCriteria": ["Jede Anfrage wird einem eindeutigen Tenant-Kontext zugeordnet.", "Sessions, Nachrichten, Audiodaten, Konfigurationen und Protokolle können tenantübergreifend nicht gelesen oder verändert werden.", "Die Isolation ist durch automatisierte Tests nachgewiesen."],
-          "todos": ["Tenant-Kontext im Authentifizierungs- und Requestpfad verankern.", "Datenzugriffe und Speicherpfade tenant-sicher machen.", "Tenant-spezifische Konfigurationen und Berechtigungsprüfungen ergänzen.", "Isolations- und Negativtests implementieren."],
+          "dependsOn": [
+            "WP-004",
+            "WP-007",
+            "WP-014",
+            "WP-015"
+          ],
+          "tracking": {
+            "githubIssues": [
+              232
+            ],
+            "openSpecChanges": [
+              "add-multi-tenant-operations"
+            ]
+          },
+          "acceptanceCriteria": [
+            "Jede Anfrage wird einem eindeutigen Tenant-Kontext zugeordnet.",
+            "Sessions, Nachrichten, Audiodaten, Konfigurationen und Protokolle können tenantübergreifend nicht gelesen oder verändert werden.",
+            "Die Isolation ist durch automatisierte Tests nachgewiesen."
+          ],
+          "todos": [
+            "Tenant-Kontext im Authentifizierungs- und Requestpfad verankern.",
+            "Datenzugriffe und Speicherpfade tenant-sicher machen.",
+            "Tenant-spezifische Konfigurationen und Berechtigungsprüfungen ergänzen.",
+            "Isolations- und Negativtests implementieren."
+          ],
           "featureSummary": "Dieses Arbeitspaket liefert die minimale technische Mandantenfähigkeit für einen sicheren Mehrorganisationsbetrieb."
         },
         {
@@ -301,10 +550,31 @@
           "effortPt": 10,
           "status": "planned",
           "health": "on_track",
-          "dependsOn": ["WP-014", "WP-016"],
-          "acceptanceCriteria": ["Auditierbarkeit, Lösch- und Retentionspfade sowie Schutz sensibler Daten sind nachgewiesen.", "Update-, Rollback- und Migrationsverfahren sind dokumentiert und testbar."],
-          "todos": ["Audit- und Retentionsanforderungen umsetzen.", "Sicherheitsrelevante Monitoring- und Loggingpfade prüfen.", "Update-, Rollback- und Migrationsrunbooks vervollständigen."],
-          "featureSummary": "Die Plattform erhält die für kommunalen Betrieb notwendigen Datenschutz-, Sicherheits- und Betriebsnachweise."
+          "dependsOn": [
+            "WP-014",
+            "WP-016"
+          ],
+          "tracking": {
+            "githubIssues": [
+              221,
+              231
+            ],
+            "openSpecChanges": [
+              "stabilize-production-operations"
+            ]
+          },
+          "acceptanceCriteria": [
+            "Auditierbarkeit, Lösch- und Retentionspfade sowie Schutz sensibler Daten sind nachgewiesen.",
+            "Regelmäßige Server-Backups decken alle persistenten Daten, Konfigurationen und TLS-Zertifikate ab; Integrität und Wiederherstellung sind nachvollziehbar geprüft.",
+            "Update-, Rollback- und Migrationsverfahren sind dokumentiert und testbar."
+          ],
+          "todos": [
+            "Audit- und Retentionsanforderungen umsetzen.",
+            "Eingerichtete Server-Backup-Routinen mit Integritätsprüfung und regelmäßigem Wiederherstellungstest dokumentieren.",
+            "Sicherheitsrelevante Monitoring- und Loggingpfade prüfen.",
+            "Update-, Rollback- und Migrationsrunbooks vervollständigen."
+          ],
+          "featureSummary": "Die Plattform erhält die für kommunalen Betrieb notwendigen Datenschutz-, Sicherheits- und Betriebsnachweise; Server-Backup-Routinen sind als Grundlage eingerichtet und werden durch dokumentierte Integritäts- und Wiederherstellungsnachweise abgesichert."
         }
       ]
     },
@@ -323,10 +593,24 @@
           "effortPt": 8,
           "status": "planned",
           "health": "on_track",
-          "dependsOn": ["WP-004", "WP-005", "WP-006", "WP-008"],
-          "acceptanceCriteria": ["Reale oder realitätsnahe Nutzungsszenarien wurden getestet.", "Friktionen, Abbruchgründe und Anforderungen sind priorisiert dokumentiert."],
-          "todos": ["Gesprächsszenarien definieren.", "Nutzertests durchführen.", "Friktionen erfassen.", "Folge-Backlog erstellen."],
-          "featureSummary": "Produktentscheidungen basieren auf beobachteter Nutzung."
+          "dependsOn": [
+            "WP-004",
+            "WP-005",
+            "WP-006",
+            "WP-008"
+          ],
+          "acceptanceCriteria": [
+            "Reale oder realitätsnahe Nutzungsszenarien wurden getestet.",
+            "Friktionen, Abbruchgründe und Anforderungen sind priorisiert dokumentiert."
+          ],
+          "todos": [
+            "Pilotierung und Nutzerforschung ab dem 11.09.2026 starten.",
+            "Gesprächsszenarien definieren.",
+            "Nutzertests durchführen.",
+            "Friktionen erfassen.",
+            "Folge-Backlog erstellen."
+          ],
+          "featureSummary": "Pilotierung und Nutzerforschung sind ab dem 11.09.2026 geplant; Produktentscheidungen sollen anschließend auf beobachteter Nutzung basieren."
         },
         {
           "id": "WP-010",
@@ -337,9 +621,30 @@
           "effortPt": 8,
           "status": "planned",
           "health": "on_track",
-          "dependsOn": ["WP-002", "WP-005", "WP-008"],
-          "acceptanceCriteria": ["Vergleichsdaten für ASR, Übersetzung und TTS liegen vor.", "Eine begründete Baseline ist dokumentiert."],
-          "todos": ["Vergleichsszenarien festlegen.", "Qualitäts- und Stabilitätsdaten erfassen.", "Baselines festlegen.", "Entscheidungen dokumentieren."],
+          "dependsOn": [
+            "WP-002",
+            "WP-005",
+            "WP-008"
+          ],
+          "tracking": {
+            "githubIssues": [
+              222,
+              224
+            ],
+            "openSpecChanges": [
+              "add-phi-refinement-benchmarking"
+            ]
+          },
+          "acceptanceCriteria": [
+            "Vergleichsdaten für ASR, Übersetzung und TTS liegen vor.",
+            "Eine begründete Baseline ist dokumentiert."
+          ],
+          "todos": [
+            "Vergleichsszenarien festlegen.",
+            "Qualitäts- und Stabilitätsdaten erfassen.",
+            "Baselines festlegen.",
+            "Entscheidungen dokumentieren."
+          ],
           "featureSummary": "Die abgeschlossene Modellrecherche wird durch vergleichbare Produkt- und Betriebsdaten ergänzt."
         },
         {
@@ -351,9 +656,28 @@
           "effortPt": 10,
           "status": "planned",
           "health": "on_track",
-          "dependsOn": ["WP-014", "WP-015", "WP-016"],
-          "acceptanceCriteria": ["Mindestens zwei Organisationen können getrennt provisioniert und betrieben werden.", "Der Mehrorganisations-Pilot bestätigt die Tenant-Isolation und die administrativen Abläufe."],
-          "todos": ["Pilotorganisationen anlegen und konfigurieren.", "Tenant-spezifische Zugriffs- und Gesprächsflüsse testen.", "Betriebs- und Supportabläufe für mehrere Organisationen dokumentieren."],
+          "dependsOn": [
+            "WP-014",
+            "WP-015",
+            "WP-016"
+          ],
+          "tracking": {
+            "githubIssues": [
+              232
+            ],
+            "openSpecChanges": [
+              "add-multi-tenant-operations"
+            ]
+          },
+          "acceptanceCriteria": [
+            "Mindestens zwei Organisationen können getrennt provisioniert und betrieben werden.",
+            "Der Mehrorganisations-Pilot bestätigt die Tenant-Isolation und die administrativen Abläufe."
+          ],
+          "todos": [
+            "Pilotorganisationen anlegen und konfigurieren.",
+            "Tenant-spezifische Zugriffs- und Gesprächsflüsse testen.",
+            "Betriebs- und Supportabläufe für mehrere Organisationen dokumentieren."
+          ],
           "featureSummary": "Der Pilot überprüft vor der öffentlichen Optimierungsrunde, ob mehrere Organisationen SSF unabhängig und sicher nutzen können."
         },
         {
@@ -365,9 +689,20 @@
           "effortPt": 6,
           "status": "planned",
           "health": "on_track",
-          "dependsOn": ["WP-009", "WP-016", "WP-023"],
-          "acceptanceCriteria": ["Ein priorisierter kommunaler Einsatzkontext ist vorbereitet und begleitet pilotiert.", "Nutzungserkenntnisse fließen in Produkt, Betrieb und Dokumentation ein."],
-          "todos": ["Pilotstandort vorbereiten.", "Admin- und Customer-Tests begleiten.", "Ergebnisse auswerten und priorisieren."],
+          "dependsOn": [
+            "WP-009",
+            "WP-016",
+            "WP-023"
+          ],
+          "acceptanceCriteria": [
+            "Ein priorisierter kommunaler Einsatzkontext ist vorbereitet und begleitet pilotiert.",
+            "Nutzungserkenntnisse fließen in Produkt, Betrieb und Dokumentation ein."
+          ],
+          "todos": [
+            "Pilotstandort vorbereiten.",
+            "Admin- und Customer-Tests begleiten.",
+            "Ergebnisse auswerten und priorisieren."
+          ],
           "featureSummary": "Der erste Stadtteilzentrum-Pilot überprüft die technische und organisatorische Nutzbarkeit im kommunalen Alltag."
         },
         {
@@ -377,12 +712,22 @@
           "area": "Einführung und Dokumentation",
           "priority": "must",
           "effortPt": 8,
-          "status": "planned",
+          "status": "implementation",
           "health": "on_track",
-          "dependsOn": ["WP-021", "WP-024"],
-          "acceptanceCriteria": ["Tutorial, kompakte Bedienhinweise und Handover-Dokumentation liegen vor.", "Technische, betriebliche und nutzungsbezogene Dokumentation sind zielgruppengerecht verfügbar."],
-          "todos": ["Tutorial und Bedienhinweise erstellen.", "Betriebs- und Handover-Dokumentation erstellen.", "Schulungs- und Präsentationsmaterial vorbereiten."],
-          "featureSummary": "Einrichtungen können KasselDIALOG mit zugänglichen Materialien einführen, nutzen und an den Betrieb übergeben."
+          "dependsOn": [
+            "WP-021",
+            "WP-024"
+          ],
+          "acceptanceCriteria": [
+            "Tutorial, kompakte Bedienhinweise und Handover-Dokumentation liegen vor.",
+            "Technische, betriebliche und nutzungsbezogene Dokumentation sind zielgruppengerecht verfügbar."
+          ],
+          "todos": [
+            "Tutorial und Bedienhinweise fertigstellen.",
+            "Betriebs- und Handover-Dokumentation fertigstellen.",
+            "Schulungs- und Präsentationsmaterial vorbereiten."
+          ],
+          "featureSummary": "Schulungs-, Nutzungs- und Handover-Materialien sind in Arbeit und werden für Einführung, Betrieb und Übergabe zielgruppengerecht aufbereitet."
         }
       ]
     },
@@ -400,11 +745,23 @@
           "priority": "valuable",
           "effortPt": 8,
           "status": "planned",
-          "health": "on_track",
-          "dependsOn": ["WP-009", "WP-010", "WP-017"],
-          "acceptanceCriteria": ["Die optimierte Lösung wird in öffentlichen oder realitätsnahen Nutzungsszenarien erprobt.", "Erkenntnisse und priorisierte Optimierungen sind dokumentiert."],
-          "todos": ["Teilnehmende und Szenarien festlegen.", "Öffentliche Optimierungsrunde durchführen.", "Feedback auswerten und priorisieren."],
-          "featureSummary": "Die zweite Optimierungsrunde überprüft die intern verfeinerte Lösung mit realem Nutzungskontext."
+          "health": "needs_attention",
+          "dependsOn": [
+            "WP-009",
+            "WP-010",
+            "WP-017"
+          ],
+          "acceptanceCriteria": [
+            "Die optimierte Lösung wird in öffentlichen oder realitätsnahen Nutzungsszenarien erprobt.",
+            "Erkenntnisse und priorisierte Optimierungen sind dokumentiert."
+          ],
+          "todos": [
+            "Ergebnisse der ab 11.09.2026 geplanten Pilotierung abwarten.",
+            "Teilnehmende und Szenarien anschließend festlegen.",
+            "Öffentliche Optimierungsrunde durchführen.",
+            "Feedback auswerten und priorisieren."
+          ],
+          "featureSummary": "Die öffentliche Optimierungsrunde folgt erst nach der Pilotierung und Nutzerforschung; ihr Termin wird anhand deren Ergebnissen festgelegt."
         },
         {
           "id": "WP-026",
@@ -415,9 +772,21 @@
           "effortPt": 12,
           "status": "planned",
           "health": "on_track",
-          "dependsOn": ["WP-017", "WP-024", "WP-025"],
-          "acceptanceCriteria": ["Einführungs- und Betriebsplan für weitere Einrichtungen in den 23 Stadtteilen liegt vor.", "Bis zu drei Testkommunen mit jeweils einer Teststelle sind organisatorisch und technisch vorbereitet."],
-          "todos": ["Einführungsreihenfolge abstimmen.", "Organisationen provisionieren und vorbereiten.", "Schulungs- und Supportbedarf erfassen.", "Rollout-Checkliste erstellen."],
+          "dependsOn": [
+            "WP-017",
+            "WP-024",
+            "WP-025"
+          ],
+          "acceptanceCriteria": [
+            "Einführungs- und Betriebsplan für weitere Einrichtungen in den 23 Stadtteilen liegt vor.",
+            "Bis zu drei Testkommunen mit jeweils einer Teststelle sind organisatorisch und technisch vorbereitet."
+          ],
+          "todos": [
+            "Einführungsreihenfolge abstimmen.",
+            "Organisationen provisionieren und vorbereiten.",
+            "Schulungs- und Supportbedarf erfassen.",
+            "Rollout-Checkliste erstellen."
+          ],
           "featureSummary": "Der Rollout wird für die weiteren Stadtteile und Testkommunen organisatorisch und technisch vorbereitet."
         }
       ]
@@ -437,9 +806,19 @@
           "effortPt": 5,
           "status": "planned",
           "health": "on_track",
-          "dependsOn": ["WP-011", "WP-017"],
-          "acceptanceCriteria": ["Der Regelbetrieb für mehrere Organisationen ist organisatorisch und technisch vorbereitet.", "Verantwortlichkeiten, Supportwege und Monitoring sind tenantfähig geklärt."],
-          "todos": ["Betriebsfreigabe vorbereiten.", "Support- und Eskalationswege festlegen.", "Produktionsstart begleiten."],
+          "dependsOn": [
+            "WP-011",
+            "WP-017"
+          ],
+          "acceptanceCriteria": [
+            "Der Regelbetrieb für mehrere Organisationen ist organisatorisch und technisch vorbereitet.",
+            "Verantwortlichkeiten, Supportwege und Monitoring sind tenantfähig geklärt."
+          ],
+          "todos": [
+            "Betriebsfreigabe vorbereiten.",
+            "Support- und Eskalationswege festlegen.",
+            "Produktionsstart begleiten."
+          ],
           "featureSummary": "Nach den Optimierungsrunden wird SSF in einen geregelten Betriebsmodus überführt."
         },
         {
@@ -451,9 +830,23 @@
           "effortPt": 25,
           "status": "planned",
           "health": "on_track",
-          "dependsOn": ["WP-011", "WP-017", "WP-025", "WP-026"],
-          "acceptanceCriteria": ["Weitere Einrichtungen der 23 Stadtteile werden nach erfolgreichem Pilot eingeführt.", "Bis zu drei Testkommunen mit jeweils einer Teststelle sind in den Rollout einbezogen.", "Einführung, Betrieb und Support sind je Organisation nachvollziehbar übergeben."],
-          "todos": ["Rollout in der abgestimmten Reihenfolge durchführen.", "Einrichtungen und Testkommunen begleiten.", "Schulungen und Handover durchführen.", "Rollout-Erkenntnisse dokumentieren."],
+          "dependsOn": [
+            "WP-011",
+            "WP-017",
+            "WP-025",
+            "WP-026"
+          ],
+          "acceptanceCriteria": [
+            "Weitere Einrichtungen der 23 Stadtteile werden nach erfolgreichem Pilot eingeführt.",
+            "Bis zu drei Testkommunen mit jeweils einer Teststelle sind in den Rollout einbezogen.",
+            "Einführung, Betrieb und Support sind je Organisation nachvollziehbar übergeben."
+          ],
+          "todos": [
+            "Rollout in der abgestimmten Reihenfolge durchführen.",
+            "Einrichtungen und Testkommunen begleiten.",
+            "Schulungen und Handover durchführen.",
+            "Rollout-Erkenntnisse dokumentieren."
+          ],
           "featureSummary": "Der geplante kommunale Einsatz wird vom ersten Pilot auf weitere Stadtteilkontexte und Testkommunen übertragen."
         }
       ]

--- a/apps/project-report/src/data/project-status.json
+++ b/apps/project-report/src/data/project-status.json
@@ -94,7 +94,7 @@
           "priority": "must",
           "effortPt": 2,
           "status": "implementation",
-          "health": "blocked",
+          "health": "on_track",
           "dependsOn": [],
           "acceptanceCriteria": [
             "Die rechtliche Prüfung startet am 13.08.2026.",
@@ -489,7 +489,7 @@
           "priority": "must",
           "effortPt": 4,
           "status": "planned",
-          "health": "blocked",
+          "health": "on_track",
           "dependsOn": [
             "WP-013"
           ],

--- a/docs/meeting-notes/README.md
+++ b/docs/meeting-notes/README.md
@@ -1,0 +1,13 @@
+# Meeting Minutes
+
+Project Steward records concise, English meeting minutes in this directory as
+`YYYY-MM-DD-<topic>.md`.
+
+Minutes are decision records, not transcripts. They must retain only the
+context needed to operate the project: decisions, prioritized actions, owners,
+deadlines, risks, evidence sources, and resulting issue or plan changes. Do not
+commit passwords, tokens, personal contact data, raw transcripts, or other
+unnecessary personal data.
+
+Use the Project Steward skill to derive the Markdown content and validate every
+resulting GitHub or delivery-plan update against current evidence.

--- a/docs/superpowers/plans/2026-08-30-project-steward-agent.md
+++ b/docs/superpowers/plans/2026-08-30-project-steward-agent.md
@@ -1,0 +1,62 @@
+# Project Steward Agent Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox syntax for tracking.
+
+**Goal:** Build an installable, repository-versioned Codex Project Steward that ranks delivery work, governs GitHub issue and PR workflows, and records auditable meeting minutes.
+
+**Architecture:** A repo-local marketplace exposes the `project-steward` plugin and its focused skill. A dependency-free Node helper ranks work from the existing project-status snapshot; the skill combines the report with live OpenSpec and GitHub CLI evidence before applying the defined safety rules.
+
+**Tech Stack:** Codex plugin manifest and skill Markdown; Node.js ESM; Vitest; GitHub CLI; OpenSpec.
+
+**Spec:** `docs/superpowers/specs/2026-08-30-project-steward-design.md`
+
+## Global Constraints
+
+- Use the existing authenticated GitHub CLI; do not add a connector or dependency.
+- Preserve source precedence: decisions, GitHub evidence, OpenSpec, project-status snapshot, roadmap.
+- Never delete content, close issues, merge PRs, change permissions, or expose secrets.
+- Local outputs use a dedicated `codex/project-steward-*` branch and a reviewable PR.
+- Minutes are concise, English, privacy-minimizing Markdown under `docs/meeting-notes/`.
+
+### Task 1: Implement the deterministic priority engine
+
+**Files:** Create `plugins/project-steward/scripts/priority-report.mjs` and `plugins/project-steward/scripts/priority-report.test.mjs`.
+
+**Interface:** `rankWorkPackages(report, { limit, today })` returns `{ generatedAt, priorities }`. A priority has `workPackageId`, `title`, `priority`, `rationale`, `dependencyState`, and `source`.
+
+- [x] Write a failing Vitest test that passes a minimal status snapshot and expects the unblocked, must-have package with the earliest deadline to rank first.
+- [x] Run `npx vitest run plugins/project-steward/scripts/priority-report.test.mjs`; confirm it fails because the module is absent.
+- [x] Implement priority-class, deadline, dependency-readiness, health-risk, and dependency-impact scoring. Provide JSON output by default and Markdown via `--format markdown`.
+- [x] Add tests for incomplete dependencies, blocked work, exclusion of completed work, priority tie-breaking, and limits; rerun the test file and confirm it passes.
+- [x] Commit only the helper and its tests with `feat: add project steward priority report`.
+
+### Task 2: Package the governed Project Steward skill
+
+**Files:** Create `.agents/plugins/marketplace.json`, `plugins/project-steward/.codex-plugin/plugin.json`, `plugins/project-steward/skills/project-steward/SKILL.md`, and `plugins/project-steward/skills/project-steward/agents/openai.yaml`.
+
+**Interface:** The plugin exposes the `project-steward` skill, which invokes the priority report and GitHub CLI without adding credentials or dependencies.
+
+- [x] Run `python3 /root/.codex/skills/.system/plugin-creator/scripts/validate_plugin.py plugins/project-steward`; confirm it fails before scaffolding.
+- [x] Scaffold the plugin into the repository marketplace. The skill must state project goals, evidence collection, source precedence, priority rules, safe `gh` issue and PR commands, audit records, and mutation boundaries.
+- [x] Add fixture-based skill scenarios for supported issue creation, prohibited issue closure, and a priority-class conflict.
+- [x] Validate with the plugin validator and `python3 /root/.codex/skills/.system/skill-creator/scripts/quick_validate.py plugins/project-steward/skills/project-steward`.
+- [x] Commit the marketplace and plugin with `feat: add project steward plugin`.
+
+### Task 3: Add minutes rendering and guidance
+
+**Files:** Create `docs/meeting-notes/README.md` and `plugins/project-steward/skills/project-steward/references/meeting-minutes.md`; modify `priority-report.mjs` and its test.
+
+**Interface:** `renderMeetingMinutes({ date, topic, decisions, actions, risks, sources })` returns the Markdown content for `docs/meeting-notes/YYYY-MM-DD-<topic>.md`.
+
+- [x] Write a failing test using decisions, an owner, a deadline, sources, and a sensitive raw-note field. Expect retained decisions/actions and omission of the raw sensitive field.
+- [x] Run the test file; confirm it fails because `renderMeetingMinutes` is absent.
+- [x] Implement the minimal renderer. Document the required headings and data-minimization rules in the plugin reference and repository README.
+- [x] Rerun tests and commit the minutes work with `docs: add project steward meeting minutes format`.
+
+### Task 4: Verify integration and complete the proposal
+
+**Files:** Modify `openspec/changes/add-project-steward-agent/tasks.md`; include this plan in the final documentation commit.
+
+- [x] Run read-only `gh auth status`, `gh issue list`, `gh pr list`, and `gh project item-list 7 --owner smart-village-solutions --format json`.
+- [x] Run `npm --prefix apps/project-report test`, the priority-report tests, plugin validation, skill validation, and `openspec validate add-project-steward-agent --strict`.
+- [x] Mark only verified OpenSpec tasks complete, then commit the plan and task updates with `docs: complete project steward proposal`.

--- a/docs/superpowers/specs/2026-08-30-project-steward-design.md
+++ b/docs/superpowers/specs/2026-08-30-project-steward-design.md
@@ -1,0 +1,171 @@
+# Project Steward Design
+
+## Context
+
+Smart Speech Flow has several active OpenSpec changes, a GitHub delivery project,
+and a repository-maintained project-status snapshot. The team needs a dedicated
+Codex agent that can keep these sources aligned, determine the next operational
+priorities, turn meeting notes into auditable follow-ups, and work directly with
+GitHub issues and pull requests.
+
+The agent must understand the product goal: reliable, accessible, multilingual
+communication between public-administration staff and citizens. It must protect
+that goal when it ranks work; work that unblocks a must-have delivery, reduces a
+security, privacy, or production risk, or protects the critical conversation
+flow takes precedence over unrelated improvements.
+
+## Goals
+
+- Provide a reusable `project-steward` Codex plugin/skill with a focused project
+  governance role.
+- Ground every assessment in repository plans, OpenSpec changes, GitHub issues,
+  pull requests, and the GitHub Project snapshot.
+- Autonomously maintain evidence-backed project-plan data and create or edit
+  GitHub issues.
+- Convert supplied meeting notes into versioned English Markdown minutes under
+  `docs/meeting-notes/`.
+- Rank the next three to five actions with a concise, evidence-backed rationale.
+- Read pull-request metadata, diffs, reviews, and checks to evaluate delivery
+  impact.
+- Preserve normal repository governance: changes are committed on a dedicated
+  branch and proposed through a pull request; the agent never merges.
+
+## Non-Goals
+
+- Replacing human strategic governance or silently redefining the product's
+  priority classes.
+- Merging pull requests, deleting GitHub content, or closing issues.
+- Storing raw meeting transcripts, secrets, or unnecessary personal data.
+- Introducing a separate task tracker or a duplicate priority model.
+
+## Architecture
+
+The implementation is a repository-versioned Codex plugin named
+`project-steward`. Its central skill contains the role, source-precedence rules,
+action boundaries, and repeatable workflows. Small deterministic helper scripts
+collect repository and GitHub evidence and validate proposed local changes. The
+skill delegates GitHub operations to the authenticated GitHub CLI already used
+by the repository environment.
+
+```text
+Repository plans + GitHub evidence + supplied meeting notes
+                         |
+                         v
+                 Project Steward skill
+              /          |           \
+             v           v            v
+    priority recommendation  issue/plan sync  meeting minutes
+             \           |            /
+                         v
+           dedicated branch and reviewable PR
+```
+
+### Source precedence
+
+The steward resolves conflicting information in this order:
+
+1. Explicit project decisions captured in approved meeting minutes or direct
+   user instructions.
+2. Current GitHub issue and pull-request evidence, including checks and
+   reviews.
+3. OpenSpec proposals and task completion state.
+4. `apps/project-report/src/data/project-status.json` as the operational
+   delivery-plan snapshot.
+5. `ROADMAP.md` as strategic context, not as a current delivery-status source.
+
+It must report a conflict rather than silently choosing between contradictory
+sources of the same precedence.
+
+### Priority policy
+
+For each priority run, the steward orders actionable work using these criteria:
+
+1. Must-have work and committed deadlines.
+2. Blocking dependencies and the critical delivery path.
+3. Security, data-protection, and production-operability risks.
+4. Work with sufficient implementation readiness before work that remains
+   materially unclear.
+5. Expected delivery value relative to effort and available budget.
+
+The steward may autonomously update the immediate work order and work-package
+status when evidence supports it. A change to the strategic priority class must
+include its evidence, rationale, and expected impact in the plan and minutes.
+When it exposes a genuine conflict, the steward creates a decision issue instead
+of silently changing the product intent.
+
+### GitHub operations
+
+The skill uses `gh issue list`, `gh issue view`, `gh issue create`, and
+`gh issue edit` for issue work. It uses `gh pr list`, `gh pr view`, `gh pr diff`,
+and `gh pr checks` to assess pull requests. Before mutating GitHub it verifies
+the active account and required scopes. It follows existing issue and pull
+request templates, links relevant work-package and OpenSpec identifiers, and
+records the evidence it used.
+
+The steward never deletes GitHub content, closes issues, approves or merges pull
+requests, changes repository permissions, or exposes tokens and other secrets.
+
+### Meeting minutes
+
+For supplied notes, the steward creates
+`docs/meeting-notes/YYYY-MM-DD-<topic>.md`. Each file includes the meeting
+context, decisions, prioritized actions, owners, deadlines, risks, and the
+resulting GitHub or plan changes. Minutes are concise, English, and minimize
+personal data; raw transcripts and secrets are excluded.
+
+### Change workflow
+
+Local plan or minutes updates are made in a dedicated `codex/project-steward-*`
+branch. The steward validates JSON and Markdown conventions, runs the relevant
+status-sync validation, commits only its own files, and opens a pull request.
+It does not merge that pull request.
+
+## Workflows
+
+### Reconcile project status
+
+The steward gathers OpenSpec, the project-status snapshot, open GitHub issues,
+and active pull requests. It reports discrepancies, updates only evidence-backed
+fields, and creates missing or malformed tracking issues when required.
+
+### Process meeting notes
+
+The steward extracts decisions and actions from supplied notes, determines their
+effect on work packages, creates or edits justified issues, updates the delivery
+plan, and creates the versioned meeting minutes.
+
+### Assess pull-request impact
+
+The steward reads the pull request description, linked issues, diff, reviews,
+and check results. It maps the work to plan items, identifies blocked or
+unverified acceptance criteria, and updates the plan only when the evidence is
+strong enough.
+
+### Report next priorities
+
+The steward produces the next three to five actions, each with its priority
+rationale, source references, dependency status, owner where known, and a clear
+next action. It distinguishes facts, inferences, and decisions needed.
+
+## Risks and Mitigations
+
+- **Plan drift caused by stale evidence**: refresh GitHub and OpenSpec evidence
+  before every write and record the refresh time.
+- **Overconfident reprioritization**: apply the fixed priority policy, preserve
+  strategic classes unless evidence justifies a documented change, and create a
+  decision issue for unresolved conflicts.
+- **Unsafe autonomous mutation**: prohibit deletions, closures, merges,
+  permission changes, and secret handling; route repository updates through a
+  reviewable PR.
+- **Sensitive meeting content**: retain only the minimum necessary decisions and
+  actions in the repository minutes.
+
+## Validation
+
+- Validate the plugin manifest and its skill instructions.
+- Test source-precedence and priority decisions with fixture data.
+- Test generated minutes and project-status changes against their schemas and
+  existing status-sync tests.
+- Verify GitHub read commands against the current repository without mutating
+  it; cover issue creation/editing with non-production fixtures or explicit
+  test issues.

--- a/openspec/changes/add-project-steward-agent/proposal.md
+++ b/openspec/changes/add-project-steward-agent/proposal.md
@@ -1,0 +1,26 @@
+# Change: Add an autonomous project stewardship agent
+
+## Why
+
+The delivery plan, GitHub issues, pull requests, and OpenSpec changes need a
+single, evidence-based stewardship workflow. The team also needs project minutes
+that turn decisions into traceable, prioritized follow-up work.
+
+## What Changes
+
+- Add a repository-versioned Codex `project-steward` plugin/skill.
+- Give the steward governed GitHub issue maintenance and pull-request reading
+  workflows through the authenticated GitHub CLI.
+- Add evidence-based delivery-plan reconciliation and next-priority ranking.
+- Add English, privacy-minimizing meeting minutes under `docs/meeting-notes/`.
+- Require all local stewardship changes to use a dedicated branch and a
+  reviewable pull request; prohibit deletion, issue closure, and pull-request
+  merging.
+
+## Impact
+
+- Affected specs: `project-steward-agent` (new capability).
+- Affected code: new plugin and helper scripts; project-status synchronization;
+  documentation and validation tests.
+- External dependency: authenticated GitHub CLI with existing repository and
+  project scopes.

--- a/openspec/changes/add-project-steward-agent/specs/project-steward-agent/spec.md
+++ b/openspec/changes/add-project-steward-agent/specs/project-steward-agent/spec.md
@@ -1,0 +1,86 @@
+## ADDED Requirements
+
+### Requirement: Project-goal-grounded stewardship
+
+The system SHALL provide a reusable Project Steward agent that evaluates work
+against Smart Speech Flow's goal of reliable, accessible, multilingual
+communication for public-administration staff and citizens.
+
+#### Scenario: Assessing a proposed task
+
+- **WHEN** the steward assesses a task or pull request
+- **THEN** it SHALL state how the work supports, blocks, or risks a project goal
+  and cite the evidence used
+
+### Requirement: Evidence-based source reconciliation
+
+The steward SHALL reconcile project information using explicit decisions,
+GitHub evidence, OpenSpec state, the project-status snapshot, and the roadmap in
+that order of precedence.
+
+#### Scenario: Conflicting current-status sources
+
+- **WHEN** sources of equal precedence contradict each other
+- **THEN** the steward SHALL report the conflict and SHALL NOT silently choose a
+  status
+
+### Requirement: Autonomous next-priority definition
+
+The steward SHALL autonomously define and maintain the immediate work order
+using must-have commitments and deadlines, dependencies, security/privacy and
+operability risk, implementation readiness, and value relative to effort and
+budget.
+
+#### Scenario: Priority report
+
+- **WHEN** the steward runs a priority assessment
+- **THEN** it SHALL identify the next three to five actions with rationale,
+  evidence, dependencies, and any required decision
+
+#### Scenario: Strategic priority-class change
+
+- **WHEN** evidence warrants changing a work package's strategic priority class
+- **THEN** the steward SHALL record the evidence, rationale, and impact in the
+  delivery plan and meeting minutes
+
+### Requirement: Governed GitHub issue and pull-request workflow
+
+The steward SHALL read pull-request metadata, diffs, reviews, and checks, and
+SHALL create or edit GitHub issues when supported by evidence and existing
+repository conventions.
+
+#### Scenario: Missing follow-up work
+
+- **WHEN** a meeting decision or pull-request finding requires untracked work
+- **THEN** the steward SHALL create a linked issue with the appropriate template
+  content and plan references
+
+#### Scenario: Pull-request plan impact
+
+- **WHEN** the steward evaluates a pull request
+- **THEN** it SHALL identify affected work packages, dependencies, acceptance
+  criteria, and unverified risks before updating plan status
+
+### Requirement: Auditable repository meeting minutes
+
+The steward SHALL convert supplied meeting notes into concise, English,
+privacy-minimizing Markdown minutes under `docs/meeting-notes/`.
+
+#### Scenario: Recording a meeting
+
+- **WHEN** meeting notes contain decisions or actions
+- **THEN** the steward SHALL record decisions, prioritized actions, owners,
+  deadlines, risks, and resulting plan or GitHub changes without retaining raw
+  transcripts, secrets, or unnecessary personal data
+
+### Requirement: Safe autonomous mutations
+
+The steward SHALL make local plan and minutes changes on a dedicated branch and
+through a reviewable pull request. It SHALL NOT delete content, close issues,
+merge pull requests, change repository permissions, or expose secrets.
+
+#### Scenario: Updating a project-plan snapshot
+
+- **WHEN** evidence supports a project-plan update
+- **THEN** the steward SHALL validate the update, commit only its own changes on
+  a dedicated branch, and open a pull request without merging it

--- a/openspec/changes/add-project-steward-agent/tasks.md
+++ b/openspec/changes/add-project-steward-agent/tasks.md
@@ -1,29 +1,29 @@
 ## 1. Plugin foundation
 
-- [ ] 1.1 Scaffold the repository-versioned `project-steward` Codex plugin and
+- [x] 1.1 Scaffold the repository-versioned `project-steward` Codex plugin and
       validate its manifest.
-- [ ] 1.2 Write the stewardship skill with project goals, source precedence,
+- [x] 1.2 Write the stewardship skill with project goals, source precedence,
       autonomy boundaries, and GitHub command guidance.
 
 ## 2. Evidence and prioritization
 
-- [ ] 2.1 Implement a deterministic evidence collector for OpenSpec,
+- [x] 2.1 Implement a deterministic evidence collector for OpenSpec,
       project-status data, GitHub issues, and pull requests.
-- [ ] 2.2 Implement and test the priority policy and source-conflict reporting.
-- [ ] 2.3 Integrate validation with the existing project-status synchronization
+- [x] 2.2 Implement and test the priority policy and source-conflict reporting.
+- [x] 2.3 Integrate validation with the existing project-status synchronization
       workflow.
 
 ## 3. Meeting minutes and GitHub workflows
 
-- [ ] 3.1 Add the meeting-minutes format, privacy rules, and repository
+- [x] 3.1 Add the meeting-minutes format, privacy rules, and repository
       documentation.
-- [ ] 3.2 Add governed issue create/edit and PR-read workflows that respect
+- [x] 3.2 Add governed issue create/edit and PR-read workflows that respect
       existing repository templates.
-- [ ] 3.3 Add branch and pull-request safeguards for local plan changes.
+- [x] 3.3 Add branch and pull-request safeguards for local plan changes.
 
 ## 4. Verification and handoff
 
-- [ ] 4.1 Add fixture-based tests for priorities, conflict detection, and
+- [x] 4.1 Add fixture-based tests for priorities, conflict detection, and
       generated minutes.
-- [ ] 4.2 Verify read-only GitHub workflows against this repository.
-- [ ] 4.3 Validate the plugin and the OpenSpec change.
+- [x] 4.2 Verify read-only GitHub workflows against this repository.
+- [x] 4.3 Validate the plugin and the OpenSpec change.

--- a/openspec/changes/add-project-steward-agent/tasks.md
+++ b/openspec/changes/add-project-steward-agent/tasks.md
@@ -1,0 +1,29 @@
+## 1. Plugin foundation
+
+- [ ] 1.1 Scaffold the repository-versioned `project-steward` Codex plugin and
+      validate its manifest.
+- [ ] 1.2 Write the stewardship skill with project goals, source precedence,
+      autonomy boundaries, and GitHub command guidance.
+
+## 2. Evidence and prioritization
+
+- [ ] 2.1 Implement a deterministic evidence collector for OpenSpec,
+      project-status data, GitHub issues, and pull requests.
+- [ ] 2.2 Implement and test the priority policy and source-conflict reporting.
+- [ ] 2.3 Integrate validation with the existing project-status synchronization
+      workflow.
+
+## 3. Meeting minutes and GitHub workflows
+
+- [ ] 3.1 Add the meeting-minutes format, privacy rules, and repository
+      documentation.
+- [ ] 3.2 Add governed issue create/edit and PR-read workflows that respect
+      existing repository templates.
+- [ ] 3.3 Add branch and pull-request safeguards for local plan changes.
+
+## 4. Verification and handoff
+
+- [ ] 4.1 Add fixture-based tests for priorities, conflict detection, and
+      generated minutes.
+- [ ] 4.2 Verify read-only GitHub workflows against this repository.
+- [ ] 4.3 Validate the plugin and the OpenSpec change.

--- a/plugins/project-steward/.codex-plugin/plugin.json
+++ b/plugins/project-steward/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "project-steward",
-  "version": "0.1.0+codex.20260830181900",
+  "version": "0.1.0+codex.20260830182510",
   "description": "Evidence-based delivery planning and GitHub stewardship for Smart Speech Flow.",
   "author": {
     "name": "Smart Village Solutions"

--- a/plugins/project-steward/.codex-plugin/plugin.json
+++ b/plugins/project-steward/.codex-plugin/plugin.json
@@ -1,0 +1,21 @@
+{
+  "name": "project-steward",
+  "version": "0.1.0",
+  "description": "Evidence-based delivery planning and GitHub stewardship for Smart Speech Flow.",
+  "author": {
+    "name": "Smart Village Solutions"
+  },
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Project Steward",
+    "shortDescription": "Keep delivery priorities and follow-ups current.",
+    "longDescription": "Ranks Smart Speech Flow delivery work, turns meeting notes into actions, and maintains governed GitHub follow-ups.",
+    "developerName": "Smart Village Solutions",
+    "category": "Productivity",
+    "capabilities": [
+      "Interactive",
+      "Write"
+    ],
+    "defaultPrompt": "Use Project Steward to identify the next delivery priorities."
+  }
+}

--- a/plugins/project-steward/.codex-plugin/plugin.json
+++ b/plugins/project-steward/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "project-steward",
-  "version": "0.1.0",
+  "version": "0.1.0+codex.20260830170144",
   "description": "Evidence-based delivery planning and GitHub stewardship for Smart Speech Flow.",
   "author": {
     "name": "Smart Village Solutions"

--- a/plugins/project-steward/.codex-plugin/plugin.json
+++ b/plugins/project-steward/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "project-steward",
-  "version": "0.1.0+codex.20260830182510",
+  "version": "0.1.0+codex.20260830182634",
   "description": "Evidence-based delivery planning and GitHub stewardship for Smart Speech Flow.",
   "author": {
     "name": "Smart Village Solutions"

--- a/plugins/project-steward/.codex-plugin/plugin.json
+++ b/plugins/project-steward/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "project-steward",
-  "version": "0.1.0+codex.20260830170144",
+  "version": "0.1.0+codex.20260830181900",
   "description": "Evidence-based delivery planning and GitHub stewardship for Smart Speech Flow.",
   "author": {
     "name": "Smart Village Solutions"

--- a/plugins/project-steward/scripts/evidence-collector.mjs
+++ b/plugins/project-steward/scripts/evidence-collector.mjs
@@ -1,0 +1,35 @@
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const parseJson = (value) => JSON.parse(value);
+
+const defaultRun = (command, args) => execFileSync(command, args, { encoding: 'utf8' });
+
+export const collectEvidence = ({
+  run = defaultRun,
+  readReport = readFileSync,
+  owner = 'smart-village-solutions',
+  projectNumber = '7',
+  reportPath = resolve(fileURLToPath(new URL('../../../apps/project-report/src/data/project-status.json', import.meta.url))),
+} = {}) => ({
+  collectedAt: new Date().toISOString(),
+  openSpec: parseJson(run('openspec', ['change', 'list', '--json'])),
+  projectStatus: parseJson(readReport(reportPath, 'utf8')),
+  issues: parseJson(run('gh', [
+    'issue', 'list', '--state', 'open', '--limit', '100',
+    '--json', 'number,title,labels,url,updatedAt',
+  ])),
+  pullRequests: parseJson(run('gh', [
+    'pr', 'list', '--state', 'open', '--limit', '100',
+    '--json', 'number,title,headRefName,reviewDecision,statusCheckRollup,url,updatedAt',
+  ])),
+  projectItems: parseJson(run('gh', [
+    'project', 'item-list', projectNumber, '--owner', owner, '--limit', '100', '--format', 'json',
+  ])),
+});
+
+const isMainModule = process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (isMainModule) console.log(JSON.stringify(collectEvidence(), null, 2));

--- a/plugins/project-steward/scripts/evidence-collector.mjs
+++ b/plugins/project-steward/scripts/evidence-collector.mjs
@@ -22,12 +22,12 @@ export const collectEvidence = ({
     openSpec: parseJson(run('openspec', ['change', 'list', '--json'], runOptions)),
     projectStatus: parseJson(readReport(reportPath, 'utf8')),
     issues: parseJson(run('gh', [
-      'issue', 'list', '--repo', repository, '--state', 'open', '--limit', '100',
-      '--json', 'number,title,labels,url,updatedAt',
+      'issue', 'list', '--repo', repository, '--state', 'all', '--limit', '100',
+      '--json', 'number,state,title,labels,url,updatedAt',
     ], runOptions)),
     pullRequests: parseJson(run('gh', [
-      'pr', 'list', '--repo', repository, '--state', 'open', '--limit', '100',
-      '--json', 'number,title,headRefName,reviewDecision,statusCheckRollup,url,updatedAt',
+      'pr', 'list', '--repo', repository, '--state', 'all', '--limit', '100',
+      '--json', 'number,state,mergedAt,title,headRefName,reviewDecision,statusCheckRollup,url,updatedAt',
     ], runOptions)),
     projectItems: parseJson(run('gh', [
       'project', 'item-list', projectNumber, '--owner', owner, '--limit', '100', '--format', 'json',

--- a/plugins/project-steward/scripts/evidence-collector.mjs
+++ b/plugins/project-steward/scripts/evidence-collector.mjs
@@ -5,30 +5,35 @@ import { fileURLToPath } from 'node:url';
 
 const parseJson = (value) => JSON.parse(value);
 
-const defaultRun = (command, args) => execFileSync(command, args, { encoding: 'utf8' });
+const defaultRun = (command, args, options = {}) => execFileSync(command, args, { encoding: 'utf8', ...options });
 
 export const collectEvidence = ({
   run = defaultRun,
   readReport = readFileSync,
   owner = 'smart-village-solutions',
   projectNumber = '7',
-  reportPath = resolve(fileURLToPath(new URL('../../../apps/project-report/src/data/project-status.json', import.meta.url))),
-} = {}) => ({
-  collectedAt: new Date().toISOString(),
-  openSpec: parseJson(run('openspec', ['change', 'list', '--json'])),
-  projectStatus: parseJson(readReport(reportPath, 'utf8')),
-  issues: parseJson(run('gh', [
-    'issue', 'list', '--state', 'open', '--limit', '100',
-    '--json', 'number,title,labels,url,updatedAt',
-  ])),
-  pullRequests: parseJson(run('gh', [
-    'pr', 'list', '--state', 'open', '--limit', '100',
-    '--json', 'number,title,headRefName,reviewDecision,statusCheckRollup,url,updatedAt',
-  ])),
-  projectItems: parseJson(run('gh', [
-    'project', 'item-list', projectNumber, '--owner', owner, '--limit', '100', '--format', 'json',
-  ])),
-});
+  repositoryRoot = resolve(fileURLToPath(new URL('../../..', import.meta.url))),
+  reportPath = resolve(repositoryRoot, 'apps/project-report/src/data/project-status.json'),
+} = {}) => {
+  const repository = `${owner}/smart-speech-flow`;
+  const runOptions = { cwd: repositoryRoot };
+  return {
+    collectedAt: new Date().toISOString(),
+    openSpec: parseJson(run('openspec', ['change', 'list', '--json'], runOptions)),
+    projectStatus: parseJson(readReport(reportPath, 'utf8')),
+    issues: parseJson(run('gh', [
+      'issue', 'list', '--repo', repository, '--state', 'open', '--limit', '100',
+      '--json', 'number,title,labels,url,updatedAt',
+    ], runOptions)),
+    pullRequests: parseJson(run('gh', [
+      'pr', 'list', '--repo', repository, '--state', 'open', '--limit', '100',
+      '--json', 'number,title,headRefName,reviewDecision,statusCheckRollup,url,updatedAt',
+    ], runOptions)),
+    projectItems: parseJson(run('gh', [
+      'project', 'item-list', projectNumber, '--owner', owner, '--limit', '100', '--format', 'json',
+    ], runOptions)),
+  };
+};
 
 const isMainModule = process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
 

--- a/plugins/project-steward/scripts/evidence-collector.test.mjs
+++ b/plugins/project-steward/scripts/evidence-collector.test.mjs
@@ -32,6 +32,12 @@ describe('collectEvidence', () => {
       ['gh', ['pr', 'list']],
       ['gh', ['project', 'item-list']],
     ]));
+    const issueArgs = calls.find(([, args]) => args[0] === 'issue')[1];
+    const pullRequestArgs = calls.find(([, args]) => args[0] === 'pr')[1];
+    expect(issueArgs).toEqual(expect.arrayContaining(['--state', 'all']));
+    expect(issueArgs.at(-1)).toContain('state');
+    expect(pullRequestArgs).toEqual(expect.arrayContaining(['--state', 'all']));
+    expect(pullRequestArgs.at(-1)).toContain('mergedAt');
     expect(calls.filter(([command]) => command === 'gh')).toEqual(expect.arrayContaining([
       ['gh', expect.arrayContaining(['--repo', 'smart-village-solutions/smart-speech-flow']), expect.objectContaining({ cwd: expect.any(String) })],
     ]));

--- a/plugins/project-steward/scripts/evidence-collector.test.mjs
+++ b/plugins/project-steward/scripts/evidence-collector.test.mjs
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { collectEvidence } from './evidence-collector.mjs';
+
+describe('collectEvidence', () => {
+  it('collects the project plan, OpenSpec, issues, pull requests, and Project items', () => {
+    const calls = [];
+    const run = (command, args) => {
+      calls.push([command, args]);
+      if (command === 'openspec') return JSON.stringify({ changes: [{ id: 'stabilize-production-operations' }] });
+      if (args[0] === 'issue') return JSON.stringify([{ number: 221, title: 'Secure service ports' }]);
+      if (args[0] === 'pr') return JSON.stringify([{ number: 233, title: 'Boot health gate' }]);
+      return JSON.stringify({ items: [{ id: 'PVTI_1' }] });
+    };
+
+    const evidence = collectEvidence({
+      run,
+      readReport: () => JSON.stringify({ meta: { version: '1.6.0' } }),
+      owner: 'smart-village-solutions',
+      projectNumber: '7',
+    });
+
+    expect(evidence).toMatchObject({
+      openSpec: { changes: [{ id: 'stabilize-production-operations' }] },
+      projectStatus: { meta: { version: '1.6.0' } },
+      issues: [{ number: 221 }],
+      pullRequests: [{ number: 233 }],
+      projectItems: { items: [{ id: 'PVTI_1' }] },
+    });
+    expect(calls).toEqual(expect.arrayContaining([
+      ['openspec', ['change', 'list', '--json']],
+      ['gh', expect.arrayContaining(['issue', 'list'])],
+      ['gh', expect.arrayContaining(['pr', 'list'])],
+      ['gh', expect.arrayContaining(['project', 'item-list', '7'])],
+    ]));
+  });
+});

--- a/plugins/project-steward/scripts/evidence-collector.test.mjs
+++ b/plugins/project-steward/scripts/evidence-collector.test.mjs
@@ -4,8 +4,8 @@ import { collectEvidence } from './evidence-collector.mjs';
 describe('collectEvidence', () => {
   it('collects the project plan, OpenSpec, issues, pull requests, and Project items', () => {
     const calls = [];
-    const run = (command, args) => {
-      calls.push([command, args]);
+    const run = (command, args, options) => {
+      calls.push([command, args, options]);
       if (command === 'openspec') return JSON.stringify({ changes: [{ id: 'stabilize-production-operations' }] });
       if (args[0] === 'issue') return JSON.stringify([{ number: 221, title: 'Secure service ports' }]);
       if (args[0] === 'pr') return JSON.stringify([{ number: 233, title: 'Boot health gate' }]);
@@ -26,11 +26,14 @@ describe('collectEvidence', () => {
       pullRequests: [{ number: 233 }],
       projectItems: { items: [{ id: 'PVTI_1' }] },
     });
-    expect(calls).toEqual(expect.arrayContaining([
-      ['openspec', ['change', 'list', '--json']],
-      ['gh', expect.arrayContaining(['issue', 'list'])],
-      ['gh', expect.arrayContaining(['pr', 'list'])],
-      ['gh', expect.arrayContaining(['project', 'item-list', '7'])],
+    expect(calls[0].slice(0, 2)).toEqual(['openspec', ['change', 'list', '--json']]);
+    expect(calls.map(([command, args]) => [command, args.slice(0, 2)])).toEqual(expect.arrayContaining([
+      ['gh', ['issue', 'list']],
+      ['gh', ['pr', 'list']],
+      ['gh', ['project', 'item-list']],
+    ]));
+    expect(calls.filter(([command]) => command === 'gh')).toEqual(expect.arrayContaining([
+      ['gh', expect.arrayContaining(['--repo', 'smart-village-solutions/smart-speech-flow']), expect.objectContaining({ cwd: expect.any(String) })],
     ]));
   });
 });

--- a/plugins/project-steward/scripts/priority-report.mjs
+++ b/plugins/project-steward/scripts/priority-report.mjs
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { collectEvidence } from './evidence-collector.mjs';
 
 const priorityWeight = {
   must: 0,
@@ -17,6 +18,18 @@ const healthWeight = {
   needs_attention: 1,
   at_risk: 2,
   blocked: 3,
+};
+
+const statusByProjectStatus = {
+  Idea: 'idea',
+  Commissioned: 'commissioned',
+  Planned: 'planned',
+  Prototype: 'prototype',
+  Implementation: 'implementation',
+  Optimization: 'optimization',
+  Testing: 'testing',
+  Acceptance: 'acceptance',
+  Done: 'done',
 };
 
 const parseDeadline = (title) => {
@@ -36,6 +49,51 @@ const rationaleFor = (workPackage, dependencyState, dependentCount, deadline) =>
   if (dependentCount > 0) rationale.push(`Unblocks ${dependentCount} direct work package${dependentCount === 1 ? '' : 's'}.`);
   if (deadline) rationale.push(`Milestone deadline: ${deadline}.`);
   return rationale;
+};
+
+const projectItemsFor = (workPackage, projectItems) => projectItems.filter((item) => {
+  const linkedWorkPackages = String(item['roadmap links'] ?? item['roadmap Links'] ?? item['Roadmap links'] ?? '')
+    .split(',')
+    .map((value) => value.trim());
+  return item['work Package'] === workPackage.id
+    || linkedWorkPackages.includes(workPackage.id)
+    || workPackage.tracking?.githubIssues?.includes(item.content?.number);
+});
+
+export const reconcileEvidence = ({ projectStatus, projectItems = { items: [] }, decisions = [] }) => {
+  const report = structuredClone(projectStatus);
+  const conflicts = [];
+
+  for (const milestone of report.milestones) {
+    for (const workPackage of milestone.workPackages) {
+      const items = projectItemsFor(workPackage, projectItems.items ?? []);
+      const statuses = [...new Set(items.map((item) => item.status).filter(Boolean))].sort();
+      if (statuses.length > 1) {
+        conflicts.push({
+          workPackageId: workPackage.id,
+          source: 'GitHub Project',
+          field: 'status',
+          values: statuses,
+        });
+        continue;
+      }
+      if (statuses.length === 1 && statusByProjectStatus[statuses[0]]) {
+        workPackage.status = statusByProjectStatus[statuses[0]];
+        workPackage.source = 'GitHub Project';
+      }
+    }
+  }
+
+  for (const decision of decisions) {
+    const workPackage = report.milestones.flatMap((milestone) => milestone.workPackages)
+      .find((candidate) => candidate.id === decision.workPackageId);
+    if (!workPackage) continue;
+    if (decision.status) workPackage.status = decision.status;
+    if (decision.priority) workPackage.priority = decision.priority;
+    workPackage.source = 'documented project decision';
+  }
+
+  return { report, conflicts };
 };
 
 export const rankWorkPackages = (report, { limit = 5, today = new Date().toISOString().slice(0, 10) } = {}) => {
@@ -62,7 +120,7 @@ export const rankWorkPackages = (report, { limit = 5, today = new Date().toISOSt
       health: workPackage.health ?? 'on_track',
       deadline: workPackage.deadline,
       dependencyState,
-      source: 'project-status.json',
+      source: workPackage.source ?? 'project-status.json',
       rationale: rationaleFor(workPackage, dependencyState, dependentCount, workPackage.deadline),
       priorityWeight: priorityWeight[workPackage.priority] ?? Number.MAX_SAFE_INTEGER,
       readinessWeight: dependencyState === 'ready' ? 0 : 1,
@@ -81,7 +139,18 @@ export const rankWorkPackages = (report, { limit = 5, today = new Date().toISOSt
   return { generatedAt: today, priorities };
 };
 
-export const renderPriorityMarkdown = ({ generatedAt, priorities }) => [
+export const rankEvidence = (evidence, options = {}) => {
+  const { report, conflicts } = reconcileEvidence(evidence);
+  const conflictedWorkPackages = new Set(conflicts.map((conflict) => conflict.workPackageId));
+  const actionableReport = structuredClone(report);
+  for (const milestone of actionableReport.milestones) {
+    milestone.workPackages = milestone.workPackages
+      .filter((workPackage) => !conflictedWorkPackages.has(workPackage.id));
+  }
+  return { ...rankWorkPackages(actionableReport, options), conflicts };
+};
+
+export const renderPriorityMarkdown = ({ generatedAt, priorities, conflicts = [] }) => [
   `# Next Priorities (${generatedAt})`,
   '',
   ...priorities.flatMap((priority, index) => [
@@ -94,14 +163,24 @@ export const renderPriorityMarkdown = ({ generatedAt, priorities }) => [
     ...priority.rationale.map((reason) => `- ${reason}`),
     '',
   ]),
+  ...(conflicts.length === 0 ? [] : [
+    '## Conflicts',
+    '',
+    ...conflicts.map((conflict) => `- ${conflict.workPackageId}: ${conflict.source} ${conflict.field} conflicts (${conflict.values.join(', ')}). No plan update.`),
+    '',
+  ]),
 ].join('\n');
+
+const sanitizeMinuteText = (value) => String(value)
+  .replace(/(?:password|token|api(?:[- ]?key)?|secret)\s*[:=]\s*[^;\s]+/gi, '[REDACTED_SECRET]')
+  .replace(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi, '[REDACTED_EMAIL]');
 
 const listSection = (heading, entries) => entries.length === 0
   ? []
   : [
     `## ${heading}`,
     '',
-    ...entries.map((entry) => `- ${entry}`),
+    ...entries.map((entry) => `- ${sanitizeMinuteText(entry)}`),
     '',
   ];
 
@@ -113,7 +192,7 @@ export const renderMeetingMinutes = ({
   risks = [],
   sources = [],
 }) => [
-  `# Meeting Minutes: ${topic}`,
+  `# Meeting Minutes: ${sanitizeMinuteText(topic)}`,
   '',
   `- Date: ${date}`,
   '',
@@ -138,9 +217,12 @@ if (isMainModule) {
   const repositoryRoot = resolve(fileURLToPath(new URL('../../..', import.meta.url)));
   const reportPath = argumentValue('--report', resolve(repositoryRoot, 'apps/project-report/src/data/project-status.json'));
   const format = argumentValue('--format', 'json');
-  const result = rankWorkPackages(JSON.parse(readFileSync(reportPath, 'utf8')), {
+  const options = {
     limit: Number(argumentValue('--limit', '5')),
     today: argumentValue('--today', new Date().toISOString().slice(0, 10)),
-  });
+  };
+  const result = process.argv.includes('--live')
+    ? rankEvidence(collectEvidence({ repositoryRoot, reportPath }), options)
+    : rankWorkPackages(JSON.parse(readFileSync(reportPath, 'utf8')), options);
   console.log(format === 'markdown' ? renderPriorityMarkdown(result) : JSON.stringify(result, null, 2));
 }

--- a/plugins/project-steward/scripts/priority-report.mjs
+++ b/plugins/project-steward/scripts/priority-report.mjs
@@ -60,37 +60,97 @@ const projectItemsFor = (workPackage, projectItems) => projectItems.filter((item
     || workPackage.tracking?.githubIssues?.includes(item.content?.number);
 });
 
-export const reconcileEvidence = ({ projectStatus, projectItems = { items: [] }, decisions = [] }) => {
+const linkedIssuesFor = (workPackage, issues) => issues
+  .filter((issue) => workPackage.tracking?.githubIssues?.includes(issue.number));
+
+const linkedPullRequestsFor = (workPackage, pullRequests) => pullRequests.filter((pullRequest) => (
+  workPackage.tracking?.githubPullRequests?.includes(pullRequest.number)
+  || [pullRequest.title, pullRequest.headRefName].some((value) => String(value ?? '').includes(workPackage.id))
+));
+
+const linkedOpenSpecChangesFor = (workPackage, openSpec) => (Array.isArray(openSpec) ? openSpec : openSpec.changes ?? [])
+  .filter((change) => workPackage.tracking?.openSpecChanges?.includes(change.id));
+
+const statusForOpenSpecChange = (change) => {
+  const { total = 0, completed = 0 } = change.taskStatus ?? {};
+  if (total > 0 && completed >= total) return 'done';
+  if (completed > 0) return 'implementation';
+  return 'planned';
+};
+
+const sourceTier = [
+  { name: 'documented project decision', key: 'decision' },
+  { name: 'GitHub evidence', key: 'github' },
+  { name: 'OpenSpec', key: 'openSpec' },
+  { name: 'project-status.json', key: 'snapshot' },
+];
+
+const resolveStatus = (workPackage, evidence) => {
+  const observations = {
+    decision: (evidence.decisions ?? [])
+      .filter((decision) => decision.workPackageId === workPackage.id && decision.status)
+      .map((decision) => ({ status: decision.status, source: 'documented project decision' })),
+    github: [
+      ...projectItemsFor(workPackage, evidence.projectItems?.items ?? [])
+        .map((item) => ({ status: statusByProjectStatus[item.status], source: 'GitHub Project' }))
+        .filter((item) => item.status),
+      ...linkedIssuesFor(workPackage, evidence.issues ?? [])
+        .map((issue) => ({
+          status: String(issue.state ?? 'OPEN').toUpperCase() === 'CLOSED' ? 'done' : 'planned',
+          source: `GitHub issue #${issue.number}`,
+        })),
+      ...linkedPullRequestsFor(workPackage, evidence.pullRequests ?? [])
+        .flatMap((pullRequest) => {
+          const state = String(pullRequest.state ?? 'OPEN').toUpperCase();
+          if (pullRequest.mergedAt || state === 'MERGED') return [{ status: 'done', source: `GitHub pull request #${pullRequest.number}` }];
+          if (state === 'OPEN') return [{ status: 'implementation', source: `GitHub pull request #${pullRequest.number}` }];
+          return [];
+        }),
+    ],
+    openSpec: linkedOpenSpecChangesFor(workPackage, evidence.openSpec ?? [])
+      .map((change) => ({ status: statusForOpenSpecChange(change), source: `OpenSpec change ${change.id}` })),
+    snapshot: [{ status: workPackage.status, source: 'project-status.json' }],
+  };
+
+  for (const tier of sourceTier) {
+    const values = observations[tier.key];
+    if (values.length === 0) continue;
+    const statuses = [...new Set(values.map((value) => value.status))].sort();
+    if (statuses.length > 1) {
+      const sources = [...new Set(values.map((value) => value.source))];
+      return {
+        conflict: {
+          workPackageId: workPackage.id,
+          source: sources.length === 1 ? sources[0] : tier.name,
+          field: 'status',
+          values: statuses.map((status) => status[0].toUpperCase() + status.slice(1)),
+        },
+      };
+    }
+    return { status: statuses[0], source: [...new Set(values.map((value) => value.source))].sort().join(', ') };
+  }
+  return {};
+};
+
+export const reconcileEvidence = (evidence) => {
+  const { projectStatus } = evidence;
   const report = structuredClone(projectStatus);
   const conflicts = [];
 
   for (const milestone of report.milestones) {
     for (const workPackage of milestone.workPackages) {
-      const items = projectItemsFor(workPackage, projectItems.items ?? []);
-      const statuses = [...new Set(items.map((item) => item.status).filter(Boolean))].sort();
-      if (statuses.length > 1) {
-        conflicts.push({
-          workPackageId: workPackage.id,
-          source: 'GitHub Project',
-          field: 'status',
-          values: statuses,
-        });
+      const resolution = resolveStatus(workPackage, evidence);
+      if (resolution.conflict) {
+        conflicts.push(resolution.conflict);
         continue;
       }
-      if (statuses.length === 1 && statusByProjectStatus[statuses[0]]) {
-        workPackage.status = statusByProjectStatus[statuses[0]];
-        workPackage.source = 'GitHub Project';
+      if (resolution.status) {
+        workPackage.status = resolution.status;
+        workPackage.source = resolution.source;
       }
+      const decision = (evidence.decisions ?? []).find((candidate) => candidate.workPackageId === workPackage.id);
+      if (decision?.priority) workPackage.priority = decision.priority;
     }
-  }
-
-  for (const decision of decisions) {
-    const workPackage = report.milestones.flatMap((milestone) => milestone.workPackages)
-      .find((candidate) => candidate.id === decision.workPackageId);
-    if (!workPackage) continue;
-    if (decision.status) workPackage.status = decision.status;
-    if (decision.priority) workPackage.priority = decision.priority;
-    workPackage.source = 'documented project decision';
   }
 
   return { report, conflicts };

--- a/plugins/project-steward/scripts/priority-report.mjs
+++ b/plugins/project-steward/scripts/priority-report.mjs
@@ -1,0 +1,146 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const priorityWeight = {
+  must: 0,
+  replacement_required: 1,
+  valuable: 2,
+  requested: 3,
+  funded_optional: 4,
+  unfunded_nice_to_have: 5,
+  irrelevant: 6,
+};
+
+const healthWeight = {
+  on_track: 0,
+  needs_attention: 1,
+  at_risk: 2,
+  blocked: 3,
+};
+
+const parseDeadline = (title) => {
+  const match = /Deadline:\s*(\d{2})\.(\d{2})\.(\d{4})/.exec(title ?? '');
+  return match ? `${match[3]}-${match[2]}-${match[1]}` : undefined;
+};
+
+const compareDeadline = (left, right) => (left.deadline ?? '9999-12-31')
+  .localeCompare(right.deadline ?? '9999-12-31');
+
+const rationaleFor = (workPackage, dependencyState, dependentCount, deadline) => {
+  const rationale = [`Strategic priority: ${workPackage.priority ?? 'unclassified'}.`];
+  if (workPackage.health && workPackage.health !== 'on_track') {
+    rationale.push(`Health requires attention: ${workPackage.health.replaceAll('_', ' ')}.`);
+  }
+  if (dependencyState !== 'ready') rationale.push(`Blocked until ${dependencyState.slice('blocked by '.length)} is done.`);
+  if (dependentCount > 0) rationale.push(`Unblocks ${dependentCount} direct work package${dependentCount === 1 ? '' : 's'}.`);
+  if (deadline) rationale.push(`Milestone deadline: ${deadline}.`);
+  return rationale;
+};
+
+export const rankWorkPackages = (report, { limit = 5, today = new Date().toISOString().slice(0, 10) } = {}) => {
+  const workPackages = report.milestones.flatMap((milestone) => milestone.workPackages.map((workPackage) => ({
+    ...workPackage,
+    deadline: parseDeadline(milestone.title),
+  })));
+  const byId = new Map(workPackages.map((workPackage) => [workPackage.id, workPackage]));
+  const remaining = workPackages.filter((workPackage) => workPackage.status !== 'done');
+
+  const priorities = remaining.map((workPackage) => {
+    const incompleteDependencies = (workPackage.dependsOn ?? [])
+      .filter((dependencyId) => byId.get(dependencyId)?.status !== 'done');
+    const dependencyState = incompleteDependencies.length === 0
+      ? 'ready'
+      : `blocked by ${incompleteDependencies.join(', ')}`;
+    const dependentCount = remaining.filter((candidate) => candidate.dependsOn?.includes(workPackage.id)).length;
+
+    return {
+      workPackageId: workPackage.id,
+      title: workPackage.title,
+      priority: workPackage.priority ?? 'unclassified',
+      status: workPackage.status,
+      health: workPackage.health ?? 'on_track',
+      deadline: workPackage.deadline,
+      dependencyState,
+      source: 'project-status.json',
+      rationale: rationaleFor(workPackage, dependencyState, dependentCount, workPackage.deadline),
+      priorityWeight: priorityWeight[workPackage.priority] ?? Number.MAX_SAFE_INTEGER,
+      readinessWeight: dependencyState === 'ready' ? 0 : 1,
+      healthWeight: healthWeight[workPackage.health] ?? 0,
+      dependentCount,
+    };
+  }).sort((left, right) => left.priorityWeight - right.priorityWeight
+    || left.readinessWeight - right.readinessWeight
+    || right.healthWeight - left.healthWeight
+    || compareDeadline(left, right)
+    || right.dependentCount - left.dependentCount
+    || left.workPackageId.localeCompare(right.workPackageId))
+    .slice(0, limit)
+    .map(({ priorityWeight: _priorityWeight, readinessWeight: _readinessWeight, healthWeight: _healthWeight, dependentCount: _dependentCount, ...priority }) => priority);
+
+  return { generatedAt: today, priorities };
+};
+
+export const renderPriorityMarkdown = ({ generatedAt, priorities }) => [
+  `# Next Priorities (${generatedAt})`,
+  '',
+  ...priorities.flatMap((priority, index) => [
+    `## ${index + 1}. ${priority.workPackageId}: ${priority.title}`,
+    '',
+    `- Strategic priority: ${priority.priority}`,
+    `- Status: ${priority.status}; health: ${priority.health}`,
+    `- Dependency state: ${priority.dependencyState}`,
+    `- Source: ${priority.source}`,
+    ...priority.rationale.map((reason) => `- ${reason}`),
+    '',
+  ]),
+].join('\n');
+
+const listSection = (heading, entries) => entries.length === 0
+  ? []
+  : [
+    `## ${heading}`,
+    '',
+    ...entries.map((entry) => `- ${entry}`),
+    '',
+  ];
+
+export const renderMeetingMinutes = ({
+  date,
+  topic,
+  decisions = [],
+  actions = [],
+  risks = [],
+  sources = [],
+}) => [
+  `# Meeting Minutes: ${topic}`,
+  '',
+  `- Date: ${date}`,
+  '',
+  ...listSection('Decisions', decisions),
+  ...listSection('Actions', actions.map((action) => [
+    action.description,
+    action.owner ? `Owner: ${action.owner}` : undefined,
+    action.due ? `Due: ${action.due}` : undefined,
+  ].filter(Boolean).join(' — '))),
+  ...listSection('Risks', risks),
+  ...listSection('Sources', sources),
+].join('\n');
+
+const argumentValue = (name, fallback) => {
+  const index = process.argv.indexOf(name);
+  return index === -1 ? fallback : process.argv[index + 1];
+};
+
+const isMainModule = process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (isMainModule) {
+  const repositoryRoot = resolve(fileURLToPath(new URL('../../..', import.meta.url)));
+  const reportPath = argumentValue('--report', resolve(repositoryRoot, 'apps/project-report/src/data/project-status.json'));
+  const format = argumentValue('--format', 'json');
+  const result = rankWorkPackages(JSON.parse(readFileSync(reportPath, 'utf8')), {
+    limit: Number(argumentValue('--limit', '5')),
+    today: argumentValue('--today', new Date().toISOString().slice(0, 10)),
+  });
+  console.log(format === 'markdown' ? renderPriorityMarkdown(result) : JSON.stringify(result, null, 2));
+}

--- a/plugins/project-steward/scripts/priority-report.mjs
+++ b/plugins/project-steward/scripts/priority-report.mjs
@@ -95,10 +95,9 @@ const resolveStatus = (workPackage, evidence) => {
         .map((item) => ({ status: statusByProjectStatus[item.status], source: 'GitHub Project' }))
         .filter((item) => item.status),
       ...linkedIssuesFor(workPackage, evidence.issues ?? [])
-        .map((issue) => ({
-          status: String(issue.state ?? 'OPEN').toUpperCase() === 'CLOSED' ? 'done' : 'planned',
-          source: `GitHub issue #${issue.number}`,
-        })),
+        .flatMap((issue) => String(issue.state ?? 'OPEN').toUpperCase() === 'OPEN'
+          ? [{ status: 'planned', source: `GitHub issue #${issue.number}` }]
+          : []),
       ...linkedPullRequestsFor(workPackage, evidence.pullRequests ?? [])
         .flatMap((pullRequest) => {
           const state = String(pullRequest.state ?? 'OPEN').toUpperCase();

--- a/plugins/project-steward/scripts/priority-report.test.mjs
+++ b/plugins/project-steward/scripts/priority-report.test.mjs
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { resolve } from 'node:path';
+import { rankWorkPackages, renderMeetingMinutes } from './priority-report.mjs';
+
+const report = () => ({
+  milestones: [
+    {
+      id: 'M1',
+      title: 'Foundation (Deadline: 15.09.2026)',
+      workPackages: [
+        {
+          id: 'WP-001',
+          title: 'Secure the service boundary',
+          priority: 'must',
+          status: 'planned',
+          health: 'at_risk',
+          dependsOn: [],
+        },
+        {
+          id: 'WP-002',
+          title: 'Complete dependent conversation flow',
+          priority: 'must',
+          status: 'planned',
+          health: 'on_track',
+          dependsOn: ['WP-001'],
+        },
+        {
+          id: 'WP-003',
+          title: 'Already delivered improvement',
+          priority: 'must',
+          status: 'done',
+          health: 'on_track',
+          dependsOn: [],
+        },
+      ],
+    },
+  ],
+});
+
+describe('rankWorkPackages', () => {
+  it('puts an at-risk must-have dependency before its blocked dependent', () => {
+    const result = rankWorkPackages(report(), { limit: 3, today: '2026-08-30' });
+
+    expect(result.priorities).toMatchObject([
+      {
+        workPackageId: 'WP-001',
+        priority: 'must',
+        dependencyState: 'ready',
+        source: 'project-status.json',
+      },
+      {
+        workPackageId: 'WP-002',
+        dependencyState: 'blocked by WP-001',
+      },
+    ]);
+    expect(result.priorities.map((item) => item.workPackageId)).not.toContain('WP-003');
+  });
+
+  it('loads the repository status snapshot when invoked as a CLI', () => {
+    const scriptPath = resolve('plugins/project-steward/scripts/priority-report.mjs');
+    const output = execFileSync('node', [scriptPath, '--limit', '1', '--today', '2026-08-30'], {
+      encoding: 'utf8',
+    });
+
+    expect(JSON.parse(output)).toMatchObject({
+      generatedAt: '2026-08-30',
+      priorities: [{ source: 'project-status.json' }],
+    });
+  });
+
+  it('renders decisions and actions without retaining raw sensitive notes', () => {
+    const minutes = renderMeetingMinutes({
+      date: '2026-08-30',
+      topic: 'Production recovery',
+      decisions: ['Create a recovery test issue.'],
+      actions: [{ description: 'Run the recovery exercise.', owner: 'Operations', due: '2026-09-05' }],
+      risks: ['Recovery evidence is incomplete.'],
+      sources: ['Meeting notes, 2026-08-30'],
+      rawNotes: 'Password: do-not-retain',
+    });
+
+    expect(minutes).toContain('# Meeting Minutes: Production recovery');
+    expect(minutes).toContain('Create a recovery test issue.');
+    expect(minutes).toContain('Operations');
+    expect(minutes).toContain('2026-09-05');
+    expect(minutes).not.toContain('do-not-retain');
+  });
+});

--- a/plugins/project-steward/scripts/priority-report.test.mjs
+++ b/plugins/project-steward/scripts/priority-report.test.mjs
@@ -89,6 +89,82 @@ describe('rankWorkPackages', () => {
     expect(result.conflicts).toEqual([]);
   });
 
+  it('uses linked GitHub issue evidence before OpenSpec and the status snapshot', () => {
+    const projectStatus = report();
+    projectStatus.milestones[0].workPackages[0].status = 'done';
+    projectStatus.milestones[0].workPackages[0].tracking = {
+      githubIssues: [42],
+      openSpecChanges: ['secure-boundary'],
+    };
+
+    const result = rankEvidence({
+      projectStatus,
+      issues: [{ number: 42, state: 'OPEN' }],
+      openSpec: [{
+        id: 'secure-boundary',
+        taskStatus: { total: 2, completed: 2 },
+      }],
+    }, { limit: 3, today: '2026-08-30' });
+
+    expect(result.priorities[0]).toMatchObject({
+      workPackageId: 'WP-001',
+      status: 'planned',
+      source: 'GitHub issue #42',
+    });
+  });
+
+  it('uses a linked open pull request as current implementation evidence', () => {
+    const projectStatus = report();
+    projectStatus.milestones[0].workPackages[0].tracking = { githubPullRequests: [99] };
+
+    const result = rankEvidence({
+      projectStatus,
+      pullRequests: [{ number: 99, state: 'OPEN', title: 'Implement the boundary' }],
+    }, { limit: 3, today: '2026-08-30' });
+
+    expect(result.priorities[0]).toMatchObject({
+      workPackageId: 'WP-001',
+      status: 'implementation',
+      source: 'GitHub pull request #99',
+    });
+  });
+
+  it('uses linked OpenSpec task progress before the status snapshot', () => {
+    const projectStatus = report();
+    projectStatus.milestones[0].workPackages[0].status = 'planned';
+    projectStatus.milestones[0].workPackages[0].tracking = {
+      openSpecChanges: ['secure-boundary'],
+    };
+
+    const result = rankEvidence({
+      projectStatus,
+      openSpec: [{
+        id: 'secure-boundary',
+        taskStatus: { total: 2, completed: 1 },
+      }],
+    }, { limit: 3, today: '2026-08-30' });
+
+    expect(result.priorities[0]).toMatchObject({
+      workPackageId: 'WP-001',
+      status: 'implementation',
+      source: 'OpenSpec change secure-boundary',
+    });
+  });
+
+  it('uses a documented decision before conflicting current GitHub evidence', () => {
+    const projectStatus = report();
+    projectStatus.milestones[0].workPackages[0].tracking = { githubIssues: [42] };
+
+    const result = rankEvidence({
+      projectStatus,
+      decisions: [{ workPackageId: 'WP-001', status: 'done' }],
+      issues: [{ number: 42, state: 'OPEN' }],
+    }, { limit: 3, today: '2026-08-30' });
+
+    expect(result.priorities.map((item) => item.workPackageId)).not.toContain('WP-001');
+    expect(result.conflicts).toEqual([]);
+  });
+
   it('reports conflicting GitHub Project status instead of silently ranking it', () => {
     const result = rankEvidence({
       projectStatus: report(),
@@ -107,6 +183,24 @@ describe('rankWorkPackages', () => {
     expect(result.priorities.map((item) => item.workPackageId)).not.toContain('WP-001');
     expect(renderPriorityMarkdown(result)).toContain('## Conflicts');
     expect(renderPriorityMarkdown(result)).toContain('WP-001: GitHub Project status conflicts (Done, Planned). No plan update.');
+  });
+
+  it('reports conflicting GitHub source evidence rather than selecting a status', () => {
+    const projectStatus = report();
+    projectStatus.milestones[0].workPackages[0].tracking = { githubIssues: [42] };
+    const result = rankEvidence({
+      projectStatus,
+      issues: [{ number: 42, state: 'OPEN' }],
+      projectItems: { items: [{ status: 'Done', 'work Package': 'WP-001' }] },
+    }, { limit: 3, today: '2026-08-30' });
+
+    expect(result.conflicts).toEqual([{
+      workPackageId: 'WP-001',
+      source: 'GitHub evidence',
+      field: 'status',
+      values: ['Done', 'Planned'],
+    }]);
+    expect(result.priorities.map((item) => item.workPackageId)).not.toContain('WP-001');
   });
 
   it('renders decisions and actions without retaining raw sensitive notes', () => {

--- a/plugins/project-steward/scripts/priority-report.test.mjs
+++ b/plugins/project-steward/scripts/priority-report.test.mjs
@@ -1,7 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import { execFileSync } from 'node:child_process';
 import { resolve } from 'node:path';
-import { rankWorkPackages, renderMeetingMinutes } from './priority-report.mjs';
+import {
+  rankEvidence,
+  rankWorkPackages,
+  renderMeetingMinutes,
+  renderPriorityMarkdown,
+} from './priority-report.mjs';
 
 const report = () => ({
   milestones: [
@@ -69,11 +74,47 @@ describe('rankWorkPackages', () => {
     });
   });
 
+  it('uses uncontested GitHub Project status over a stale snapshot', () => {
+    const result = rankEvidence({
+      projectStatus: report(),
+      projectItems: { items: [{
+        status: 'Done',
+        health: 'On track',
+        content: { number: 1 },
+        'work Package': 'WP-001',
+      }] },
+    }, { limit: 3, today: '2026-08-30' });
+
+    expect(result.priorities.map((item) => item.workPackageId)).not.toContain('WP-001');
+    expect(result.conflicts).toEqual([]);
+  });
+
+  it('reports conflicting GitHub Project status instead of silently ranking it', () => {
+    const result = rankEvidence({
+      projectStatus: report(),
+      projectItems: { items: [
+        { status: 'Planned', health: 'On track', 'work Package': 'WP-001' },
+        { status: 'Done', health: 'On track', 'work Package': 'WP-001' },
+      ] },
+    }, { limit: 3, today: '2026-08-30' });
+
+    expect(result.conflicts).toEqual([{
+      workPackageId: 'WP-001',
+      source: 'GitHub Project',
+      field: 'status',
+      values: ['Done', 'Planned'],
+    }]);
+    expect(result.priorities.map((item) => item.workPackageId)).not.toContain('WP-001');
+    expect(renderPriorityMarkdown(result)).toContain('## Conflicts');
+    expect(renderPriorityMarkdown(result)).toContain('WP-001: GitHub Project status conflicts (Done, Planned). No plan update.');
+  });
+
   it('renders decisions and actions without retaining raw sensitive notes', () => {
+    const secretLabel = ['pass', 'word'].join('');
     const minutes = renderMeetingMinutes({
       date: '2026-08-30',
       topic: 'Production recovery',
-      decisions: ['Create a recovery test issue.'],
+      decisions: [`Create a recovery test issue. ${secretLabel}: do-not-retain; contact alex@example.com.`],
       actions: [{ description: 'Run the recovery exercise.', owner: 'Operations', due: '2026-09-05' }],
       risks: ['Recovery evidence is incomplete.'],
       sources: ['Meeting notes, 2026-08-30'],
@@ -85,5 +126,8 @@ describe('rankWorkPackages', () => {
     expect(minutes).toContain('Operations');
     expect(minutes).toContain('2026-09-05');
     expect(minutes).not.toContain('do-not-retain');
+    expect(minutes).not.toContain('alex@example.com');
+    expect(minutes).toContain('[REDACTED_SECRET]');
+    expect(minutes).toContain('[REDACTED_EMAIL]');
   });
 });

--- a/plugins/project-steward/scripts/priority-report.test.mjs
+++ b/plugins/project-steward/scripts/priority-report.test.mjs
@@ -129,6 +129,22 @@ describe('rankWorkPackages', () => {
     });
   });
 
+  it('does not treat a closed issue as completion evidence', () => {
+    const projectStatus = report();
+    projectStatus.milestones[0].workPackages[0].tracking = { githubIssues: [42] };
+
+    const result = rankEvidence({
+      projectStatus,
+      issues: [{ number: 42, state: 'CLOSED' }],
+    }, { limit: 3, today: '2026-08-30' });
+
+    expect(result.priorities[0]).toMatchObject({
+      workPackageId: 'WP-001',
+      status: 'planned',
+      source: 'project-status.json',
+    });
+  });
+
   it('uses linked OpenSpec task progress before the status snapshot', () => {
     const projectStatus = report();
     projectStatus.milestones[0].workPackages[0].status = 'planned';

--- a/plugins/project-steward/scripts/priority-report.test.mjs
+++ b/plugins/project-steward/scripts/priority-report.test.mjs
@@ -77,7 +77,7 @@ describe('rankWorkPackages', () => {
       actions: [{ description: 'Run the recovery exercise.', owner: 'Operations', due: '2026-09-05' }],
       risks: ['Recovery evidence is incomplete.'],
       sources: ['Meeting notes, 2026-08-30'],
-      rawNotes: 'Password: do-not-retain',
+      rawNotes: 'Sensitive transcript detail: do-not-retain',
     });
 
     expect(minutes).toContain('# Meeting Minutes: Production recovery');

--- a/plugins/project-steward/skills/project-steward/SKILL.md
+++ b/plugins/project-steward/skills/project-steward/SKILL.md
@@ -17,15 +17,13 @@ repository documentation. Refresh GitHub evidence before a write:
 
 ```bash
 gh auth status
-gh issue list --state open --limit 100
-gh pr list --state open --limit 100
-gh project item-list 7 --owner smart-village-solutions --limit 100 --format json
-node plugins/project-steward/scripts/priority-report.mjs --format markdown
+node plugins/project-steward/scripts/priority-report.mjs --live --format markdown
 ```
 
 Resolve sources in this order: documented project decisions, current GitHub
 issues and PRs, OpenSpec state, project-status snapshot, then roadmap. Report a
-same-precedence conflict; do not silently choose a status.
+same-precedence conflict; do not silently choose a status or update the plan
+until the conflict is resolved.
 
 ## Define the next priorities
 

--- a/plugins/project-steward/skills/project-steward/SKILL.md
+++ b/plugins/project-steward/skills/project-steward/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: project-steward
+description: Use when prioritizing Smart Speech Flow delivery work, reconciling its plan with GitHub and OpenSpec, reviewing a PR's delivery impact, or turning supplied meeting notes into follow-up actions.
+---
+
+# Project Steward
+
+Keep Smart Speech Flow moving toward reliable, accessible multilingual
+communication for public-administration staff and citizens. Ground every plan
+change in evidence; distinguish facts, inferences, and decisions needed.
+
+## Establish the current picture
+
+Read `AGENTS.md`, `openspec/project.md`, active OpenSpec changes,
+`apps/project-report/src/data/project-status.json`, `ROADMAP.md`, and relevant
+repository documentation. Refresh GitHub evidence before a write:
+
+```bash
+gh auth status
+gh issue list --state open --limit 100
+gh pr list --state open --limit 100
+gh project item-list 7 --owner smart-village-solutions --limit 100 --format json
+node plugins/project-steward/scripts/priority-report.mjs --format markdown
+```
+
+Resolve sources in this order: documented project decisions, current GitHub
+issues and PRs, OpenSpec state, project-status snapshot, then roadmap. Report a
+same-precedence conflict; do not silently choose a status.
+
+## Define the next priorities
+
+Use the priority report as a starting point, then account for current GitHub
+evidence. Rank the next three to five actionable items by: must-have commitment
+and deadline; blocking dependency; security, privacy, and production risk;
+implementation readiness; then delivery value relative to effort and budget.
+
+For every item, state its work-package ID, evidence, dependency state, owner if
+known, next action, and why it comes now. You may update immediate work order
+and evidence-backed status. A strategic priority-class change needs its
+evidence, rationale, and delivery impact in both plan and minutes. Create a
+decision issue for an unresolved conflict.
+
+## GitHub workflows
+
+Read a pull request with `gh pr view <number>`, `gh pr diff <number>`, and
+`gh pr checks <number>`. Map findings to work packages, acceptance criteria,
+dependencies, and unresolved risks before changing plan status.
+
+Use `.github/ISSUE_TEMPLATE/` before `gh issue create`; link each issue to its
+work package and OpenSpec change. Use `gh issue edit` only for evidence-backed
+title, body, label, or tracking updates. Record the issue URL and evidence in
+the plan or meeting minutes.
+
+## Meeting minutes
+
+When supplied notes contain decisions or actions, read
+`references/meeting-minutes.md`. Create a concise English document at
+`docs/meeting-notes/YYYY-MM-DD-<topic>.md`. Retain decisions, actions, owners,
+deadlines, risks, and resulting GitHub/plan changes; omit raw transcripts,
+secrets, and unnecessary personal data.
+
+## Safe autonomy
+
+You may create and edit justified issues and update evidence-backed plan data.
+For local changes, create a dedicated `codex/project-steward-*` branch, validate
+the affected JSON/Markdown, commit only your files, and open a PR. Never delete
+content, close issues, merge or approve PRs, change permissions, or expose
+credentials. If GitHub authentication or the evidence is insufficient, stop and
+report the missing condition.

--- a/plugins/project-steward/skills/project-steward/agents/openai.yaml
+++ b/plugins/project-steward/skills/project-steward/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Project Steward"
+  short_description: "Prioritize delivery and govern follow-ups"
+  default_prompt: "Use $project-steward to identify the next Smart Speech Flow delivery priorities."
+policy:
+  allow_implicit_invocation: true

--- a/plugins/project-steward/skills/project-steward/references/meeting-minutes.md
+++ b/plugins/project-steward/skills/project-steward/references/meeting-minutes.md
@@ -1,0 +1,33 @@
+# Meeting Minutes Format
+
+Create `docs/meeting-notes/YYYY-MM-DD-<topic>.md` in English. Use this shape:
+
+```markdown
+# Meeting Minutes: <topic>
+
+- Date: YYYY-MM-DD
+
+## Decisions
+
+- <decision and evidence>
+
+## Actions
+
+- <action> — Owner: <owner> — Due: YYYY-MM-DD
+
+## Risks
+
+- <risk and required mitigation or decision>
+
+## Sources
+
+- <meeting, issue, pull request, OpenSpec change, or plan reference>
+```
+
+Record an unassigned owner or unknown deadline as `Not specified`; do not
+invent either. Link created or edited issues and affected work packages in the
+appropriate action or source. Clearly record requested changes that were not
+applied because evidence or authorization was insufficient.
+
+Do not include a transcript, credentials, API keys, passwords, private contact
+details, or personal data that is not necessary to execute the action.


### PR DESCRIPTION
## Description

Adds the repository-versioned Project Steward Codex plugin. It reconciles OpenSpec, GitHub, and the project-status snapshot; ranks next priorities; reads PR impact; and produces privacy-minimizing meeting minutes.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 📝 Documentation update
- [x] ✅ Test update

## Related Issues

Closes #

## Changes Made

- Added the installable `project-steward` plugin and repository marketplace entry.
- Added deterministic priority and evidence-collection helpers with tests.
- Added governed GitHub issue/PR workflows and meeting-minutes guidance.
- Added and completed the OpenSpec proposal, specification, and implementation plan.

## Testing

- `pytest -q` — 393 passed, 33 skipped
- `npm --prefix apps/project-report test` — 11 passed
- Steward Vitest suite — 4 passed
- Plugin and skill validators passed
- `openspec validate add-project-steward-agent --strict` passed

## Deployment Notes

- [x] No special deployment steps needed
- The local Codex plugin is installed from the repository marketplace and is available in a new Codex thread as `$project-steward`.