### PR TITLE
feat: add project steward agent

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "personal",
+  "interface": {
+    "displayName": "Personal"
+  },
+  "plugins": [
+    {
+      "name": "project-steward",
+      "source": {
+        "source": "local",
+        "path": "./plugins/project-steward"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    }
+  ]
+}

--- a/docs/meeting-notes/README.md
+++ b/docs/meeting-notes/README.md
@@ -1,0 +1,13 @@
+# Meeting Minutes
+
+Project Steward records concise, English meeting minutes in this directory as
+`YYYY-MM-DD-<topic>.md`.
+
+Minutes are decision records, not transcripts. They must retain only the
+context needed to operate the project: decisions, prioritized actions, owners,
+deadlines, risks, evidence sources, and resulting issue or plan changes. Do not
+commit passwords, tokens, personal contact data, raw transcripts, or other
+unnecessary personal data.
+
+Use the Project Steward skill to derive the Markdown content and validate every
+resulting GitHub or delivery-plan update against current evidence.

--- a/docs/superpowers/plans/2026-08-30-project-steward-agent.md
+++ b/docs/superpowers/plans/2026-08-30-project-steward-agent.md
@@ -1,0 +1,62 @@
+# Project Steward Agent Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox syntax for tracking.
+
+**Goal:** Build an installable, repository-versioned Codex Project Steward that ranks delivery work, governs GitHub issue and PR workflows, and records auditable meeting minutes.
+
+**Architecture:** A repo-local marketplace exposes the `project-steward` plugin and its focused skill. A dependency-free Node helper ranks work from the existing project-status snapshot; the skill combines the report with live OpenSpec and GitHub CLI evidence before applying the defined safety rules.
+
+**Tech Stack:** Codex plugin manifest and skill Markdown; Node.js ESM; Vitest; GitHub CLI; OpenSpec.
+
+**Spec:** `docs/superpowers/specs/2026-08-30-project-steward-design.md`
+
+## Global Constraints
+
+- Use the existing authenticated GitHub CLI; do not add a connector or dependency.
+- Preserve source precedence: decisions, GitHub evidence, OpenSpec, project-status snapshot, roadmap.
+- Never delete content, close issues, merge PRs, change permissions, or expose secrets.
+- Local outputs use a dedicated `codex/project-steward-*` branch and a reviewable PR.
+- Minutes are concise, English, privacy-minimizing Markdown under `docs/meeting-notes/`.
+
+### Task 1: Implement the deterministic priority engine
+
+**Files:** Create `plugins/project-steward/scripts/priority-report.mjs` and `plugins/project-steward/scripts/priority-report.test.mjs`.
+
+**Interface:** `rankWorkPackages(report, { limit, today })` returns `{ generatedAt, priorities }`. A priority has `workPackageId`, `title`, `priority`, `rationale`, `dependencyState`, and `source`.
+
+- [x] Write a failing Vitest test that passes a minimal status snapshot and expects the unblocked, must-have package with the earliest deadline to rank first.
+- [x] Run `npx vitest run plugins/project-steward/scripts/priority-report.test.mjs`; confirm it fails because the module is absent.
+- [x] Implement priority-class, deadline, dependency-readiness, health-risk, and dependency-impact scoring. Provide JSON output by default and Markdown via `--format markdown`.
+- [x] Add tests for incomplete dependencies, blocked work, exclusion of completed work, priority tie-breaking, and limits; rerun the test file and confirm it passes.
+- [x] Commit only the helper and its tests with `feat: add project steward priority report`.
+
+### Task 2: Package the governed Project Steward skill
+
+**Files:** Create `.agents/plugins/marketplace.json`, `plugins/project-steward/.codex-plugin/plugin.json`, `plugins/project-steward/skills/project-steward/SKILL.md`, and `plugins/project-steward/skills/project-steward/agents/openai.yaml`.
+
+**Interface:** The plugin exposes the `project-steward` skill, which invokes the priority report and GitHub CLI without adding credentials or dependencies.
+
+- [x] Run `python3 /root/.codex/skills/.system/plugin-creator/scripts/validate_plugin.py plugins/project-steward`; confirm it fails before scaffolding.
+- [x] Scaffold the plugin into the repository marketplace. The skill must state project goals, evidence collection, source precedence, priority rules, safe `gh` issue and PR commands, audit records, and mutation boundaries.
+- [x] Add fixture-based skill scenarios for supported issue creation, prohibited issue closure, and a priority-class conflict.
+- [x] Validate with the plugin validator and `python3 /root/.codex/skills/.system/skill-creator/scripts/quick_validate.py plugins/project-steward/skills/project-steward`.
+- [x] Commit the marketplace and plugin with `feat: add project steward plugin`.
+
+### Task 3: Add minutes rendering and guidance
+
+**Files:** Create `docs/meeting-notes/README.md` and `plugins/project-steward/skills/project-steward/references/meeting-minutes.md`; modify `priority-report.mjs` and its test.
+
+**Interface:** `renderMeetingMinutes({ date, topic, decisions, actions, risks, sources })` returns the Markdown content for `docs/meeting-notes/YYYY-MM-DD-<topic>.md`.
+
+- [x] Write a failing test using decisions, an owner, a deadline, sources, and a sensitive raw-note field. Expect retained decisions/actions and omission of the raw sensitive field.
+- [x] Run the test file; confirm it fails because `renderMeetingMinutes` is absent.
+- [x] Implement the minimal renderer. Document the required headings and data-minimization rules in the plugin reference and repository README.
+- [x] Rerun tests and commit the minutes work with `docs: add project steward meeting minutes format`.
+
+### Task 4: Verify integration and complete the proposal
+
+**Files:** Modify `openspec/changes/add-project-steward-agent/tasks.md`; include this plan in the final documentation commit.
+
+- [x] Run read-only `gh auth status`, `gh issue list`, `gh pr list`, and `gh project item-list 7 --owner smart-village-solutions --format json`.
+- [x] Run `npm --prefix apps/project-report test`, the priority-report tests, plugin validation, skill validation, and `openspec validate add-project-steward-agent --strict`.
+- [x] Mark only verified OpenSpec tasks complete, then commit the plan and task updates with `docs: complete project steward proposal`.

--- a/docs/superpowers/specs/2026-08-30-project-steward-design.md
+++ b/docs/superpowers/specs/2026-08-30-project-steward-design.md
@@ -1,0 +1,171 @@
+# Project Steward Design
+
+## Context
+
+Smart Speech Flow has several active OpenSpec changes, a GitHub delivery project,
+and a repository-maintained project-status snapshot. The team needs a dedicated
+Codex agent that can keep these sources aligned, determine the next operational
+priorities, turn meeting notes into auditable follow-ups, and work directly with
+GitHub issues and pull requests.
+
+The agent must understand the product goal: reliable, accessible, multilingual
+communication between public-administration staff and citizens. It must protect
+that goal when it ranks work; work that unblocks a must-have delivery, reduces a
+security, privacy, or production risk, or protects the critical conversation
+flow takes precedence over unrelated improvements.
+
+## Goals
+
+- Provide a reusable `project-steward` Codex plugin/skill with a focused project
+  governance role.
+- Ground every assessment in repository plans, OpenSpec changes, GitHub issues,
+  pull requests, and the GitHub Project snapshot.
+- Autonomously maintain evidence-backed project-plan data and create or edit
+  GitHub issues.
+- Convert supplied meeting notes into versioned English Markdown minutes under
+  `docs/meeting-notes/`.
+- Rank the next three to five actions with a concise, evidence-backed rationale.
+- Read pull-request metadata, diffs, reviews, and checks to evaluate delivery
+  impact.
+- Preserve normal repository governance: changes are committed on a dedicated
+  branch and proposed through a pull request; the agent never merges.
+
+## Non-Goals
+
+- Replacing human strategic governance or silently redefining the product's
+  priority classes.
+- Merging pull requests, deleting GitHub content, or closing issues.
+- Storing raw meeting transcripts, secrets, or unnecessary personal data.
+- Introducing a separate task tracker or a duplicate priority model.
+
+## Architecture
+
+The implementation is a repository-versioned Codex plugin named
+`project-steward`. Its central skill contains the role, source-precedence rules,
+action boundaries, and repeatable workflows. Small deterministic helper scripts
+collect repository and GitHub evidence and validate proposed local changes. The
+skill delegates GitHub operations to the authenticated GitHub CLI already used
+by the repository environment.
+
+```text
+Repository plans + GitHub evidence + supplied meeting notes
+                         |
+                         v
+                 Project Steward skill
+              /          |           \
+             v           v            v
+    priority recommendation  issue/plan sync  meeting minutes
+             \           |            /
+                         v
+           dedicated branch and reviewable PR
+```
+
+### Source precedence
+
+The steward resolves conflicting information in this order:
+
+1. Explicit project decisions captured in approved meeting minutes or direct
+   user instructions.
+2. Current GitHub issue and pull-request evidence, including checks and
+   reviews.
+3. OpenSpec proposals and task completion state.
+4. `apps/project-report/src/data/project-status.json` as the operational
+   delivery-plan snapshot.
+5. `ROADMAP.md` as strategic context, not as a current delivery-status source.
+
+It must report a conflict rather than silently choosing between contradictory
+sources of the same precedence.
+
+### Priority policy
+
+For each priority run, the steward orders actionable work using these criteria:
+
+1. Must-have work and committed deadlines.
+2. Blocking dependencies and the critical delivery path.
+3. Security, data-protection, and production-operability risks.
+4. Work with sufficient implementation readiness before work that remains
+   materially unclear.
+5. Expected delivery value relative to effort and available budget.
+
+The steward may autonomously update the immediate work order and work-package
+status when evidence supports it. A change to the strategic priority class must
+include its evidence, rationale, and expected impact in the plan and minutes.
+When it exposes a genuine conflict, the steward creates a decision issue instead
+of silently changing the product intent.
+
+### GitHub operations
+
+The skill uses `gh issue list`, `gh issue view`, `gh issue create`, and
+`gh issue edit` for issue work. It uses `gh pr list`, `gh pr view`, `gh pr diff`,
+and `gh pr checks` to assess pull requests. Before mutating GitHub it verifies
+the active account and required scopes. It follows existing issue and pull
+request templates, links relevant work-package and OpenSpec identifiers, and
+records the evidence it used.
+
+The steward never deletes GitHub content, closes issues, approves or merges pull
+requests, changes repository permissions, or exposes tokens and other secrets.
+
+### Meeting minutes
+
+For supplied notes, the steward creates
+`docs/meeting-notes/YYYY-MM-DD-<topic>.md`. Each file includes the meeting
+context, decisions, prioritized actions, owners, deadlines, risks, and the
+resulting GitHub or plan changes. Minutes are concise, English, and minimize
+personal data; raw transcripts and secrets are excluded.
+
+### Change workflow
+
+Local plan or minutes updates are made in a dedicated `codex/project-steward-*`
+branch. The steward validates JSON and Markdown conventions, runs the relevant
+status-sync validation, commits only its own files, and opens a pull request.
+It does not merge that pull request.
+
+## Workflows
+
+### Reconcile project status
+
+The steward gathers OpenSpec, the project-status snapshot, open GitHub issues,
+and active pull requests. It reports discrepancies, updates only evidence-backed
+fields, and creates missing or malformed tracking issues when required.
+
+### Process meeting notes
+
+The steward extracts decisions and actions from supplied notes, determines their
+effect on work packages, creates or edits justified issues, updates the delivery
+plan, and creates the versioned meeting minutes.
+
+### Assess pull-request impact
+
+The steward reads the pull request description, linked issues, diff, reviews,
+and check results. It maps the work to plan items, identifies blocked or
+unverified acceptance criteria, and updates the plan only when the evidence is
+strong enough.
+
+### Report next priorities
+
+The steward produces the next three to five actions, each with its priority
+rationale, source references, dependency status, owner where known, and a clear
+next action. It distinguishes facts, inferences, and decisions needed.
+
+## Risks and Mitigations
+
+- **Plan drift caused by stale evidence**: refresh GitHub and OpenSpec evidence
+  before every write and record the refresh time.
+- **Overconfident reprioritization**: apply the fixed priority policy, preserve
+  strategic classes unless evidence justifies a documented change, and create a
+  decision issue for unresolved conflicts.
+- **Unsafe autonomous mutation**: prohibit deletions, closures, merges,
+  permission changes, and secret handling; route repository updates through a
+  reviewable PR.
+- **Sensitive meeting content**: retain only the minimum necessary decisions and
+  actions in the repository minutes.
+
+## Validation
+
+- Validate the plugin manifest and its skill instructions.
+- Test source-precedence and priority decisions with fixture data.
+- Test generated minutes and project-status changes against their schemas and
+  existing status-sync tests.
+- Verify GitHub read commands against the current repository without mutating
+  it; cover issue creation/editing with non-production fixtures or explicit
+  test issues.

--- a/openspec/changes/add-project-steward-agent/proposal.md
+++ b/openspec/changes/add-project-steward-agent/proposal.md
@@ -1,0 +1,26 @@
+# Change: Add an autonomous project stewardship agent
+
+## Why
+
+The delivery plan, GitHub issues, pull requests, and OpenSpec changes need a
+single, evidence-based stewardship workflow. The team also needs project minutes
+that turn decisions into traceable, prioritized follow-up work.
+
+## What Changes
+
+- Add a repository-versioned Codex `project-steward` plugin/skill.
+- Give the steward governed GitHub issue maintenance and pull-request reading
+  workflows through the authenticated GitHub CLI.
+- Add evidence-based delivery-plan reconciliation and next-priority ranking.
+- Add English, privacy-minimizing meeting minutes under `docs/meeting-notes/`.
+- Require all local stewardship changes to use a dedicated branch and a
+  reviewable pull request; prohibit deletion, issue closure, and pull-request
+  merging.
+
+## Impact
+
+- Affected specs: `project-steward-agent` (new capability).
+- Affected code: new plugin and helper scripts; project-status synchronization;
+  documentation and validation tests.
+- External dependency: authenticated GitHub CLI with existing repository and
+  project scopes.

--- a/openspec/changes/add-project-steward-agent/specs/project-steward-agent/spec.md
+++ b/openspec/changes/add-project-steward-agent/specs/project-steward-agent/spec.md
@@ -1,0 +1,86 @@
+## ADDED Requirements
+
+### Requirement: Project-goal-grounded stewardship
+
+The system SHALL provide a reusable Project Steward agent that evaluates work
+against Smart Speech Flow's goal of reliable, accessible, multilingual
+communication for public-administration staff and citizens.
+
+#### Scenario: Assessing a proposed task
+
+- **WHEN** the steward assesses a task or pull request
+- **THEN** it SHALL state how the work supports, blocks, or risks a project goal
+  and cite the evidence used
+
+### Requirement: Evidence-based source reconciliation
+
+The steward SHALL reconcile project information using explicit decisions,
+GitHub evidence, OpenSpec state, the project-status snapshot, and the roadmap in
+that order of precedence.
+
+#### Scenario: Conflicting current-status sources
+
+- **WHEN** sources of equal precedence contradict each other
+- **THEN** the steward SHALL report the conflict and SHALL NOT silently choose a
+  status
+
+### Requirement: Autonomous next-priority definition
+
+The steward SHALL autonomously define and maintain the immediate work order
+using must-have commitments and deadlines, dependencies, security/privacy and
+operability risk, implementation readiness, and value relative to effort and
+budget.
+
+#### Scenario: Priority report
+
+- **WHEN** the steward runs a priority assessment
+- **THEN** it SHALL identify the next three to five actions with rationale,
+  evidence, dependencies, and any required decision
+
+#### Scenario: Strategic priority-class change
+
+- **WHEN** evidence warrants changing a work package's strategic priority class
+- **THEN** the steward SHALL record the evidence, rationale, and impact in the
+  delivery plan and meeting minutes
+
+### Requirement: Governed GitHub issue and pull-request workflow
+
+The steward SHALL read pull-request metadata, diffs, reviews, and checks, and
+SHALL create or edit GitHub issues when supported by evidence and existing
+repository conventions.
+
+#### Scenario: Missing follow-up work
+
+- **WHEN** a meeting decision or pull-request finding requires untracked work
+- **THEN** the steward SHALL create a linked issue with the appropriate template
+  content and plan references
+
+#### Scenario: Pull-request plan impact
+
+- **WHEN** the steward evaluates a pull request
+- **THEN** it SHALL identify affected work packages, dependencies, acceptance
+  criteria, and unverified risks before updating plan status
+
+### Requirement: Auditable repository meeting minutes
+
+The steward SHALL convert supplied meeting notes into concise, English,
+privacy-minimizing Markdown minutes under `docs/meeting-notes/`.
+
+#### Scenario: Recording a meeting
+
+- **WHEN** meeting notes contain decisions or actions
+- **THEN** the steward SHALL record decisions, prioritized actions, owners,
+  deadlines, risks, and resulting plan or GitHub changes without retaining raw
+  transcripts, secrets, or unnecessary personal data
+
+### Requirement: Safe autonomous mutations
+
+The steward SHALL make local plan and minutes changes on a dedicated branch and
+through a reviewable pull request. It SHALL NOT delete content, close issues,
+merge pull requests, change repository permissions, or expose secrets.
+
+#### Scenario: Updating a project-plan snapshot
+
+- **WHEN** evidence supports a project-plan update
+- **THEN** the steward SHALL validate the update, commit only its own changes on
+  a dedicated branch, and open a pull request without merging it

--- a/openspec/changes/add-project-steward-agent/tasks.md
+++ b/openspec/changes/add-project-steward-agent/tasks.md
@@ -1,0 +1,29 @@
+## 1. Plugin foundation
+
+- [x] 1.1 Scaffold the repository-versioned `project-steward` Codex plugin and
+      validate its manifest.
+- [x] 1.2 Write the stewardship skill with project goals, source precedence,
+      autonomy boundaries, and GitHub command guidance.
+
+## 2. Evidence and prioritization
+
+- [x] 2.1 Implement a deterministic evidence collector for OpenSpec,
+      project-status data, GitHub issues, and pull requests.
+- [x] 2.2 Implement and test the priority policy and source-conflict reporting.
+- [x] 2.3 Integrate validation with the existing project-status synchronization
+      workflow.
+
+## 3. Meeting minutes and GitHub workflows
+
+- [x] 3.1 Add the meeting-minutes format, privacy rules, and repository
+      documentation.
+- [x] 3.2 Add governed issue create/edit and PR-read workflows that respect
+      existing repository templates.
+- [x] 3.3 Add branch and pull-request safeguards for local plan changes.
+
+## 4. Verification and handoff
+
+- [x] 4.1 Add fixture-based tests for priorities, conflict detection, and
+      generated minutes.
+- [x] 4.2 Verify read-only GitHub workflows against this repository.
+- [x] 4.3 Validate the plugin and the OpenSpec change.

--- a/plugins/project-steward/.codex-plugin/plugin.json
+++ b/plugins/project-steward/.codex-plugin/plugin.json
@@ -1,0 +1,21 @@
+{
+  "name": "project-steward",
+  "version": "0.1.0+codex.20260830182634",
+  "description": "Evidence-based delivery planning and GitHub stewardship for Smart Speech Flow.",
+  "author": {
+    "name": "Smart Village Solutions"
+  },
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Project Steward",
+    "shortDescription": "Keep delivery priorities and follow-ups current.",
+    "longDescription": "Ranks Smart Speech Flow delivery work, turns meeting notes into actions, and maintains governed GitHub follow-ups.",
+    "developerName": "Smart Village Solutions",
+    "category": "Productivity",
+    "capabilities": [
+      "Interactive",
+      "Write"
+    ],
+    "defaultPrompt": "Use Project Steward to identify the next delivery priorities."
+  }
+}

--- a/plugins/project-steward/scripts/evidence-collector.mjs
+++ b/plugins/project-steward/scripts/evidence-collector.mjs
@@ -1,0 +1,40 @@
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const parseJson = (value) => JSON.parse(value);
+
+const defaultRun = (command, args, options = {}) => execFileSync(command, args, { encoding: 'utf8', ...options });
+
+export const collectEvidence = ({
+  run = defaultRun,
+  readReport = readFileSync,
+  owner = 'smart-village-solutions',
+  projectNumber = '7',
+  repositoryRoot = resolve(fileURLToPath(new URL('../../..', import.meta.url))),
+  reportPath = resolve(repositoryRoot, 'apps/project-report/src/data/project-status.json'),
+} = {}) => {
+  const repository = `${owner}/smart-speech-flow`;
+  const runOptions = { cwd: repositoryRoot };
+  return {
+    collectedAt: new Date().toISOString(),
+    openSpec: parseJson(run('openspec', ['change', 'list', '--json'], runOptions)),
+    projectStatus: parseJson(readReport(reportPath, 'utf8')),
+    issues: parseJson(run('gh', [
+      'issue', 'list', '--repo', repository, '--state', 'all', '--limit', '100',
+      '--json', 'number,state,title,labels,url,updatedAt',
+    ], runOptions)),
+    pullRequests: parseJson(run('gh', [
+      'pr', 'list', '--repo', repository, '--state', 'all', '--limit', '100',
+      '--json', 'number,state,mergedAt,title,headRefName,reviewDecision,statusCheckRollup,url,updatedAt',
+    ], runOptions)),
+    projectItems: parseJson(run('gh', [
+      'project', 'item-list', projectNumber, '--owner', owner, '--limit', '100', '--format', 'json',
+    ], runOptions)),
+  };
+};
+
+const isMainModule = process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (isMainModule) console.log(JSON.stringify(collectEvidence(), null, 2));

--- a/plugins/project-steward/scripts/evidence-collector.test.mjs
+++ b/plugins/project-steward/scripts/evidence-collector.test.mjs
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { collectEvidence } from './evidence-collector.mjs';
+
+describe('collectEvidence', () => {
+  it('collects the project plan, OpenSpec, issues, pull requests, and Project items', () => {
+    const calls = [];
+    const run = (command, args, options) => {
+      calls.push([command, args, options]);
+      if (command === 'openspec') return JSON.stringify({ changes: [{ id: 'stabilize-production-operations' }] });
+      if (args[0] === 'issue') return JSON.stringify([{ number: 221, title: 'Secure service ports' }]);
+      if (args[0] === 'pr') return JSON.stringify([{ number: 233, title: 'Boot health gate' }]);
+      return JSON.stringify({ items: [{ id: 'PVTI_1' }] });
+    };
+
+    const evidence = collectEvidence({
+      run,
+      readReport: () => JSON.stringify({ meta: { version: '1.6.0' } }),
+      owner: 'smart-village-solutions',
+      projectNumber: '7',
+    });
+
+    expect(evidence).toMatchObject({
+      openSpec: { changes: [{ id: 'stabilize-production-operations' }] },
+      projectStatus: { meta: { version: '1.6.0' } },
+      issues: [{ number: 221 }],
+      pullRequests: [{ number: 233 }],
+      projectItems: { items: [{ id: 'PVTI_1' }] },
+    });
+    expect(calls[0].slice(0, 2)).toEqual(['openspec', ['change', 'list', '--json']]);
+    expect(calls.map(([command, args]) => [command, args.slice(0, 2)])).toEqual(expect.arrayContaining([
+      ['gh', ['issue', 'list']],
+      ['gh', ['pr', 'list']],
+      ['gh', ['project', 'item-list']],
+    ]));
+    const issueArgs = calls.find(([, args]) => args[0] === 'issue')[1];
+    const pullRequestArgs = calls.find(([, args]) => args[0] === 'pr')[1];
+    expect(issueArgs).toEqual(expect.arrayContaining(['--state', 'all']));
+    expect(issueArgs.at(-1)).toContain('state');
+    expect(pullRequestArgs).toEqual(expect.arrayContaining(['--state', 'all']));
+    expect(pullRequestArgs.at(-1)).toContain('mergedAt');
+    expect(calls.filter(([command]) => command === 'gh')).toEqual(expect.arrayContaining([
+      ['gh', expect.arrayContaining(['--repo', 'smart-village-solutions/smart-speech-flow']), expect.objectContaining({ cwd: expect.any(String) })],
+    ]));
+  });
+});

--- a/plugins/project-steward/scripts/priority-report.mjs
+++ b/plugins/project-steward/scripts/priority-report.mjs
@@ -1,0 +1,287 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { collectEvidence } from './evidence-collector.mjs';
+
+const priorityWeight = {
+  must: 0,
+  replacement_required: 1,
+  valuable: 2,
+  requested: 3,
+  funded_optional: 4,
+  unfunded_nice_to_have: 5,
+  irrelevant: 6,
+};
+
+const healthWeight = {
+  on_track: 0,
+  needs_attention: 1,
+  at_risk: 2,
+  blocked: 3,
+};
+
+const statusByProjectStatus = {
+  Idea: 'idea',
+  Commissioned: 'commissioned',
+  Planned: 'planned',
+  Prototype: 'prototype',
+  Implementation: 'implementation',
+  Optimization: 'optimization',
+  Testing: 'testing',
+  Acceptance: 'acceptance',
+  Done: 'done',
+};
+
+const parseDeadline = (title) => {
+  const match = /Deadline:\s*(\d{2})\.(\d{2})\.(\d{4})/.exec(title ?? '');
+  return match ? `${match[3]}-${match[2]}-${match[1]}` : undefined;
+};
+
+const compareDeadline = (left, right) => (left.deadline ?? '9999-12-31')
+  .localeCompare(right.deadline ?? '9999-12-31');
+
+const rationaleFor = (workPackage, dependencyState, dependentCount, deadline) => {
+  const rationale = [`Strategic priority: ${workPackage.priority ?? 'unclassified'}.`];
+  if (workPackage.health && workPackage.health !== 'on_track') {
+    rationale.push(`Health requires attention: ${workPackage.health.replaceAll('_', ' ')}.`);
+  }
+  if (dependencyState !== 'ready') rationale.push(`Blocked until ${dependencyState.slice('blocked by '.length)} is done.`);
+  if (dependentCount > 0) rationale.push(`Unblocks ${dependentCount} direct work package${dependentCount === 1 ? '' : 's'}.`);
+  if (deadline) rationale.push(`Milestone deadline: ${deadline}.`);
+  return rationale;
+};
+
+const projectItemsFor = (workPackage, projectItems) => projectItems.filter((item) => {
+  const linkedWorkPackages = String(item['roadmap links'] ?? item['roadmap Links'] ?? item['Roadmap links'] ?? '')
+    .split(',')
+    .map((value) => value.trim());
+  return item['work Package'] === workPackage.id
+    || linkedWorkPackages.includes(workPackage.id)
+    || workPackage.tracking?.githubIssues?.includes(item.content?.number);
+});
+
+const linkedIssuesFor = (workPackage, issues) => issues
+  .filter((issue) => workPackage.tracking?.githubIssues?.includes(issue.number));
+
+const linkedPullRequestsFor = (workPackage, pullRequests) => pullRequests.filter((pullRequest) => (
+  workPackage.tracking?.githubPullRequests?.includes(pullRequest.number)
+  || [pullRequest.title, pullRequest.headRefName].some((value) => String(value ?? '').includes(workPackage.id))
+));
+
+const linkedOpenSpecChangesFor = (workPackage, openSpec) => (Array.isArray(openSpec) ? openSpec : openSpec.changes ?? [])
+  .filter((change) => workPackage.tracking?.openSpecChanges?.includes(change.id));
+
+const statusForOpenSpecChange = (change) => {
+  const { total = 0, completed = 0 } = change.taskStatus ?? {};
+  if (total > 0 && completed >= total) return 'done';
+  if (completed > 0) return 'implementation';
+  return 'planned';
+};
+
+const sourceTier = [
+  { name: 'documented project decision', key: 'decision' },
+  { name: 'GitHub evidence', key: 'github' },
+  { name: 'OpenSpec', key: 'openSpec' },
+  { name: 'project-status.json', key: 'snapshot' },
+];
+
+const resolveStatus = (workPackage, evidence) => {
+  const observations = {
+    decision: (evidence.decisions ?? [])
+      .filter((decision) => decision.workPackageId === workPackage.id && decision.status)
+      .map((decision) => ({ status: decision.status, source: 'documented project decision' })),
+    github: [
+      ...projectItemsFor(workPackage, evidence.projectItems?.items ?? [])
+        .map((item) => ({ status: statusByProjectStatus[item.status], source: 'GitHub Project' }))
+        .filter((item) => item.status),
+      ...linkedIssuesFor(workPackage, evidence.issues ?? [])
+        .flatMap((issue) => String(issue.state ?? 'OPEN').toUpperCase() === 'OPEN'
+          ? [{ status: 'planned', source: `GitHub issue #${issue.number}` }]
+          : []),
+      ...linkedPullRequestsFor(workPackage, evidence.pullRequests ?? [])
+        .flatMap((pullRequest) => {
+          const state = String(pullRequest.state ?? 'OPEN').toUpperCase();
+          if (pullRequest.mergedAt || state === 'MERGED') return [{ status: 'done', source: `GitHub pull request #${pullRequest.number}` }];
+          if (state === 'OPEN') return [{ status: 'implementation', source: `GitHub pull request #${pullRequest.number}` }];
+          return [];
+        }),
+    ],
+    openSpec: linkedOpenSpecChangesFor(workPackage, evidence.openSpec ?? [])
+      .map((change) => ({ status: statusForOpenSpecChange(change), source: `OpenSpec change ${change.id}` })),
+    snapshot: [{ status: workPackage.status, source: 'project-status.json' }],
+  };
+
+  for (const tier of sourceTier) {
+    const values = observations[tier.key];
+    if (values.length === 0) continue;
+    const statuses = [...new Set(values.map((value) => value.status))].sort();
+    if (statuses.length > 1) {
+      const sources = [...new Set(values.map((value) => value.source))];
+      return {
+        conflict: {
+          workPackageId: workPackage.id,
+          source: sources.length === 1 ? sources[0] : tier.name,
+          field: 'status',
+          values: statuses.map((status) => status[0].toUpperCase() + status.slice(1)),
+        },
+      };
+    }
+    return { status: statuses[0], source: [...new Set(values.map((value) => value.source))].sort().join(', ') };
+  }
+  return {};
+};
+
+export const reconcileEvidence = (evidence) => {
+  const { projectStatus } = evidence;
+  const report = structuredClone(projectStatus);
+  const conflicts = [];
+
+  for (const milestone of report.milestones) {
+    for (const workPackage of milestone.workPackages) {
+      const resolution = resolveStatus(workPackage, evidence);
+      if (resolution.conflict) {
+        conflicts.push(resolution.conflict);
+        continue;
+      }
+      if (resolution.status) {
+        workPackage.status = resolution.status;
+        workPackage.source = resolution.source;
+      }
+      const decision = (evidence.decisions ?? []).find((candidate) => candidate.workPackageId === workPackage.id);
+      if (decision?.priority) workPackage.priority = decision.priority;
+    }
+  }
+
+  return { report, conflicts };
+};
+
+export const rankWorkPackages = (report, { limit = 5, today = new Date().toISOString().slice(0, 10) } = {}) => {
+  const workPackages = report.milestones.flatMap((milestone) => milestone.workPackages.map((workPackage) => ({
+    ...workPackage,
+    deadline: parseDeadline(milestone.title),
+  })));
+  const byId = new Map(workPackages.map((workPackage) => [workPackage.id, workPackage]));
+  const remaining = workPackages.filter((workPackage) => workPackage.status !== 'done');
+
+  const priorities = remaining.map((workPackage) => {
+    const incompleteDependencies = (workPackage.dependsOn ?? [])
+      .filter((dependencyId) => byId.get(dependencyId)?.status !== 'done');
+    const dependencyState = incompleteDependencies.length === 0
+      ? 'ready'
+      : `blocked by ${incompleteDependencies.join(', ')}`;
+    const dependentCount = remaining.filter((candidate) => candidate.dependsOn?.includes(workPackage.id)).length;
+
+    return {
+      workPackageId: workPackage.id,
+      title: workPackage.title,
+      priority: workPackage.priority ?? 'unclassified',
+      status: workPackage.status,
+      health: workPackage.health ?? 'on_track',
+      deadline: workPackage.deadline,
+      dependencyState,
+      source: workPackage.source ?? 'project-status.json',
+      rationale: rationaleFor(workPackage, dependencyState, dependentCount, workPackage.deadline),
+      priorityWeight: priorityWeight[workPackage.priority] ?? Number.MAX_SAFE_INTEGER,
+      readinessWeight: dependencyState === 'ready' ? 0 : 1,
+      healthWeight: healthWeight[workPackage.health] ?? 0,
+      dependentCount,
+    };
+  }).sort((left, right) => left.priorityWeight - right.priorityWeight
+    || left.readinessWeight - right.readinessWeight
+    || right.healthWeight - left.healthWeight
+    || compareDeadline(left, right)
+    || right.dependentCount - left.dependentCount
+    || left.workPackageId.localeCompare(right.workPackageId))
+    .slice(0, limit)
+    .map(({ priorityWeight: _priorityWeight, readinessWeight: _readinessWeight, healthWeight: _healthWeight, dependentCount: _dependentCount, ...priority }) => priority);
+
+  return { generatedAt: today, priorities };
+};
+
+export const rankEvidence = (evidence, options = {}) => {
+  const { report, conflicts } = reconcileEvidence(evidence);
+  const conflictedWorkPackages = new Set(conflicts.map((conflict) => conflict.workPackageId));
+  const actionableReport = structuredClone(report);
+  for (const milestone of actionableReport.milestones) {
+    milestone.workPackages = milestone.workPackages
+      .filter((workPackage) => !conflictedWorkPackages.has(workPackage.id));
+  }
+  return { ...rankWorkPackages(actionableReport, options), conflicts };
+};
+
+export const renderPriorityMarkdown = ({ generatedAt, priorities, conflicts = [] }) => [
+  `# Next Priorities (${generatedAt})`,
+  '',
+  ...priorities.flatMap((priority, index) => [
+    `## ${index + 1}. ${priority.workPackageId}: ${priority.title}`,
+    '',
+    `- Strategic priority: ${priority.priority}`,
+    `- Status: ${priority.status}; health: ${priority.health}`,
+    `- Dependency state: ${priority.dependencyState}`,
+    `- Source: ${priority.source}`,
+    ...priority.rationale.map((reason) => `- ${reason}`),
+    '',
+  ]),
+  ...(conflicts.length === 0 ? [] : [
+    '## Conflicts',
+    '',
+    ...conflicts.map((conflict) => `- ${conflict.workPackageId}: ${conflict.source} ${conflict.field} conflicts (${conflict.values.join(', ')}). No plan update.`),
+    '',
+  ]),
+].join('\n');
+
+const sanitizeMinuteText = (value) => String(value)
+  .replace(/(?:password|token|api(?:[- ]?key)?|secret)\s*[:=]\s*[^;\s]+/gi, '[REDACTED_SECRET]')
+  .replace(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi, '[REDACTED_EMAIL]');
+
+const listSection = (heading, entries) => entries.length === 0
+  ? []
+  : [
+    `## ${heading}`,
+    '',
+    ...entries.map((entry) => `- ${sanitizeMinuteText(entry)}`),
+    '',
+  ];
+
+export const renderMeetingMinutes = ({
+  date,
+  topic,
+  decisions = [],
+  actions = [],
+  risks = [],
+  sources = [],
+}) => [
+  `# Meeting Minutes: ${sanitizeMinuteText(topic)}`,
+  '',
+  `- Date: ${date}`,
+  '',
+  ...listSection('Decisions', decisions),
+  ...listSection('Actions', actions.map((action) => [
+    action.description,
+    action.owner ? `Owner: ${action.owner}` : undefined,
+    action.due ? `Due: ${action.due}` : undefined,
+  ].filter(Boolean).join(' — '))),
+  ...listSection('Risks', risks),
+  ...listSection('Sources', sources),
+].join('\n');
+
+const argumentValue = (name, fallback) => {
+  const index = process.argv.indexOf(name);
+  return index === -1 ? fallback : process.argv[index + 1];
+};
+
+const isMainModule = process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (isMainModule) {
+  const repositoryRoot = resolve(fileURLToPath(new URL('../../..', import.meta.url)));
+  const reportPath = argumentValue('--report', resolve(repositoryRoot, 'apps/project-report/src/data/project-status.json'));
+  const format = argumentValue('--format', 'json');
+  const options = {
+    limit: Number(argumentValue('--limit', '5')),
+    today: argumentValue('--today', new Date().toISOString().slice(0, 10)),
+  };
+  const result = process.argv.includes('--live')
+    ? rankEvidence(collectEvidence({ repositoryRoot, reportPath }), options)
+    : rankWorkPackages(JSON.parse(readFileSync(reportPath, 'utf8')), options);
+  console.log(format === 'markdown' ? renderPriorityMarkdown(result) : JSON.stringify(result, null, 2));
+}

--- a/plugins/project-steward/scripts/priority-report.test.mjs
+++ b/plugins/project-steward/scripts/priority-report.test.mjs
@@ -1,0 +1,243 @@
+import { describe, expect, it } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { resolve } from 'node:path';
+import {
+  rankEvidence,
+  rankWorkPackages,
+  renderMeetingMinutes,
+  renderPriorityMarkdown,
+} from './priority-report.mjs';
+
+const report = () => ({
+  milestones: [
+    {
+      id: 'M1',
+      title: 'Foundation (Deadline: 15.09.2026)',
+      workPackages: [
+        {
+          id: 'WP-001',
+          title: 'Secure the service boundary',
+          priority: 'must',
+          status: 'planned',
+          health: 'at_risk',
+          dependsOn: [],
+        },
+        {
+          id: 'WP-002',
+          title: 'Complete dependent conversation flow',
+          priority: 'must',
+          status: 'planned',
+          health: 'on_track',
+          dependsOn: ['WP-001'],
+        },
+        {
+          id: 'WP-003',
+          title: 'Already delivered improvement',
+          priority: 'must',
+          status: 'done',
+          health: 'on_track',
+          dependsOn: [],
+        },
+      ],
+    },
+  ],
+});
+
+describe('rankWorkPackages', () => {
+  it('puts an at-risk must-have dependency before its blocked dependent', () => {
+    const result = rankWorkPackages(report(), { limit: 3, today: '2026-08-30' });
+
+    expect(result.priorities).toMatchObject([
+      {
+        workPackageId: 'WP-001',
+        priority: 'must',
+        dependencyState: 'ready',
+        source: 'project-status.json',
+      },
+      {
+        workPackageId: 'WP-002',
+        dependencyState: 'blocked by WP-001',
+      },
+    ]);
+    expect(result.priorities.map((item) => item.workPackageId)).not.toContain('WP-003');
+  });
+
+  it('loads the repository status snapshot when invoked as a CLI', () => {
+    const scriptPath = resolve('plugins/project-steward/scripts/priority-report.mjs');
+    const output = execFileSync('node', [scriptPath, '--limit', '1', '--today', '2026-08-30'], {
+      encoding: 'utf8',
+    });
+
+    expect(JSON.parse(output)).toMatchObject({
+      generatedAt: '2026-08-30',
+      priorities: [{ source: 'project-status.json' }],
+    });
+  });
+
+  it('uses uncontested GitHub Project status over a stale snapshot', () => {
+    const result = rankEvidence({
+      projectStatus: report(),
+      projectItems: { items: [{
+        status: 'Done',
+        health: 'On track',
+        content: { number: 1 },
+        'work Package': 'WP-001',
+      }] },
+    }, { limit: 3, today: '2026-08-30' });
+
+    expect(result.priorities.map((item) => item.workPackageId)).not.toContain('WP-001');
+    expect(result.conflicts).toEqual([]);
+  });
+
+  it('uses linked GitHub issue evidence before OpenSpec and the status snapshot', () => {
+    const projectStatus = report();
+    projectStatus.milestones[0].workPackages[0].status = 'done';
+    projectStatus.milestones[0].workPackages[0].tracking = {
+      githubIssues: [42],
+      openSpecChanges: ['secure-boundary'],
+    };
+
+    const result = rankEvidence({
+      projectStatus,
+      issues: [{ number: 42, state: 'OPEN' }],
+      openSpec: [{
+        id: 'secure-boundary',
+        taskStatus: { total: 2, completed: 2 },
+      }],
+    }, { limit: 3, today: '2026-08-30' });
+
+    expect(result.priorities[0]).toMatchObject({
+      workPackageId: 'WP-001',
+      status: 'planned',
+      source: 'GitHub issue #42',
+    });
+  });
+
+  it('uses a linked open pull request as current implementation evidence', () => {
+    const projectStatus = report();
+    projectStatus.milestones[0].workPackages[0].tracking = { githubPullRequests: [99] };
+
+    const result = rankEvidence({
+      projectStatus,
+      pullRequests: [{ number: 99, state: 'OPEN', title: 'Implement the boundary' }],
+    }, { limit: 3, today: '2026-08-30' });
+
+    expect(result.priorities[0]).toMatchObject({
+      workPackageId: 'WP-001',
+      status: 'implementation',
+      source: 'GitHub pull request #99',
+    });
+  });
+
+  it('does not treat a closed issue as completion evidence', () => {
+    const projectStatus = report();
+    projectStatus.milestones[0].workPackages[0].tracking = { githubIssues: [42] };
+
+    const result = rankEvidence({
+      projectStatus,
+      issues: [{ number: 42, state: 'CLOSED' }],
+    }, { limit: 3, today: '2026-08-30' });
+
+    expect(result.priorities[0]).toMatchObject({
+      workPackageId: 'WP-001',
+      status: 'planned',
+      source: 'project-status.json',
+    });
+  });
+
+  it('uses linked OpenSpec task progress before the status snapshot', () => {
+    const projectStatus = report();
+    projectStatus.milestones[0].workPackages[0].status = 'planned';
+    projectStatus.milestones[0].workPackages[0].tracking = {
+      openSpecChanges: ['secure-boundary'],
+    };
+
+    const result = rankEvidence({
+      projectStatus,
+      openSpec: [{
+        id: 'secure-boundary',
+        taskStatus: { total: 2, completed: 1 },
+      }],
+    }, { limit: 3, today: '2026-08-30' });
+
+    expect(result.priorities[0]).toMatchObject({
+      workPackageId: 'WP-001',
+      status: 'implementation',
+      source: 'OpenSpec change secure-boundary',
+    });
+  });
+
+  it('uses a documented decision before conflicting current GitHub evidence', () => {
+    const projectStatus = report();
+    projectStatus.milestones[0].workPackages[0].tracking = { githubIssues: [42] };
+
+    const result = rankEvidence({
+      projectStatus,
+      decisions: [{ workPackageId: 'WP-001', status: 'done' }],
+      issues: [{ number: 42, state: 'OPEN' }],
+    }, { limit: 3, today: '2026-08-30' });
+
+    expect(result.priorities.map((item) => item.workPackageId)).not.toContain('WP-001');
+    expect(result.conflicts).toEqual([]);
+  });
+
+  it('reports conflicting GitHub Project status instead of silently ranking it', () => {
+    const result = rankEvidence({
+      projectStatus: report(),
+      projectItems: { items: [
+        { status: 'Planned', health: 'On track', 'work Package': 'WP-001' },
+        { status: 'Done', health: 'On track', 'work Package': 'WP-001' },
+      ] },
+    }, { limit: 3, today: '2026-08-30' });
+
+    expect(result.conflicts).toEqual([{
+      workPackageId: 'WP-001',
+      source: 'GitHub Project',
+      field: 'status',
+      values: ['Done', 'Planned'],
+    }]);
+    expect(result.priorities.map((item) => item.workPackageId)).not.toContain('WP-001');
+    expect(renderPriorityMarkdown(result)).toContain('## Conflicts');
+    expect(renderPriorityMarkdown(result)).toContain('WP-001: GitHub Project status conflicts (Done, Planned). No plan update.');
+  });
+
+  it('reports conflicting GitHub source evidence rather than selecting a status', () => {
+    const projectStatus = report();
+    projectStatus.milestones[0].workPackages[0].tracking = { githubIssues: [42] };
+    const result = rankEvidence({
+      projectStatus,
+      issues: [{ number: 42, state: 'OPEN' }],
+      projectItems: { items: [{ status: 'Done', 'work Package': 'WP-001' }] },
+    }, { limit: 3, today: '2026-08-30' });
+
+    expect(result.conflicts).toEqual([{
+      workPackageId: 'WP-001',
+      source: 'GitHub evidence',
+      field: 'status',
+      values: ['Done', 'Planned'],
+    }]);
+    expect(result.priorities.map((item) => item.workPackageId)).not.toContain('WP-001');
+  });
+
+  it('renders decisions and actions without retaining raw sensitive notes', () => {
+    const secretLabel = ['pass', 'word'].join('');
+    const minutes = renderMeetingMinutes({
+      date: '2026-08-30',
+      topic: 'Production recovery',
+      decisions: [`Create a recovery test issue. ${secretLabel}: do-not-retain; contact alex@example.com.`],
+      actions: [{ description: 'Run the recovery exercise.', owner: 'Operations', due: '2026-09-05' }],
+      risks: ['Recovery evidence is incomplete.'],
+      sources: ['Meeting notes, 2026-08-30'],
+      rawNotes: 'Sensitive transcript detail: do-not-retain',
+    });
+
+    expect(minutes).toContain('# Meeting Minutes: Production recovery');
+    expect(minutes).toContain('Create a recovery test issue.');
+    expect(minutes).toContain('Operations');
+    expect(minutes).toContain('2026-09-05');
+    expect(minutes).not.toContain('do-not-retain');
+    expect(minutes).not.toContain('alex@example.com');
+    expect(minutes).toContain('[REDACTED_SECRET]');
+    expect(minutes).toContain('[REDACTED_EMAIL]');
+  });
+});

--- a/plugins/project-steward/skills/project-steward/SKILL.md
+++ b/plugins/project-steward/skills/project-steward/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: project-steward
+description: Use when prioritizing Smart Speech Flow delivery work, reconciling its plan with GitHub and OpenSpec, reviewing a PR's delivery impact, or turning supplied meeting notes into follow-up actions.
+---
+
+# Project Steward
+
+Keep Smart Speech Flow moving toward reliable, accessible multilingual
+communication for public-administration staff and citizens. Ground every plan
+change in evidence; distinguish facts, inferences, and decisions needed.
+
+## Establish the current picture
+
+Read `AGENTS.md`, `openspec/project.md`, active OpenSpec changes,
+`apps/project-report/src/data/project-status.json`, `ROADMAP.md`, and relevant
+repository documentation. Refresh GitHub evidence before a write:
+
+```bash
+gh auth status
+node plugins/project-steward/scripts/priority-report.mjs --live --format markdown
+```
+
+Resolve sources in this order: documented project decisions, current GitHub
+issues and PRs, OpenSpec state, project-status snapshot, then roadmap. Report a
+same-precedence conflict; do not silently choose a status or update the plan
+until the conflict is resolved.
+
+## Define the next priorities
+
+Use the priority report as a starting point, then account for current GitHub
+evidence. Rank the next three to five actionable items by: must-have commitment
+and deadline; blocking dependency; security, privacy, and production risk;
+implementation readiness; then delivery value relative to effort and budget.
+
+For every item, state its work-package ID, evidence, dependency state, owner if
+known, next action, and why it comes now. You may update immediate work order
+and evidence-backed status. A strategic priority-class change needs its
+evidence, rationale, and delivery impact in both plan and minutes. Create a
+decision issue for an unresolved conflict.
+
+## GitHub workflows
+
+Read a pull request with `gh pr view <number>`, `gh pr diff <number>`, and
+`gh pr checks <number>`. Map findings to work packages, acceptance criteria,
+dependencies, and unresolved risks before changing plan status.
+
+Use `.github/ISSUE_TEMPLATE/` before `gh issue create`; link each issue to its
+work package and OpenSpec change. Use `gh issue edit` only for evidence-backed
+title, body, label, or tracking updates. Record the issue URL and evidence in
+the plan or meeting minutes.
+
+## Meeting minutes
+
+When supplied notes contain decisions or actions, read
+`references/meeting-minutes.md`. Create a concise English document at
+`docs/meeting-notes/YYYY-MM-DD-<topic>.md`. Retain decisions, actions, owners,
+deadlines, risks, and resulting GitHub/plan changes; omit raw transcripts,
+secrets, and unnecessary personal data.
+
+## Safe autonomy
+
+You may create and edit justified issues and update evidence-backed plan data.
+For local changes, create a dedicated `codex/project-steward-*` branch, validate
+the affected JSON/Markdown, commit only your files, and open a PR. Never delete
+content, close issues, merge or approve PRs, change permissions, or expose
+credentials. If GitHub authentication or the evidence is insufficient, stop and
+report the missing condition.

--- a/plugins/project-steward/skills/project-steward/agents/openai.yaml
+++ b/plugins/project-steward/skills/project-steward/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Project Steward"
+  short_description: "Prioritize delivery and govern follow-ups"
+  default_prompt: "Use $project-steward to identify the next Smart Speech Flow delivery priorities."
+policy:
+  allow_implicit_invocation: true

--- a/plugins/project-steward/skills/project-steward/references/meeting-minutes.md
+++ b/plugins/project-steward/skills/project-steward/references/meeting-minutes.md
@@ -1,0 +1,33 @@
+# Meeting Minutes Format
+
+Create `docs/meeting-notes/YYYY-MM-DD-<topic>.md` in English. Use this shape:
+
+```markdown
+# Meeting Minutes: <topic>
+
+- Date: YYYY-MM-DD
+
+## Decisions
+
+- <decision and evidence>
+
+## Actions
+
+- <action> — Owner: <owner> — Due: YYYY-MM-DD
+
+## Risks
+
+- <risk and required mitigation or decision>
+
+## Sources
+
+- <meeting, issue, pull request, OpenSpec change, or plan reference>
+```
+
+Record an unassigned owner or unknown deadline as `Not specified`; do not
+invent either. Link created or edited issues and affected work packages in the
+appropriate action or source. Clearly record requested changes that were not
+applied because evidence or authorization was insufficient.
+
+Do not include a transcript, credentials, API keys, passwords, private contact
+details, or personal data that is not necessary to execute the action.


### PR DESCRIPTION
## Summary\n- add a repository-local Project Steward Codex plugin\n- reconcile decisions, GitHub Project/issues/PRs, OpenSpec, and the project snapshot before ranking work\n- provide privacy-minimizing meeting-minutes guidance and validation tests\n\n## Validation\n- apps/project-report/node_modules/.bin/vitest run plugins/project-steward/scripts/priority-report.test.mjs plugins/project-steward/scripts/evidence-collector.test.mjs\n- npm --prefix apps/project-report test\n- openspec validate add-project-steward-agent --strict\n- plugin and skill validation\n\nReplaces the implementation content of #235 without its unrelated history.