### PR TITLE
fix: permit legacy admin CORS preflight and align SSF contract

### DIFF
--- a/deploy/production/docker-compose.production.yml
+++ b/deploy/production/docker-compose.production.yml
@@ -146,7 +146,7 @@ services:
     - traefik.http.services.api_gateway.loadbalancer.passhostheader=true
     - traefik.http.middlewares.websocket-headers.headers.customrequestheaders.X-Forwarded-Proto=https
     restart: unless-stopped
-    image: ssf-backend-api_gateway:prod-d4d1feb
+    image: ssf-backend-api_gateway:prod-b888119
     pull_policy: never
   ollama:
     image: ollama/ollama@sha256:57f573b47f1f71ebb445789f279fe3e596a8beab182f7cf486db9205bad87c5a

--- a/deploy/production/known-good-images.lock
+++ b/deploy/production/known-good-images.lock
@@ -2,7 +2,7 @@
 # This lock is intentionally a human-readable audit record.  The canonical
 # Compose file is the executable source of truth and uses these references.
 service	image_id	immutable_reference
-api_gateway	sha256:3085764c2366f16120c7737fe3bbe9768db8d9fed85cf8750ce592742ff1bfa7	ssf-backend-api_gateway:prod-d4d1feb
+api_gateway	sha256:4bdd5f737bf99bef080e1880f7919106fc1f26d768b96a833699eb7629527b27	ssf-backend-api_gateway:prod-b888119
 asr	sha256:ddf4fa94cf2b1a77e73a21b4a2774dab2a871f7e0b7be9f922443a8cf8e00e3d	ssf-backend-asr:prod-e409a06
 translation	sha256:ef77cc91908eded8e09bd13c799f459227a7cdb6292c6e9ef0c21b8df819d09f	ssf-backend-translation:prod-e409a06
 tts	sha256:19cab612eb39439c277d89865f2826ec226676fb34058648e92c64da5dff47e5	ssf-backend-tts:prod-e409a06

--- a/docs/architecture/sva-studio-control-plane.md
+++ b/docs/architecture/sva-studio-control-plane.md
@@ -14,8 +14,8 @@ support access are explicitly outside this initial scope.
 ## Deployment and Tenant Model
 
 One Studio deployment runs with exactly one SSF installation in the same server
-or deployment boundary. One logical Studio instance represents exactly one SSF
-tenant.
+or deployment boundary. A Studio deployment operates multiple logical tenants;
+each Studio tenant maps to exactly one SSF tenant.
 
 ```text
 SSF server or deployment
@@ -23,6 +23,8 @@ SSF server or deployment
 ├── SSF Keycloak
 ├── SVA Studio
 └── PostgreSQL database of the SSF plugin
+    ├── Studio tenant / SSF tenant A
+    └── Studio tenant / SSF tenant B
 ```
 
 The shared deployment boundary does not remove system boundaries. Studio and
@@ -37,9 +39,9 @@ SSF business roles and Studio technical roles remain distinct:
 | SSF business role | Technical Studio mapping |
 | --- | --- |
 | `system_admin` | Root scope with `instance_registry_admin` |
-| `tenant_admin` | Tenant-local Studio `system_admin` in the realm of the Studio instance |
-| `admin` | Tenant-local user with selected `ssf.*` permissions |
-| `customer` | No regular Studio identity; access through a restricted SSF session |
+| `tenant_admin` | Tenant-local Studio `system_admin` in the realm of the Studio tenant |
+| `user` | Tenant-local user with selected `ssf.*` permissions |
+| `guest` | No regular Studio identity; access through a restricted SSF session |
 
 The root system administrator creates a tenant and its initial tenant
 administrator. The tenant administrator then manages users and roles in its
@@ -127,7 +129,8 @@ The SSF plugin owns one PostgreSQL database per SSF installation. It contains
 both installation-wide and tenant-specific configuration. The Studio Core
 knows no SSF tables or domain fields.
 
-Tenant records use the canonical Studio `instanceId` as their tenant key.
+Tenant records use the canonical Studio `tenant_id` as their tenant key;
+`studio_instance_id` identifies only the enclosing Studio deployment.
 Tenant access is bound server-side to this context and secured with row-level
 security. Root access follows a separate, explicitly authorised database path.
 Migrations, repositories, and schema ownership belong to the SSF plugin.
@@ -142,22 +145,24 @@ references to SSF.
 
 ## Internal API Between SSF and Studio
 
-SSF determines the tenant from a valid session token or Keycloak login. The SSF
-backend then calls the internal Studio API with its own service identity and a
-short-lived signed tenant assertion. A freely supplied `instanceId` is not a
-trust boundary.
+SSF determines the tenant from a valid session token, Keycloak login, or
+server-resolved guest-join credential. The SSF backend then calls the internal
+Studio API with its own Client-Credentials service identity and an
+`X-Tenant-Id` header. A freely supplied tenant or instance ID is not a trust
+boundary.
 
-The Studio host validates the technical identity, audience, validity,
-replay protection, and tenant binding before invoking the SSF plugin handler in
-the bound tenant context. Browsers receive neither database credentials nor
-direct access to this internal API.
+The Studio host validates the technical identity, configured audience, validity,
+and `ssf.runtime-configuration.read` permission before invoking the SSF plugin
+handler in the bound tenant context. V1 does not require a second signed tenant
+assertion or replay protection for this read-only internal request. Browsers
+receive neither database credentials nor direct access to this internal API.
 
 ## First Delivery Runtime Flows
 
 ### Create a tenant
 
 ```text
-Root system administrator creates a Studio instance
+Root system administrator creates a Studio tenant
     → Core provisions tenant realm and separate OIDC clients
     → Core creates the initial tenant administrator
     → Core activates the installed automatic SSF plugin

--- a/docs/superpowers/specs/2026-08-31-studio-ssf-runtime-configuration-contract-v1-design.md
+++ b/docs/superpowers/specs/2026-08-31-studio-ssf-runtime-configuration-contract-v1-design.md
@@ -1,0 +1,254 @@
+# Studio--SSF Runtime Configuration Contract V1
+
+## Status and purpose
+
+This is the implementation-ready revision of the Studio--SSF runtime
+configuration contract. It replaces the previous draft before either system
+implements the interface. The API major version and schema value remain V1
+and `1.0` respectively.
+
+The contract covers a Studio installation that operates several tenants and
+the matching multi-tenant SSF installation. It defines the configuration read
+API and the SSF rules needed to apply it safely. Analytics, billing, support
+access, ClickHouse, Studio user lists, and an SSF tenant-administration UI are
+out of scope.
+
+## Terms and ownership
+
+- `studio_instance_id` identifies a Studio installation. It is contextual
+  metadata and MUST NOT be used as an SSF data-access boundary.
+- `tenant_id` identifies one stable Studio tenant and exactly one SSF tenant.
+  It is the canonical tenant identifier for this contract.
+- Studio Core owns tenant records, tenant lifecycle, Keycloak provisioning,
+  user accounts, policies, media, configuration, readiness, and audit.
+- The Studio SSF plugin owns resolution of server-wide, tenant-specific, and
+  product-default configuration values.
+- SSF owns authentication enforcement, guest sessions, conversation flow,
+  and SSF runtime/session/conversation data.
+
+Studio and SSF MUST NOT share an application database or access each other's
+persistence directly. SSF MUST NOT persist a Studio runtime-configuration
+response.
+
+## Identities and authorization
+
+Each regular SSF account belongs to exactly one tenant. Each login produces a
+token for exactly that tenant; people requiring access to several tenants use
+separate accounts and log in separately. A tenant-user token contains at least
+the following signed claims in addition to standard OIDC claims:
+
+```json
+{
+  "sub": "keycloak-user-id",
+  "studio_instance_id": "01J...",
+  "tenant_id": "01J...",
+  "ssf_roles": ["user"],
+  "ssf_permissions": ["ssf.sessions.create"],
+  "preferred_username": "erika",
+  "name": "Erika Muster",
+  "locale": "de-DE"
+}
+```
+
+`ssf_permissions` are authoritative for server-side authorization.
+`ssf_roles` are for classification, navigation, and audit. The initial
+operational permission catalogue is:
+
+- `ssf.sessions.create`
+- `ssf.sessions.read`
+- `ssf.sessions.terminate`
+- `ssf.conversations.participate`
+
+The token roles are `system_admin`, `tenant_admin`, and `user`. A
+`tenant_admin` has no operational SSF conversation permissions unless it also
+has `user` and the corresponding permissions. A `system_admin` has no
+`tenant_id` and MUST NOT access tenant conversations or tenant data; tenant
+configuration and inspection remain Studio responsibilities.
+
+Guests receive neither a Studio account nor a regular Keycloak token. The
+existing SSF participant values `admin` and `customer` remain protocol values
+during the migration and are not token roles. Their internal renaming is a
+separate SSF change.
+
+## Tenant context and guest sessions
+
+SSF MUST derive `tenant_id` from a validated user token for every authenticated
+tenant operation. When a user creates a session, SSF MUST bind that tenant ID
+to the session permanently.
+
+Guests join without logging in. SSF issues both an eight-character, human-
+usable session code and a high-entropy, session-scoped join token embedded in
+the QR-code URL. Either is a full guest-join path. Resolving either credential
+MUST derive the tenant and session only from SSF server-side state; browsers
+MUST NOT submit or select a tenant. The short-code path MUST use
+cryptographically random codes, short session validity, rate limiting, and
+generic failure responses.
+
+Every SSF persisted data object and Redis key/path MUST be tenant-bound. Every
+resource lookup MUST additionally compare the tenant derived from the token or
+guest join credential with the tenant recorded for the resource. Missing or
+conflicting context MUST fail closed.
+
+## Runtime configuration API
+
+```http
+GET /internal/plugins/ssf/v1/runtime-configuration
+Authorization: Bearer <service-token>
+X-Tenant-Id: <tenant-id-derived-by-SSF>
+X-Correlation-Id: <correlation-id>
+```
+
+The endpoint is internal-network only and is callable only by the SSF backend.
+SSF uses a dedicated Keycloak client with Client Credentials. Its token MUST
+carry the configured audience and `ssf.runtime-configuration.read`. It is
+separate from browser and user clients. Studio treats `X-Tenant-Id` as a
+statement by the authenticated SSF backend. V1 requires neither a second
+tenant assertion, replay storage, nor mTLS.
+
+The successful response contains `contractVersion: "1.0"`,
+`configurationRevision`, tenant ID/display name/time zone, optional logo and
+icon, enabled BCP-47 languages and their texts, and the effective conversation
+storage policy. Studio returns fully resolved values only; policy origins and
+administrative fields are not exposed. The response MUST echo the requested
+tenant ID in `tenant.id`.
+
+```json
+{
+  "contractVersion": "1.0",
+  "configurationRevision": "sha256:...",
+  "tenant": {
+    "id": "01J...",
+    "displayName": "Example Municipality",
+    "timeZone": "Europe/Berlin"
+  },
+  "branding": {
+    "logo": { "url": "https://example.org/logo.png", "alternativeText": "Logo" },
+    "icon": { "url": "https://example.org/icon.png", "alternativeText": "Icon" }
+  },
+  "localization": {
+    "defaultLanguage": "de-DE",
+    "languages": [{
+      "language": "de-DE",
+      "authenticatedHomeExplanationHtml": "<p>...</p>",
+      "guestExplanationHtml": "<p>...</p>",
+      "conversationContentStorageQuestionHtml": "<p>...</p>"
+    }]
+  },
+  "conversationContentStorage": { "mode": "ask" }
+}
+```
+
+`branding.logo` and `branding.icon` MAY each be `null`. If the effective
+storage mode is `disabled`, `conversationContentStorageQuestionHtml` MUST be
+`null` for every language.
+
+`configurationRevision` is `sha256:` followed by SHA-256 over the RFC 8785
+JSON Canonicalization Scheme representation of the fully resolved configuration
+excluding `configurationRevision` itself.
+
+The effective value of every field and language is resolved independently:
+
+```text
+tenant customization
+  ?? server-wide customization
+  ?? product default shipped with the relevant software version
+```
+
+## Runtime use and tenant availability
+
+SSF MUST read runtime configuration when it renders an authenticated or guest
+entry page and when it starts a session. It MUST re-read the current storage
+policy before every operation that would persist conversation content. SSF MAY
+keep the configuration already delivered to a browser as a presentation
+snapshot for the current active session, but MUST NOT persist it.
+
+Studio returns `409` when a tenant is inactive, suspended, the plugin is
+inactive, or the tenant is not ready. SSF MUST then neither start a session nor
+accept persistent conversation processing for that tenant. If runtime
+configuration is unavailable at a policy check, SSF MUST fail closed for
+persistence. An already active conversation MAY continue with transient
+processing only.
+
+## Languages, texts, and branding
+
+All external language values in this contract MUST use BCP-47 language tags,
+including enabled languages, default language, text variants, session language
+selection, and SSF API data. SSF displays only the enabled languages from
+Studio. Mapping a BCP-47 value to an ASR, translation, or TTS provider code is
+an SSF-internal implementation detail. V1 does not require server-side denial
+of a pipeline language code that is called outside the UI.
+
+For every enabled language Studio returns the authenticated-home explanation,
+guest explanation, and, when applicable, conversation-storage question. The
+default language MUST be enabled. At least one language MUST remain enabled.
+Existing tenant overrides MAY remain stored while their language is disabled.
+
+Studio is the security boundary for these HTML fields and MUST sanitize active
+or executable content, event handlers, and dangerous URL schemes. In V1 SSF
+may render the Studio-provided HTML as trusted content; independent SSF
+sanitization is deferred hardening. Branding logo and icon are optional and
+may be `null`.
+
+## Studio policy and write boundary
+
+Studio system administrators manage `customBrandingAllowed` and
+`conversationContentStorageAllowed` for every tenant, as well as server-wide
+values. Tenant administrators manage enabled languages, default language,
+individual text overrides, their desired storage mode, and branding only when
+custom branding is permitted. Users and guests cannot change configuration.
+
+If custom branding is withdrawn, the tenant's stored branding selection remains
+stored but is no longer effective. If conversation-content storage is not
+allowed, the effective mode returned to SSF is always `disabled`; a tenant's
+different stored selection has no effect. A successful Studio change is active
+immediately: ordinary branding, text, and language changes appear on the next
+entry-page load or new session, while tenant availability and the effective
+storage prohibition apply to subsequent protected operations.
+
+## Conversation content and consent
+
+The effective storage mode is `ask` or `disabled`. With `ask`, SSF presents the
+localized question to the guest before activating the session. The guest's
+choice is stored only as a minimal, content-free session consent status.
+
+If the guest declines, the conversation MAY proceed, but SSF MUST process
+content only transiently for the live translation. It MUST NOT persist audio,
+messages, transcripts, translations, or other derived conversation content.
+`disabled` has the same no-persistence behaviour but does not ask the guest;
+the tenant policy determines it. Thus `disabled` does not prohibit the
+transient processing strictly necessary to provide the live conversation.
+
+Content covered by this prohibition MUST NOT be persisted indirectly in SSF
+logs, error details, or audit records. SSF's broader internal logging policy
+is outside this integration contract.
+
+## Errors, audit, and evolution
+
+Runtime errors use the stable `contractVersion` and `error` envelope with a
+machine-readable `code`, generic `message`, boolean `retryable`, and
+`correlationId`. `401` and `403` apply to the service client, `404` to an
+unknown tenant, `409` to unavailable tenant states, and `503` to temporary
+runtime-configuration unavailability. Responses MUST NOT disclose secrets,
+internal persistence details, or data of another tenant.
+
+Studio durably audits configuration and policy changes. Normal runtime reads
+produce only technical metrics and structured logs. `X-Correlation-Id` links
+diagnostics between Studio and SSF.
+
+The API major version is in the path. Backward-compatible optional fields MAY
+be added within V1. SSF MUST ignore unknown fields and strictly validate known
+ones. A new required field, a removed field, or changed semantics requires a
+new major version. Studio and SSF MUST support at least one common major
+version during a transition.
+
+## Acceptance criteria for the accompanying OpenSpec work
+
+- Tokens, sessions, Redis paths, resource lookups, and WebSockets prove tenant
+  isolation with positive and cross-tenant negative tests.
+- A guest can join through either an eight-character code or a QR-code token
+  without a tenant identifier supplied by the browser.
+- Studio policy changes immediately prevent subsequent persistence, while a
+  declined or disabled session remains capable of transient live translation.
+- Runtime API validation covers service authentication, tenant state errors,
+  revision calculation, BCP-47 data, unknown optional fields, and all error
+  envelopes.

--- a/docs/superpowers/specs/2026-08-31-studio-ssf-runtime-configuration-contract-v1-design.md
+++ b/docs/superpowers/specs/2026-08-31-studio-ssf-runtime-configuration-contract-v1-design.md
@@ -209,7 +209,19 @@ storage prohibition apply to subsequent protected operations.
 
 The effective storage mode is `ask` or `disabled`. With `ask`, SSF presents the
 localized question to the guest before activating the session. The guest's
-choice is stored only as a minimal, content-free session consent status.
+choice is stored only as a minimal, content-free session consent status. The
+allowed status values are `pending`, `granted`, `declined`, and
+`policy_disabled`:
+
+- `pending` applies only while an `ask` session awaits the guest's answer and
+  permits no conversation-content persistence.
+- `granted` applies after an affirmative guest answer and permits persistence
+  of conversation content in accordance with the tenant's normal retention
+  policy.
+- `declined` applies after a negative guest answer and permits no
+  conversation-content persistence.
+- `policy_disabled` applies when the effective mode is `disabled` and permits
+  no conversation-content persistence.
 
 If the guest declines, the conversation MAY proceed, but SSF MUST process
 content only transiently for the live translation. It MUST NOT persist audio,

--- a/services/api_gateway/app.py
+++ b/services/api_gateway/app.py
@@ -329,6 +329,7 @@ def setup_cors_for_websockets():
             "Cache-Control",
             "Pragma",
             "X-Correlation-Id",
+            "X-SSF-Legacy-Access",
             # WebSocket-specific headers
             "Upgrade",
             "Connection",

--- a/services/api_gateway/tests/test_endpoints.py
+++ b/services/api_gateway/tests/test_endpoints.py
@@ -42,3 +42,20 @@ def test_cors_preflight_allows_correlation_id_from_customer_ui():
     assert (
         "x-correlation-id" in response.headers["access-control-allow-headers"].lower()
     )
+
+
+def test_cors_preflight_allows_legacy_admin_access_header():
+    response = client.options(
+        "/api/admin/session/create",
+        headers={
+            "Origin": "https://translate.smart-village.solutions",
+            "Access-Control-Request-Method": "POST",
+            "Access-Control-Request-Headers": "X-SSF-Legacy-Access",
+        },
+    )
+
+    assert response.status_code == 200
+    assert (
+        "x-ssf-legacy-access"
+        in response.headers["access-control-allow-headers"].lower()
+    )


### PR DESCRIPTION
## Description

Combines the already-prepared legacy admin CORS rollout with the approved Studio--SSF Runtime Configuration Contract V1 and updates the canonical control-plane architecture to match it.

## Type of Change

- [x] 🐛 Bug fix
- [x] 📝 Documentation update
- [x] 🔧 Build/CI configuration change

## Related Issues

Related to #266 and smart-village-solutions/sva-studio#1204.

## Changes Made

- Allow the temporary legacy admin access header in CORS preflight handling and roll out the corresponding known-good images.
- Add the reviewed Runtime Configuration Contract V1, including tenant IDs, guest join security, BCP-47, service-token access, and consent/storage rules.
- Align the target control-plane architecture with the multi-tenant model and the simplified read-only service-token boundary.

## Testing

- [x] All existing tests pass: `pytest -q` — 393 passed, 33 skipped.
- [x] Pre-commit checks pass.
- [x] Independent review completed; its two documentation findings were resolved and re-reviewed.

## Deployment Notes

- [x] Requires configuration changes

The CORS rollout uses the updated production image references. The runtime contract remains design-only; implementation is tracked in #266 and Studio #1204.