### PR TITLE
fix: keep the gateway and translation event loops free, under bounded admission control

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -84,6 +84,15 @@ MAX_CONCURRENT_PIPELINES=2
 
 # How long a request waits for a free pipeline slot before it is rejected with
 # 503 SYSTEM_BUSY and a Retry-After header (in seconds).
+#
+# Must exceed the p95 pipeline duration, and the default has not been measured
+# against real traffic yet. A slot is held for the whole round trip through ASR,
+# translation and TTS, so if a pipeline typically takes longer than this wait,
+# every request that arrives at saturation burns the full wait and is then
+# rejected — where before the bound existed it would have completed slowly.
+# Raise it from the gateway_pipeline_queue_wait_seconds histogram once there is
+# load-test data. Exactly 0 opts out of queueing and sheds immediately; a
+# negative value is treated as a typo and the default is used.
 PIPELINE_QUEUE_WAIT_SECONDS=10.0
 
 # Translation Inference Admission Control — the same bound one layer down, on
@@ -99,7 +108,13 @@ MAX_CONCURRENT_TRANSLATIONS=2
 # How long a translation request waits for a free inference slot before it is
 # rejected with 503 and a Retry-After header (in seconds). Deliberately below
 # the gateway's 30s HTTP timeout for /translate, so saturation surfaces as an
-# attributable error rather than a caller-side timeout.
+# attributable error rather than a caller-side timeout. Must likewise exceed the
+# p95 inference duration. Exactly 0 opts out of queueing and sheds immediately;
+# a negative value is treated as a typo and the default is used.
+#
+# An unparseable value in either translation setting is logged and ignored
+# rather than raised: both are read at import, before uvicorn binds, so a typo
+# would otherwise crash-loop the container instead of degrading to the default.
 TRANSLATION_QUEUE_WAIT_SECONDS=25.0
 
 # Rate Limiting Configuration

--- a/.env.example
+++ b/.env.example
@@ -86,6 +86,22 @@ MAX_CONCURRENT_PIPELINES=2
 # 503 SYSTEM_BUSY and a Retry-After header (in seconds).
 PIPELINE_QUEUE_WAIT_SECONDS=10.0
 
+# Translation Inference Admission Control — the same bound one layer down, on
+# the translation service itself. Inference runs on a worker thread so /health
+# and /metrics stay responsive during a beam search; this caps how many beam
+# searches reach the shared M2M100 instance at once. Watch translation_in_flight,
+# translation_queue_wait_seconds and translation_rejected_total on the service's
+# /metrics. Exactly 0 disables the bound; a negative value is rejected and the
+# default is used instead. Keep this at or above MAX_CONCURRENT_PIPELINES so the
+# gateway stays the system-level capacity boundary.
+MAX_CONCURRENT_TRANSLATIONS=2
+
+# How long a translation request waits for a free inference slot before it is
+# rejected with 503 and a Retry-After header (in seconds). Deliberately below
+# the gateway's 30s HTTP timeout for /translate, so saturation surfaces as an
+# attributable error rather than a caller-side timeout.
+TRANSLATION_QUEUE_WAIT_SECONDS=25.0
+
 # Rate Limiting Configuration
 # ----------------------------
 # Global rate limit (requests per window across all users)

--- a/.env.example
+++ b/.env.example
@@ -72,6 +72,20 @@ LLM_REFINEMENT_THINK=false
 # Maximum retries for failed LLM requests
 LLM_REFINEMENT_MAX_RETRIES=1
 
+# Pipeline Admission Control
+# ---------------------------
+# Bounds how many translation pipelines run at once. One GPU hosts asr,
+# translation and tts together, and each holds a single shared model, so the
+# default is deliberately low. Raise it from load-test evidence, watching
+# gateway_pipeline_in_flight, _queue_wait_seconds and _rejected_total on
+# /metrics. Exactly 0 disables the bound; a negative value is rejected and the
+# default is used instead.
+MAX_CONCURRENT_PIPELINES=2
+
+# How long a request waits for a free pipeline slot before it is rejected with
+# 503 SYSTEM_BUSY and a Retry-After header (in seconds).
+PIPELINE_QUEUE_WAIT_SECONDS=10.0
+
 # Rate Limiting Configuration
 # ----------------------------
 # Global rate limit (requests per window across all users)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -119,6 +119,13 @@ services:
       - LLM_REFINEMENT_TEMPERATURE=${LLM_REFINEMENT_TEMPERATURE:-0.7}
       - LLM_REFINEMENT_THINK=${LLM_REFINEMENT_THINK:-false}
       - LLM_REFINEMENT_MAX_RETRIES=${LLM_REFINEMENT_MAX_RETRIES:-1}
+      # Pipeline Admission Control — bounds concurrent GPU pipeline work.
+      # One GPU hosts asr, translation and tts together, so the default is
+      # deliberately low; raise it from load-test evidence and watch
+      # gateway_pipeline_in_flight / _queue_wait_seconds / _rejected_total.
+      # 0 disables the bound.
+      - MAX_CONCURRENT_PIPELINES=${MAX_CONCURRENT_PIPELINES:-2}
+      - PIPELINE_QUEUE_WAIT_SECONDS=${PIPELINE_QUEUE_WAIT_SECONDS:-10.0}
       # Rate Limiting Configuration für Produktion
       - GLOBAL_RATE_LIMIT=${GLOBAL_RATE_LIMIT:-1200}
       - GLOBAL_RATE_WINDOW_SECONDS=${GLOBAL_RATE_WINDOW_SECONDS:-60}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,13 @@ services:
       dockerfile: services/translation/Dockerfile
     ports:
       - "8002:8000"
+    environment:
+      # Inference Admission Control — inference runs off the event loop, so
+      # /health and /metrics stay responsive; these bound how many beam searches
+      # reach the shared M2M100 instance at once. Raise from load-test evidence
+      # using translation_queue_wait_seconds and translation_rejected_total.
+      - MAX_CONCURRENT_TRANSLATIONS=${MAX_CONCURRENT_TRANSLATIONS:-2}
+      - TRANSLATION_QUEUE_WAIT_SECONDS=${TRANSLATION_QUEUE_WAIT_SECONDS:-25.0}
     volumes:
       - ./models:/models
     deploy:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -264,6 +264,68 @@ paths:
           description: Invalid input (missing fields, invalid format, etc.)
         '404':
           description: Session not found
+        '503':
+          description: |
+            Translation pipeline at capacity. One GPU hosts ASR, translation and
+            TTS, so the number of concurrent pipelines is bounded. The request
+            was not processed and may be retried.
+
+            `detail.error_code` is the stable value `SYSTEM_BUSY`.
+
+            **Client handling.** Wait `Retry-After` seconds and resend the same
+            request; nothing was consumed. `details.retry_after_seconds` always
+            equals the header, so either may be used. Do not retry sooner, and
+            do not treat this as a permanent failure — unlike other 5xx
+            responses, retrying is expected to succeed.
+
+            The current SPA maps every 5xx to one generic error message without
+            reading this body, which is safe but tells the user less than it
+            could. Surfacing "busy, retrying shortly" is a possible improvement.
+          headers:
+            Retry-After:
+              description: Whole seconds to wait before retrying; never below 1.
+              schema:
+                type: integer
+                minimum: 1
+                example: 10
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: object
+                    properties:
+                      error_code:
+                        type: string
+                        enum: [SYSTEM_BUSY]
+                      error_message:
+                        type: string
+                        example: "The translation pipeline is at capacity. Please retry shortly."
+                      details:
+                        type: object
+                        properties:
+                          max_concurrent_pipelines:
+                            type: integer
+                            description: Configured concurrent pipeline limit.
+                            example: 2
+                          retry_after_seconds:
+                            type: integer
+                            description: >-
+                              Advised delay in whole seconds. Always identical to
+                              the Retry-After header.
+                            minimum: 1
+                            example: 10
+                          queue_wait_seconds:
+                            type: number
+                            description: >-
+                              Configured queue window, for diagnostics. Not an
+                              advised delay — use retry_after_seconds.
+                            example: 10.0
+                          waited_seconds:
+                            type: number
+                            description: How long this request actually queued.
+                            example: 10.001
         '500':
           description: Processing error
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -272,6 +272,13 @@ paths:
 
             `detail.error_code` is the stable value `SYSTEM_BUSY`.
 
+            Two layers can produce this response, and clients handle both the
+            same way. The gateway's own bound rejects before any work starts and
+            reports the full `details` below. A GPU service that shed the request
+            mid-pipeline is relayed instead, reporting `retry_after_seconds` and
+            `upstream_error` only — its `Retry-After` is the one that service
+            asked for. Treat every field in `details` as optional.
+
             **Client handling.** Wait `Retry-After` seconds and resend the same
             request; nothing was consumed. `details.retry_after_seconds` always
             equals the header, so either may be used. Do not retry sooner, and
@@ -326,6 +333,13 @@ paths:
                             type: number
                             description: How long this request actually queued.
                             example: 10.001
+                          upstream_error:
+                            type: string
+                            description: >-
+                              Present only when a GPU service shed the request
+                              mid-pipeline rather than the gateway rejecting it
+                              up front. Diagnostic; not for display.
+                            example: "Translation-Fehler: at capacity"
         '500':
           description: Processing error
 

--- a/openspec/changes/add-pipeline-admission-control/proposal.md
+++ b/openspec/changes/add-pipeline-admission-control/proposal.md
@@ -1,6 +1,6 @@
 # Change: Add bounded pipeline admission control and a SYSTEM_BUSY response
 
-Tracks: #191 (ships with #189)
+Tracks: #189, #190, #191 — the set #191 asks to ship together
 
 ## Why
 
@@ -15,6 +15,14 @@ instance with no lock of its own (`services/asr/app.py:132`,
 `services/tts/app.py:143`). Unbounded concurrency there means concurrent CUDA
 work on one shared model per service, competing for one card's memory.
 
+The translation service has the same defect one layer down (#190): its
+`async def translate` calls `_translate_texts` inline, so `m2m_model.generate()`
+holds that service's only loop thread for the whole beam search. Its `/health`
+and `/metrics` handlers are synchronous and would run in a threadpool, but the
+blocked loop never gets as far as accepting the connection. Fixing the gateway
+alone would leave translation as the real serialisation point, so raising
+`MAX_CONCURRENT_PIPELINES` would buy nothing.
+
 Clients also need an answer better than a timeout when the system is full.
 
 ## What Changes
@@ -28,6 +36,11 @@ Clients also need an answer better than a timeout when the system is full.
   `SYSTEM_BUSY` error code in the endpoint's existing error envelope.
 - Emit in-flight, queue-wait and rejection metrics so load tests can tune the
   limit.
+- Run translation inference on a worker thread and bound it the same way, with
+  `MAX_CONCURRENT_TRANSLATIONS` and `TRANSLATION_QUEUE_WAIT_SECONDS`, rejecting
+  saturation with `503` and `Retry-After`. The tokenizer lock that guards the
+  mutable `src_lang` becomes load-bearing here and is covered by a test that
+  proves mutual exclusion.
 - Document the consumer contract and the configuration.
 
 ## Impact
@@ -39,10 +52,22 @@ Clients also need an answer better than a timeout when the system is full.
   reading the response body, so a `503` already becomes `AppError('server')` and
   surfaces as `errors.server`. A dedicated `busy` kind is a possible follow-up,
   not part of this change.
+- Affected translation service: inference offloaded to a worker thread, a
+  lifespan-owned `TranslationAdmission`, and a `503` with `Retry-After` on
+  saturation.
 - Affected configuration: `MAX_CONCURRENT_PIPELINES` (default `2`),
-  `PIPELINE_QUEUE_WAIT_SECONDS` (default `10.0`).
+  `PIPELINE_QUEUE_WAIT_SECONDS` (default `10.0`),
+  `MAX_CONCURRENT_TRANSLATIONS` (default `2`),
+  `TRANSLATION_QUEUE_WAIT_SECONDS` (default `25.0`, under the gateway's 30s
+  timeout for `/translate`).
+- Also fixed, and not covered by any issue: the ASR, translation and TTS
+  Dockerfiles copy `services/gpu_metrics.py` but never
+  `services/resource_metrics.py`, which all three import at module level since
+  `1fb7f09`. As committed, those three images raise `ImportError` at startup;
+  production is only healthy because it runs an image built before that commit.
 - Not affected: cross-replica coordination. The bound is process-local; a
-  distributed queue and queue-position UX remain #227.
+  distributed queue and queue-position UX remain #227. ASR and TTS already
+  offload their inference and are left alone; neither is bounded yet.
 
 ## Open question for review
 

--- a/openspec/changes/add-pipeline-admission-control/proposal.md
+++ b/openspec/changes/add-pipeline-admission-control/proposal.md
@@ -1,0 +1,51 @@
+# Change: Add bounded pipeline admission control and a SYSTEM_BUSY response
+
+Tracks: #191 (ships with #189)
+
+## Why
+
+Until #189, the gateway called `process_wav` and `process_text_pipeline`
+synchronously from `async def` handlers, so its event loop serialised every
+pipeline. That accidental serialisation was the only thing protecting GPU
+capacity. Removing it removes the protection too.
+
+The hardware behind those calls is one RTX 4000 Ada that hosts ASR, translation
+and TTS at the same time, and each of those services holds a single shared model
+instance with no lock of its own (`services/asr/app.py:132`,
+`services/tts/app.py:143`). Unbounded concurrency there means concurrent CUDA
+work on one shared model per service, competing for one card's memory.
+
+Clients also need an answer better than a timeout when the system is full.
+
+## What Changes
+
+- Add a lifespan-owned `PipelineAdmission` component bounding in-flight
+  pipelines, with a configurable queue wait before rejection.
+- Apply the bound around the GPU call only, at all four call sites:
+  `POST /api/session/{id}/message` (audio and text), `POST /pipeline`,
+  `POST /upload`. Health, session-management and WebSocket traffic are untouched.
+- Reject saturation with `503`, a `Retry-After` header and a stable
+  `SYSTEM_BUSY` error code in the endpoint's existing error envelope.
+- Emit in-flight, queue-wait and rejection metrics so load tests can tune the
+  limit.
+- Document the consumer contract and the configuration.
+
+## Impact
+
+- Affected specs: `pipeline-admission-control` (new capability)
+- Affected API gateway: new `pipeline_admission` module, lifespan wiring,
+  the four pipeline call sites, and `upload()` gains a `request` parameter.
+- Affected frontend: **none.** `core/http/AppError.ts` maps status codes without
+  reading the response body, so a `503` already becomes `AppError('server')` and
+  surfaces as `errors.server`. A dedicated `busy` kind is a possible follow-up,
+  not part of this change.
+- Affected configuration: `MAX_CONCURRENT_PIPELINES` (default `2`),
+  `PIPELINE_QUEUE_WAIT_SECONDS` (default `10.0`).
+- Not affected: cross-replica coordination. The bound is process-local; a
+  distributed queue and queue-position UX remain #227.
+
+## Open question for review
+
+The default limit of `2` is inferred from the hardware, not measured — no
+pipeline throughput benchmark exists in the repository. The metrics in this
+change exist so the figure can be raised from evidence. `0` disables the bound.

--- a/openspec/changes/add-pipeline-admission-control/specs/pipeline-admission-control/spec.md
+++ b/openspec/changes/add-pipeline-admission-control/specs/pipeline-admission-control/spec.md
@@ -27,6 +27,26 @@ GPU pipeline work.
 - **WHEN** the pipeline raises an exception while holding a slot
 - **THEN** the gateway returns the slot before propagating the error
 
+### Requirement: Every slot is returned exactly once
+
+A slot SHALL be returned exactly once, whether or not the request that acquired
+it was cancelled, and SHALL NOT be returned while the work holding it is still
+running. Cancellation is the only case where ownership is ambiguous: a queued
+worker item is cancelled with the request, but one that has already started
+cannot be interrupted.
+
+#### Scenario: A request is cancelled after its work started
+
+- **WHEN** a client disconnects while its pipeline is executing on a worker thread
+- **THEN** the slot stays held until that thread finishes
+- **AND THEN** the slot is returned exactly once
+
+#### Scenario: A request is cancelled before its work started
+
+- **WHEN** a client disconnects while its work is still queued for a worker thread
+- **THEN** the slot is returned immediately
+- **AND THEN** the work is abandoned rather than executed without a slot
+
 ### Requirement: SYSTEM_BUSY rejection contract
 
 The API gateway SHALL reject a request with HTTP `503`, a `Retry-After` header
@@ -45,6 +65,14 @@ the endpoint's other failures.
 
 - **WHEN** the unified message endpoint rejects a request for capacity
 - **THEN** the response status is `503` and not `500`
+
+#### Scenario: An upstream service sheds the request instead
+
+- **WHEN** the translation service answers a pipeline step with `503`
+- **THEN** the audio endpoint responds `503` with `error_code` `SYSTEM_BUSY`, not `500`
+- **AND THEN** the text endpoint responds `503` with `error_code` `SYSTEM_BUSY`, not `400`
+- **AND THEN** the response carries a `Retry-After` header derived from the
+  upstream's own, so the client is not advised to retry sooner than the service asked
 
 #### Scenario: A legacy pipeline route is saturated
 
@@ -84,6 +112,17 @@ environment does not supply them.
 
 - **WHEN** an admission environment variable holds a non-numeric value
 - **THEN** the gateway logs a warning, applies the documented default, and starts
+
+#### Scenario: The queue wait is a negative value
+
+- **WHEN** a queue-wait variable is negative
+- **THEN** the service logs a warning and applies the documented default
+
+#### Scenario: Queueing is disabled
+
+- **WHEN** a queue-wait variable is exactly `0`
+- **THEN** a request is admitted immediately if a slot is free
+- **AND THEN** a request is rejected immediately, without waiting, if none is
 
 ### Requirement: Admission metrics
 
@@ -154,6 +193,20 @@ system-level capacity boundary.
 - **WHEN** `MAX_CONCURRENT_TRANSLATIONS` is negative
 - **THEN** the service logs a warning and applies the documented default rather
   than running unbounded
+
+#### Scenario: An admission setting cannot be parsed
+
+- **WHEN** `MAX_CONCURRENT_TRANSLATIONS` or `TRANSLATION_QUEUE_WAIT_SECONDS`
+  holds a non-numeric value
+- **THEN** the service logs a warning, applies the documented default and starts,
+  rather than raising before the server binds and crash-looping the container
+
+#### Scenario: An inference slot's owner is cancelled
+
+- **WHEN** a caller disconnects while its inference is running on a worker thread
+- **THEN** the slot stays held until that thread finishes
+- **WHEN** a caller disconnects while its inference is still queued
+- **THEN** the slot is returned immediately and the inference is abandoned
 
 #### Scenario: No inference slot frees within the wait period
 

--- a/openspec/changes/add-pipeline-admission-control/specs/pipeline-admission-control/spec.md
+++ b/openspec/changes/add-pipeline-admission-control/specs/pipeline-admission-control/spec.md
@@ -1,0 +1,117 @@
+## ADDED Requirements
+
+### Requirement: Bounded concurrent pipeline work
+
+The API gateway SHALL limit the number of translation pipelines executing
+concurrently to a configured maximum, and SHALL apply that limit only around
+GPU pipeline work.
+
+#### Scenario: Requests arrive within the limit
+
+- **WHEN** fewer pipelines are in flight than the configured maximum
+- **THEN** the gateway admits the request immediately
+- **AND THEN** the pipelines execute concurrently
+
+#### Scenario: A slot frees while a request is queued
+
+- **WHEN** a request is waiting and an in-flight pipeline completes
+- **THEN** the waiting request is admitted with the freed slot
+
+#### Scenario: The limit is disabled
+
+- **WHEN** `MAX_CONCURRENT_PIPELINES` is `0`
+- **THEN** the gateway admits every request without bounding concurrency
+
+#### Scenario: A pipeline fails inside its slot
+
+- **WHEN** the pipeline raises an exception while holding a slot
+- **THEN** the gateway returns the slot before propagating the error
+
+### Requirement: SYSTEM_BUSY rejection contract
+
+The API gateway SHALL reject a request with HTTP `503`, a `Retry-After` header
+and the error code `SYSTEM_BUSY` when no pipeline slot becomes available within
+the configured wait period. The response SHALL use the same error envelope as
+the endpoint's other failures.
+
+#### Scenario: No slot frees within the wait period
+
+- **WHEN** every slot is held for longer than `PIPELINE_QUEUE_WAIT_SECONDS`
+- **THEN** `POST /api/session/{session_id}/message` responds with status `503`
+- **AND THEN** the body carries `error_code` `SYSTEM_BUSY`
+- **AND THEN** the response carries a `Retry-After` header of at least `1` second
+
+#### Scenario: Rejection is not reported as an internal error
+
+- **WHEN** the unified message endpoint rejects a request for capacity
+- **THEN** the response status is `503` and not `500`
+
+#### Scenario: A legacy pipeline route is saturated
+
+- **WHEN** `POST /pipeline` or `POST /upload` finds no slot available
+- **THEN** the route responds with status `503` and a `Retry-After` header
+
+### Requirement: Non-pipeline endpoints stay responsive
+
+The API gateway SHALL serve health, session-management and WebSocket traffic
+without acquiring a pipeline slot, so saturation of the pipeline never blocks
+them.
+
+#### Scenario: Session management during saturation
+
+- **WHEN** every pipeline slot is held
+- **THEN** `GET /api/session/{session_id}` and `GET /api/sessions/active`
+  respond normally
+
+#### Scenario: Health checks during saturation
+
+- **WHEN** every pipeline slot is held
+- **THEN** `GET /health` responds normally
+
+### Requirement: Admission configuration
+
+The gateway SHALL read the concurrency limit and queue wait from typed,
+documented configuration, and SHALL start with documented defaults when the
+environment does not supply them.
+
+#### Scenario: Configuration is absent
+
+- **WHEN** neither `MAX_CONCURRENT_PIPELINES` nor `PIPELINE_QUEUE_WAIT_SECONDS`
+  is set
+- **THEN** the limit is `2` and the queue wait is `10.0` seconds
+
+#### Scenario: Configuration cannot be parsed
+
+- **WHEN** an admission environment variable holds a non-numeric value
+- **THEN** the gateway logs a warning, applies the documented default, and starts
+
+### Requirement: Admission metrics
+
+The gateway SHALL expose in-flight, queue-wait and rejection metrics for the
+pipeline bound so capacity can be tuned from load tests.
+
+#### Scenario: A pipeline occupies a slot
+
+- **WHEN** a pipeline holds a slot and then releases it
+- **THEN** `gateway_pipeline_in_flight` rises and falls accordingly
+- **AND THEN** `gateway_pipeline_queue_wait_seconds` records the wait
+
+#### Scenario: A request is rejected
+
+- **WHEN** the gateway rejects a request for capacity
+- **THEN** `gateway_pipeline_rejected_total` increases
+
+### Requirement: Lifespan ownership
+
+The admission component SHALL be created by the application lifespan and
+published on application state, not constructed at module import.
+
+#### Scenario: The application starts
+
+- **WHEN** the gateway completes lifespan startup
+- **THEN** `app.state.pipeline_admission` holds the admission component
+
+#### Scenario: A route runs without a started lifespan
+
+- **WHEN** a pipeline route is reached with no admission component available
+- **THEN** the route executes the pipeline unbounded rather than failing

--- a/openspec/changes/add-pipeline-admission-control/specs/pipeline-admission-control/spec.md
+++ b/openspec/changes/add-pipeline-admission-control/specs/pipeline-admission-control/spec.md
@@ -115,3 +115,73 @@ published on application state, not constructed at module import.
 
 - **WHEN** a pipeline route is reached with no admission component available
 - **THEN** the route executes the pipeline unbounded rather than failing
+
+### Requirement: Translation inference leaves its event loop free
+
+The translation service SHALL execute M2M100 inference off its event loop, so
+operational probes and further requests are served while a beam search runs.
+
+#### Scenario: A probe arrives during inference
+
+- **WHEN** `POST /translate` is executing `m2m_model.generate()`
+- **THEN** `GET /health` and `GET /metrics` respond normally
+
+#### Scenario: Two translations arrive together
+
+- **WHEN** two requests reach `POST /translate` within the configured limit
+- **THEN** both inferences make progress concurrently rather than serialising on
+  the event loop
+
+### Requirement: Bounded concurrent translation inference
+
+The translation service SHALL limit concurrent inference to a configured maximum,
+so the shared M2M100 instance and the GPU it sits on are not oversubscribed once
+inference no longer serialises on the event loop. The gateway bound remains the
+system-level capacity boundary.
+
+#### Scenario: Inference is bounded
+
+- **WHEN** more requests are in flight than `MAX_CONCURRENT_TRANSLATIONS`
+- **THEN** no more than that many inferences execute at once
+
+#### Scenario: The limit is disabled
+
+- **WHEN** `MAX_CONCURRENT_TRANSLATIONS` is `0`
+- **THEN** inference still runs off the event loop, without a bound
+
+#### Scenario: A negative limit is configured
+
+- **WHEN** `MAX_CONCURRENT_TRANSLATIONS` is negative
+- **THEN** the service logs a warning and applies the documented default rather
+  than running unbounded
+
+#### Scenario: No inference slot frees within the wait period
+
+- **WHEN** every slot is held for longer than `TRANSLATION_QUEUE_WAIT_SECONDS`
+- **THEN** `POST /translate` responds with status `503`
+- **AND THEN** the response carries a `Retry-After` header of at least `1` second
+- **AND THEN** the status is `503` and not `500`, despite the handler's broad
+  exception path
+
+### Requirement: Tokenizer safety under concurrency
+
+The translation service SHALL serialise the mutation of the tokenizer's
+`src_lang` and the encoding that depends on it, because the tokenizer is shared
+mutable state once inference runs on worker threads.
+
+#### Scenario: Two threads encode at once
+
+- **WHEN** two inferences run concurrently
+- **THEN** only one is inside the tokenizer's encode step at any moment
+
+### Requirement: Translation admission metrics
+
+The translation service SHALL expose in-flight, queue-wait and rejection metrics
+so its limit can be tuned from load tests.
+
+#### Scenario: A rejection occurs
+
+- **WHEN** a request is rejected for capacity
+- **THEN** `translation_rejected_total` increases
+- **AND THEN** `translation_queue_wait_seconds` records the wait it spent queued,
+  so the histogram is not blind at saturation

--- a/openspec/changes/add-pipeline-admission-control/tasks.md
+++ b/openspec/changes/add-pipeline-admission-control/tasks.md
@@ -87,10 +87,36 @@ Only tracked files count here: `LOCAL_SETUP.md` and `docs/frontend/` are in
   Dockerfiles. All three import it at module level since `1fb7f09` but none copy
   it, so the images cannot start; production runs a pre-`1fb7f09` image.
 
-## 7. Follow-ups (not this change)
+## 7. Review findings (PR #265)
 
-- [ ] 7.1 Raise `MAX_CONCURRENT_PIPELINES` and `MAX_CONCURRENT_TRANSLATIONS` from
-  load-test evidence.
-- [ ] 7.2 Optional `AppError` `busy` kind and a dedicated i18n message.
-- [ ] 7.3 Cross-replica admission (#227).
-- [ ] 7.4 Bound ASR and TTS inference, which already offload but are unbounded.
+- [x] 7.1 Return a slot when the awaiting task is cancelled before its worker
+  item starts. Releasing only from inside the thread lost the slot permanently,
+  since `to_thread` does cancel an item that is still queued; two aborted
+  uploads were enough to answer `SYSTEM_BUSY` until restart. A `_SlotClaim`
+  settles ownership under a lock, because the awaiting task resumes before the
+  worker executes its first line, so a plain flag can let both release.
+  Abandoned work is not executed: its slot is already gone.
+- [x] 7.2 Same fix in `TranslationAdmission.run`.
+- [x] 7.3 Treat a queue wait of exactly `0` as "do not queue" via a non-blocking
+  check. `asyncio.wait_for(..., timeout=0)` cancels the acquire before it runs,
+  so the setting rejected every request even on an idle service. Negative stays
+  a typo and falls back to the default, in both services.
+- [x] 7.4 Parse the translation admission settings through guarded `_env_int` /
+  `_env_float`, as the gateway already did. They are read at import, so a typo
+  raised before uvicorn bound and crash-looped the container.
+- [x] 7.5 Keep an upstream `503` retryable: mark it on the pipeline result and
+  answer `503 SYSTEM_BUSY` with the upstream's `Retry-After`, instead of `500`
+  on the audio path and `400` on the text path. Applied to the TTS steps too.
+- [x] 7.6 Read the queue wait once per rejection, so the histogram sample and
+  the `waited_seconds` in the body describe the same request.
+- [x] 7.7 Document that a queue wait must exceed p95 pipeline latency: a slot is
+  held for the whole round trip, so a shorter wait means a request arriving at
+  saturation can never be seated. Default left at `10.0` pending 8.1.
+
+## 8. Follow-ups (not this change)
+
+- [ ] 8.1 Raise `MAX_CONCURRENT_PIPELINES` and `MAX_CONCURRENT_TRANSLATIONS` from
+  load-test evidence, and set the queue waits from the measured p95.
+- [ ] 8.2 Optional `AppError` `busy` kind and a dedicated i18n message.
+- [ ] 8.3 Cross-replica admission (#227).
+- [ ] 8.4 Bound ASR and TTS inference, which already offload but are unbounded.

--- a/openspec/changes/add-pipeline-admission-control/tasks.md
+++ b/openspec/changes/add-pipeline-admission-control/tasks.md
@@ -60,8 +60,37 @@ Only tracked files count here: `LOCAL_SETUP.md` and `docs/frontend/` are in
   tuning guide in `LOCAL_SETUP.md` and the fuller narrative in
   `docs/frontend/API_CONTRACT.md`.
 
-## 5. Follow-ups (not this change)
+## 5. Translation service (#190)
 
-- [ ] 5.1 Raise `MAX_CONCURRENT_PIPELINES` from load-test evidence.
-- [ ] 5.2 Optional `AppError` `busy` kind and a dedicated i18n message.
-- [ ] 5.3 Cross-replica admission (#227).
+- [x] 5.1 Run `_translate_texts` on a worker thread so `m2m_model.generate()`
+  never holds the translation service's event loop.
+- [x] 5.2 Add a lifespan-owned `TranslationAdmission` bounding concurrent
+  inference, reading `MAX_CONCURRENT_TRANSLATIONS` (default `2`) and
+  `TRANSLATION_QUEUE_WAIT_SECONDS` (default `25.0`). Only an explicit `0`
+  disables; a negative limit falls back to the default.
+- [x] 5.3 Hold slots against the worker thread, as in task 1.4.
+- [x] 5.4 Reject saturation with `503` and `Retry-After`, ahead of the handler's
+  broad `except Exception` so it cannot surface as `500`. Register the response
+  in `TRANSLATION_ERROR_RESPONSES` so it reaches the generated schema.
+- [x] 5.5 Expose `translation_in_flight`, `translation_queue_wait_seconds` and
+  `translation_rejected_total`, observing the wait on the rejection path too.
+- [x] 5.6 Tests in `tests/`, not `services/translation/tests/`: CI runs
+  `pytest tests/` and `pytest.ini` pins `testpaths = tests`, so a guard placed
+  beside the service would never run.
+- [x] 5.7 Prove each guard fails: offload removed, tokenizer lock removed, slot
+  released by the awaiting task, busy clause removed, rejection unobserved.
+- [x] 5.8 Document both settings in `.env.example` and `docker-compose.yml`.
+
+## 6. Deployment defect found on the way (no issue)
+
+- [x] 6.1 Add `COPY services/resource_metrics.py` to the ASR, translation and TTS
+  Dockerfiles. All three import it at module level since `1fb7f09` but none copy
+  it, so the images cannot start; production runs a pre-`1fb7f09` image.
+
+## 7. Follow-ups (not this change)
+
+- [ ] 7.1 Raise `MAX_CONCURRENT_PIPELINES` and `MAX_CONCURRENT_TRANSLATIONS` from
+  load-test evidence.
+- [ ] 7.2 Optional `AppError` `busy` kind and a dedicated i18n message.
+- [ ] 7.3 Cross-replica admission (#227).
+- [ ] 7.4 Bound ASR and TTS inference, which already offload but are unbounded.

--- a/openspec/changes/add-pipeline-admission-control/tasks.md
+++ b/openspec/changes/add-pipeline-admission-control/tasks.md
@@ -1,0 +1,67 @@
+# Tasks
+
+## 1. Admission component
+
+- [x] 1.1 Add `services/api_gateway/pipeline_admission.py` with
+  `PipelineAdmissionConfig`, `PipelineAdmissionMetrics`, `PipelineAdmission`,
+  `PipelineBusyError` and the `run_pipeline` request helper.
+- [x] 1.2 Read `MAX_CONCURRENT_PIPELINES` and `PIPELINE_QUEUE_WAIT_SECONDS` per
+  instance, falling back to documented defaults on unparseable or negative
+  input. Only an explicit `0` disables the bound.
+- [x] 1.3 Register the in-flight, queue-wait and rejection series once per
+  process against the gateway registry. Observe the queue wait on the rejection
+  path as well, so the histogram is not blind at saturation.
+- [x] 1.4 Hold slots against the worker thread's lifetime, not the awaiting
+  task: `run()` releases from inside the thread, because `asyncio.to_thread`
+  cannot interrupt a running call and a cancelled request must not hand its
+  capacity to the next caller.
+
+## 2. Wiring
+
+- [x] 2.1 Create the component in the app lifespan and publish it on
+  `app.state.pipeline_admission`; clear it on shutdown.
+- [x] 2.2 Bound the audio and text paths of `POST /api/session/{id}/message`
+  around the GPU call only.
+- [x] 2.3 Bound `POST /pipeline` and `POST /upload`; `upload()` takes a
+  `request` parameter so it can reach application state.
+- [x] 2.4 Translate `PipelineBusyError` into each route's own error shape with
+  `503` and `Retry-After`.
+
+## 3. Tests
+
+- [x] 3.1 Config defaults, environment override and unparseable fallback.
+- [x] 3.2 Bounding: admits to the limit, rejects beyond it, returns slots after
+  success and after an exception, hands a freed slot to a waiter, `0` disables.
+- [x] 3.3 `SYSTEM_BUSY` contract on both paths of the unified endpoint, and that
+  the broad `except Exception` in `send_unified_message` does not mask it as 500.
+- [x] 3.4 Both legacy routes reject with `503` and `Retry-After`.
+- [x] 3.5 Session-management and health traffic stay responsive at saturation.
+- [x] 3.6 Metrics move; lifespan publishes the component; no module singleton.
+- [x] 3.7 A cancelled request keeps its slot until its thread finishes, and the
+  slot becomes reusable afterwards.
+- [x] 3.8 End-to-end over HTTP: env -> lifespan -> `app.state` -> route ->
+  `503` with the `Retry-After` header actually on the wire.
+- [x] 3.9 Body and header advise the same delay.
+- [x] 3.10 Watch the suite fail with a gate removed, and with the slot released
+  from the awaiting task, then restore both.
+
+## 4. Documentation
+
+Only tracked files count here: `LOCAL_SETUP.md` and `docs/frontend/` are in
+`.git/info/exclude`, so anything written there is invisible to a reviewer.
+
+- [x] 4.1 Document the `SYSTEM_BUSY` consumer contract where consumers will find
+  it: the `503` entry under `/api/session/{sessionId}/message` in the tracked
+  `docs/openapi.yaml`, including client handling, and the route's FastAPI
+  `responses=` dict so it reaches the generated schema too.
+- [x] 4.2 Document both settings in `.env.example` and `docker-compose.yml`.
+- [x] 4.3 Record the frontend impact in this change's `proposal.md`.
+- [x] 4.4 Local-only additions, not a substitute for the above: the operator
+  tuning guide in `LOCAL_SETUP.md` and the fuller narrative in
+  `docs/frontend/API_CONTRACT.md`.
+
+## 5. Follow-ups (not this change)
+
+- [ ] 5.1 Raise `MAX_CONCURRENT_PIPELINES` from load-test evidence.
+- [ ] 5.2 Optional `AppError` `busy` kind and a dedicated i18n message.
+- [ ] 5.3 Cross-replica admission (#227).

--- a/services/api_gateway/app.py
+++ b/services/api_gateway/app.py
@@ -17,6 +17,11 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from prometheus_client import CollectorRegistry, Counter
 
+from .pipeline_admission import (
+    PipelineAdmission,
+    PipelineAdmissionConfig,
+    PipelineAdmissionMetrics,
+)
 from .rate_limiter import RateLimitMiddleware
 
 # === Service-URLs für die Orchestrierung ===
@@ -185,6 +190,19 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     sys.stderr.write(f"WebSocketManager ready (ID: {id(manager)})\n")
     sys.stderr.flush()
 
+    # Bounded admission for GPU pipeline work (#191). Owned by the lifespan so
+    # the semaphore belongs to this running app rather than to import time.
+    admission_config = PipelineAdmissionConfig()
+    app.state.pipeline_admission = PipelineAdmission(
+        admission_config, metrics=pipeline_admission_metrics
+    )
+    sys.stderr.write(
+        "Pipeline admission ready "
+        f"(max_concurrent={admission_config.max_concurrent}, "
+        f"queue_wait_seconds={admission_config.queue_wait_seconds})\n"
+    )
+    sys.stderr.flush()
+
     # Start background tasks
     timeout_task = asyncio.create_task(session_timeout_monitor())
     circuit_breaker_task = asyncio.create_task(circuit_breaker_monitor())
@@ -227,6 +245,8 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
             ):
                 print(f"Background task shutdown error: {result}")
 
+        app.state.pipeline_admission = None
+
         print("Shutdown complete", flush=True)
 
 
@@ -268,6 +288,11 @@ requests_total = Counter(
     "gateway_requests_total", "Total API Gateway requests", registry=registry
 )
 requests_total.inc(0)
+
+# Registered here rather than in the lifespan because a Prometheus series may be
+# created only once per registry, while the admission component itself is rebuilt
+# per lifespan.
+pipeline_admission_metrics = PipelineAdmissionMetrics(registry)
 
 # Attach to app state
 app.state.prometheus_registry = registry

--- a/services/api_gateway/pipeline_admission.py
+++ b/services/api_gateway/pipeline_admission.py
@@ -9,12 +9,18 @@ The component is owned by the application lifespan rather than module import, so
 the semaphore belongs to the running app and tests can build their own. The
 bound is process-local by design: coordinating across replicas is #227.
 
-A slot may only be held by running work. ``run()`` is the sole entry point for
-that reason: the pipeline functions are synchronous and execute on a worker
-thread, and ``asyncio.to_thread`` cannot interrupt a call it has started. If the
-slot were released by the awaiting task instead, a cancelled request would hand
-its capacity to the next caller while its own thread was still on the GPU, and
-real concurrency could exceed the limit.
+A slot may only be held by running work, and it must always come back. ``run()``
+is the sole entry point for both reasons: the pipeline functions are synchronous
+and execute on a worker thread, so the slot has two possible owners and exactly
+one of them must return it.
+
+``asyncio.to_thread`` cannot interrupt a call it has started, but it does cancel
+a work item that is still queued. So a cancelled request has two very different
+shapes. If the thread is already running, releasing from the awaiting task would
+hand capacity to the next caller while this request's uninterruptible thread was
+still on the GPU. If the work item was cancelled before any thread picked it up,
+releasing only from the thread loses the slot for the life of the process. Both
+are real; ``_SlotClaim`` decides between them.
 """
 
 from __future__ import annotations
@@ -23,9 +29,10 @@ import asyncio
 import logging
 import math
 import os
+import threading
 import time
 from dataclasses import dataclass, field
-from typing import Any, Callable, Optional, TypeVar
+from typing import Any, Callable, NoReturn, Optional, TypeVar
 
 from prometheus_client import CollectorRegistry, Counter, Gauge, Histogram
 
@@ -72,6 +79,15 @@ class PipelineAdmissionConfig:
     inferred from the hardware, not measured, and the metrics in this module
     exist so load tests can raise it. Exactly ``0`` disables the bound.
 
+    ``PIPELINE_QUEUE_WAIT_SECONDS`` must exceed the p95 pipeline duration or
+    queued requests can never be seated: a slot is held for the whole round trip
+    through ASR, translation and TTS, so with a wait shorter than that, every
+    request arriving at saturation burns the wait and is then rejected. Exactly
+    ``0`` opts out of queueing altogether and sheds immediately instead.
+
+    Both settings treat a negative value as a typo and fall back to the default:
+    only an exact ``0`` is an opt-out.
+
     Defaults are read per instance rather than at import, so the values are
     testable and a container can set them without reload tricks.
     """
@@ -102,11 +118,46 @@ class PipelineAdmissionConfig:
 
         if self.queue_wait_seconds < 0:
             logger.warning(
-                "PIPELINE_QUEUE_WAIT_SECONDS=%s is negative; using default %s.",
+                "PIPELINE_QUEUE_WAIT_SECONDS=%s is negative; using default %s. "
+                "Set exactly 0 to shed instead of queueing.",
                 self.queue_wait_seconds,
                 DEFAULT_QUEUE_WAIT_SECONDS,
             )
             object.__setattr__(self, "queue_wait_seconds", DEFAULT_QUEUE_WAIT_SECONDS)
+
+
+class _SlotClaim:
+    """Settles which of two threads returns one slot, exactly once.
+
+    The awaiting task and the worker thread can both believe they own the
+    release, and a plain boolean is not enough to separate them: cancelling an
+    ``asyncio.to_thread`` resolves the awaiting task a loop tick *before* the
+    queued work item is cancelled, so the task's cleanup can observe "not
+    started" while the thread is on its way into the call. Whoever claims first
+    owns the release; the loser does nothing.
+    """
+
+    __slots__ = ("_lock", "_claimed")
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._claimed = False
+
+    def claim(self) -> bool:
+        with self._lock:
+            if self._claimed:
+                return False
+            self._claimed = True
+            return True
+
+
+class _WorkAbandoned(BaseException):
+    """The awaiting task gave up before this thread started; do not run the call.
+
+    Derived from BaseException so an ``except Exception`` inside a pipeline
+    function cannot swallow it. Never reaches a caller: by the time it is raised
+    the awaiting future is already cancelled, so the result is discarded.
+    """
 
 
 class PipelineBusyError(RuntimeError):
@@ -202,8 +253,14 @@ class PipelineAdmission:
 
         await self._acquire()
         loop = asyncio.get_running_loop()
+        claim = _SlotClaim()
 
         def guarded() -> T:
+            if not claim.claim():
+                # The awaiting task is gone and has already returned the slot.
+                # Starting the GPU call now would exceed the bound to produce a
+                # result nobody is waiting for.
+                raise _WorkAbandoned
             try:
                 return func(*args, **kwargs)
             finally:
@@ -213,7 +270,14 @@ class PipelineAdmission:
                 # own uninterruptible thread is still using.
                 self._schedule_release(loop)
 
-        return await asyncio.to_thread(guarded)
+        try:
+            return await asyncio.to_thread(guarded)
+        finally:
+            # Only wins the claim when the work item was cancelled while still
+            # queued, in which case ``guarded`` will never run and no thread
+            # will ever release. Already on the loop thread, so release directly.
+            if claim.claim():
+                self._release()
 
     def _schedule_release(self, loop: asyncio.AbstractEventLoop) -> None:
         """Hands the slot back on the loop thread.
@@ -230,29 +294,48 @@ class PipelineAdmission:
 
     async def _acquire(self) -> None:
         started = time.perf_counter()
-        try:
-            # Python 3.11+ returns the permit if the waiter is cancelled, so a
-            # timeout here cannot leak capacity.
-            await asyncio.wait_for(
-                self._semaphore.acquire(), timeout=self._config.queue_wait_seconds
-            )
-        except TimeoutError:
-            # Recorded on the rejection path too: a histogram that only sees
-            # admitted requests reports "everyone seated instantly" during the
-            # very saturation it exists to measure.
-            self._observe_wait(time.perf_counter() - started)
-            if self._metrics:
-                self._metrics.rejected.inc()
-            raise PipelineBusyError(
-                max_concurrent=self._config.max_concurrent,
-                queue_wait_seconds=self._config.queue_wait_seconds,
-                waited_seconds=time.perf_counter() - started,
-            ) from None
+
+        if self._config.queue_wait_seconds == 0:
+            # "Do not queue": shed straight away. This cannot go through
+            # wait_for, which wraps the acquire in a task and cancels it before
+            # it ever runs when the timeout is zero — rejecting every request,
+            # including on a completely idle gateway.
+            if self._semaphore.locked():
+                self._reject(time.perf_counter() - started)
+            # Uncontended, so this returns without suspending; there is no
+            # await point between the check above and the permit being taken.
+            await self._semaphore.acquire()
+        else:
+            try:
+                # Python 3.11+ returns the permit if the waiter is cancelled, so
+                # a timeout here cannot leak capacity.
+                await asyncio.wait_for(
+                    self._semaphore.acquire(), timeout=self._config.queue_wait_seconds
+                )
+            except TimeoutError:
+                self._reject(time.perf_counter() - started)
 
         self._in_flight += 1
         if self._metrics:
             self._metrics.in_flight.inc()
         self._observe_wait(time.perf_counter() - started)
+
+    def _reject(self, waited: float) -> NoReturn:
+        """Records the rejection and raises. One clock read, used everywhere.
+
+        The wait is observed on this path too: a histogram that only sees
+        admitted requests reports "everyone seated instantly" during the very
+        saturation it exists to measure. Reading the clock again for the error
+        body would make the metric and the response disagree about one request.
+        """
+        self._observe_wait(waited)
+        if self._metrics:
+            self._metrics.rejected.inc()
+        raise PipelineBusyError(
+            max_concurrent=self._config.max_concurrent,
+            queue_wait_seconds=self._config.queue_wait_seconds,
+            waited_seconds=waited,
+        ) from None
 
     def _observe_wait(self, waited: float) -> None:
         if self._metrics:

--- a/services/api_gateway/pipeline_admission.py
+++ b/services/api_gateway/pipeline_admission.py
@@ -211,13 +211,22 @@ class PipelineAdmission:
                 # the pipeline's real lifetime rather than to the awaiting task.
                 # A cancelled request therefore cannot free capacity that its
                 # own uninterruptible thread is still using.
-                try:
-                    loop.call_soon_threadsafe(self._release)
-                except RuntimeError:
-                    # Loop already closed during shutdown; nothing left to bound.
-                    logger.debug("Event loop closed before pipeline slot release")
+                self._schedule_release(loop)
 
         return await asyncio.to_thread(guarded)
+
+    def _schedule_release(self, loop: asyncio.AbstractEventLoop) -> None:
+        """Hands the slot back on the loop thread.
+
+        The semaphore is not thread-safe, so the release has to be marshalled
+        out of the worker thread. This runs in a ``finally`` inside that thread
+        and must never raise: at shutdown the loop can already be gone, and by
+        then there is no capacity left to account for.
+        """
+        try:
+            loop.call_soon_threadsafe(self._release)
+        except RuntimeError:
+            logger.debug("Event loop closed before pipeline slot release")
 
     async def _acquire(self) -> None:
         started = time.perf_counter()

--- a/services/api_gateway/pipeline_admission.py
+++ b/services/api_gateway/pipeline_admission.py
@@ -1,0 +1,279 @@
+"""Bounded admission control for GPU pipeline work.
+
+A single RTX 4000 Ada serves ASR, translation and TTS, and each of those
+services holds one shared model instance without a lock of its own. Once the
+gateway stopped serialising pipelines on its event loop (#189), nothing bounded
+how many reached that card at the same time. This module supplies the bound.
+
+The component is owned by the application lifespan rather than module import, so
+the semaphore belongs to the running app and tests can build their own. The
+bound is process-local by design: coordinating across replicas is #227.
+
+A slot may only be held by running work. ``run()`` is the sole entry point for
+that reason: the pipeline functions are synchronous and execute on a worker
+thread, and ``asyncio.to_thread`` cannot interrupt a call it has started. If the
+slot were released by the awaiting task instead, a cancelled request would hand
+its capacity to the next caller while its own thread was still on the GPU, and
+real concurrency could exceed the limit.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import math
+import os
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable, Optional, TypeVar
+
+from prometheus_client import CollectorRegistry, Counter, Gauge, Histogram
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+DEFAULT_MAX_CONCURRENT_PIPELINES = 2
+DEFAULT_QUEUE_WAIT_SECONDS = 10.0
+
+# Spread across the plausible wait range: most requests should be seated
+# immediately, and anything near the timeout is a capacity signal.
+QUEUE_WAIT_BUCKETS = (0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.0, 5.0, 10.0, 30.0, float("inf"))
+
+
+def _env_int(name: str, default: int) -> int:
+    """Reads an int env var, falling back rather than blocking gateway boot."""
+    raw = os.getenv(name)
+    if raw is None or raw.strip() == "":
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        logger.warning("Ignoring unparseable %s=%r; using default %s", name, raw, default)
+        return default
+
+
+def _env_float(name: str, default: float) -> float:
+    raw = os.getenv(name)
+    if raw is None or raw.strip() == "":
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        logger.warning("Ignoring unparseable %s=%r; using default %s", name, raw, default)
+        return default
+
+
+@dataclass(frozen=True)
+class PipelineAdmissionConfig:
+    """How many pipelines may run at once, and how long a request may queue.
+
+    ``MAX_CONCURRENT_PIPELINES`` defaults deliberately low: the figure is
+    inferred from the hardware, not measured, and the metrics in this module
+    exist so load tests can raise it. Exactly ``0`` disables the bound.
+
+    Defaults are read per instance rather than at import, so the values are
+    testable and a container can set them without reload tricks.
+    """
+
+    max_concurrent: int = field(
+        default_factory=lambda: _env_int(
+            "MAX_CONCURRENT_PIPELINES", DEFAULT_MAX_CONCURRENT_PIPELINES
+        )
+    )
+    queue_wait_seconds: float = field(
+        default_factory=lambda: _env_float(
+            "PIPELINE_QUEUE_WAIT_SECONDS", DEFAULT_QUEUE_WAIT_SECONDS
+        )
+    )
+
+    def __post_init__(self) -> None:
+        # A negative limit is a typo, not a request to run unbounded, and
+        # silently removing the bound is the dangerous reading of it. Only an
+        # explicit 0 disables.
+        if self.max_concurrent < 0:
+            logger.warning(
+                "MAX_CONCURRENT_PIPELINES=%s is negative; using default %s. "
+                "Set exactly 0 to disable the bound.",
+                self.max_concurrent,
+                DEFAULT_MAX_CONCURRENT_PIPELINES,
+            )
+            object.__setattr__(self, "max_concurrent", DEFAULT_MAX_CONCURRENT_PIPELINES)
+
+        if self.queue_wait_seconds < 0:
+            logger.warning(
+                "PIPELINE_QUEUE_WAIT_SECONDS=%s is negative; using default %s.",
+                self.queue_wait_seconds,
+                DEFAULT_QUEUE_WAIT_SECONDS,
+            )
+            object.__setattr__(self, "queue_wait_seconds", DEFAULT_QUEUE_WAIT_SECONDS)
+
+
+class PipelineBusyError(RuntimeError):
+    """Raised when no pipeline slot came free within the configured wait."""
+
+    def __init__(
+        self,
+        *,
+        max_concurrent: int,
+        queue_wait_seconds: float,
+        waited_seconds: float,
+    ) -> None:
+        super().__init__(
+            f"No pipeline slot available within {queue_wait_seconds:.2f}s "
+            f"(limit {max_concurrent})"
+        )
+        self.max_concurrent = max_concurrent
+        self.queue_wait_seconds = queue_wait_seconds
+        self.waited_seconds = waited_seconds
+        # Whole seconds and never below one, so a client reading the body and a
+        # client reading the Retry-After header wait the same amount of time.
+        self.retry_after_seconds = max(1, math.ceil(queue_wait_seconds))
+
+    @property
+    def retry_after_header(self) -> str:
+        return str(self.retry_after_seconds)
+
+
+class PipelineAdmissionMetrics:
+    """Prometheus series for capacity tuning.
+
+    Registered once per process against the gateway's own registry; the
+    admission component itself is rebuilt per lifespan, which is why these are
+    passed in rather than created alongside the semaphore.
+    """
+
+    def __init__(self, registry: CollectorRegistry) -> None:
+        self.in_flight = Gauge(
+            "gateway_pipeline_in_flight",
+            "Pipelines currently holding an admission slot",
+            registry=registry,
+        )
+        self.queue_wait = Histogram(
+            "gateway_pipeline_queue_wait_seconds",
+            "Time a request waited for a pipeline slot, admitted or rejected",
+            buckets=QUEUE_WAIT_BUCKETS,
+            registry=registry,
+        )
+        self.rejected = Counter(
+            "gateway_pipeline_rejected_total",
+            "Requests rejected with SYSTEM_BUSY because no slot came free",
+            registry=registry,
+        )
+
+
+class PipelineAdmission:
+    """Bounds concurrent pipeline work and reports on the queue."""
+
+    def __init__(
+        self,
+        config: Optional[PipelineAdmissionConfig] = None,
+        *,
+        metrics: Optional[PipelineAdmissionMetrics] = None,
+    ) -> None:
+        self._config = config or PipelineAdmissionConfig()
+        self._metrics = metrics
+        self._in_flight = 0
+        # Only meaningful when the bound is enabled; sized once so the limit
+        # cannot drift from the configuration it was built with.
+        self._semaphore = asyncio.Semaphore(max(1, self._config.max_concurrent))
+
+    @property
+    def config(self) -> PipelineAdmissionConfig:
+        return self._config
+
+    @property
+    def enabled(self) -> bool:
+        return self._config.max_concurrent > 0
+
+    @property
+    def in_flight(self) -> int:
+        return self._in_flight
+
+    async def run(self, func: Callable[..., T], /, *args: Any, **kwargs: Any) -> T:
+        """Runs a synchronous pipeline function on a worker thread under the bound.
+
+        Raises ``PipelineBusyError`` if no slot comes free within the configured
+        wait. Pass only the GPU call: work done outside it occupies capacity it
+        does not need.
+        """
+        if not self.enabled:
+            return await asyncio.to_thread(func, *args, **kwargs)
+
+        await self._acquire()
+        loop = asyncio.get_running_loop()
+
+        def guarded() -> T:
+            try:
+                return func(*args, **kwargs)
+            finally:
+                # Released from inside the worker thread, so the slot is tied to
+                # the pipeline's real lifetime rather than to the awaiting task.
+                # A cancelled request therefore cannot free capacity that its
+                # own uninterruptible thread is still using.
+                try:
+                    loop.call_soon_threadsafe(self._release)
+                except RuntimeError:
+                    # Loop already closed during shutdown; nothing left to bound.
+                    logger.debug("Event loop closed before pipeline slot release")
+
+        return await asyncio.to_thread(guarded)
+
+    async def _acquire(self) -> None:
+        started = time.perf_counter()
+        try:
+            # Python 3.11+ returns the permit if the waiter is cancelled, so a
+            # timeout here cannot leak capacity.
+            await asyncio.wait_for(
+                self._semaphore.acquire(), timeout=self._config.queue_wait_seconds
+            )
+        except TimeoutError:
+            # Recorded on the rejection path too: a histogram that only sees
+            # admitted requests reports "everyone seated instantly" during the
+            # very saturation it exists to measure.
+            self._observe_wait(time.perf_counter() - started)
+            if self._metrics:
+                self._metrics.rejected.inc()
+            raise PipelineBusyError(
+                max_concurrent=self._config.max_concurrent,
+                queue_wait_seconds=self._config.queue_wait_seconds,
+                waited_seconds=time.perf_counter() - started,
+            ) from None
+
+        self._in_flight += 1
+        if self._metrics:
+            self._metrics.in_flight.inc()
+        self._observe_wait(time.perf_counter() - started)
+
+    def _observe_wait(self, waited: float) -> None:
+        if self._metrics:
+            self._metrics.queue_wait.observe(waited)
+
+    def _release(self) -> None:
+        self._semaphore.release()
+        self._in_flight -= 1
+        if self._metrics:
+            self._metrics.in_flight.dec()
+
+
+def get_pipeline_admission(request: Any) -> Optional[PipelineAdmission]:
+    """The running app's admission component, or ``None`` when there isn't one.
+
+    The isinstance check is load-bearing: handlers are also driven by mock
+    requests in tests, where attribute access invents a truthy object rather
+    than raising. Falling through to unbounded work is the right answer there
+    and for any route reached before lifespan startup.
+    """
+    app = getattr(request, "app", None)
+    state = getattr(app, "state", None)
+    candidate = getattr(state, "pipeline_admission", None)
+    return candidate if isinstance(candidate, PipelineAdmission) else None
+
+
+async def run_pipeline(request: Any, func: Callable[..., T], /, *args: Any, **kwargs: Any) -> T:
+    """Runs a pipeline function under the app's bound, unbounded if there is none."""
+    admission = get_pipeline_admission(request)
+    if admission is None:
+        return await asyncio.to_thread(func, *args, **kwargs)
+
+    return await admission.run(func, *args, **kwargs)

--- a/services/api_gateway/pipeline_logic.py
+++ b/services/api_gateway/pipeline_logic.py
@@ -1,4 +1,3 @@
-import asyncio
 import audioop
 import io
 import logging
@@ -1514,19 +1513,3 @@ def process_wav(file_bytes, source_lang, target_lang, debug=False, validate_audi
         "audio_bytes": audio_bytes,
         "debug": debug_info,
     }
-
-
-async def process_wav_for_session(file, source_lang, target_lang, session_id=None):
-    """
-    Erweiterte Pipeline-Funktion mit Session-Support
-    Nutzt die bestehende process_wav-Logik
-    """
-    # Rufe bestehende Funktion auf
-    result = await asyncio.to_thread(process_wav, file, source_lang, target_lang)
-
-    # Zusätzliche Session-Logik (falls gewünscht)
-    if session_id:
-        # Hier könnten zusätzliche Session-spezifische Verarbeitungen stehen
-        pass
-
-    return result

--- a/services/api_gateway/pipeline_logic.py
+++ b/services/api_gateway/pipeline_logic.py
@@ -52,6 +52,12 @@ logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(mess
 
 AUDIO_WAV_MIME = "audio/wav"
 
+# Marks a pipeline failure the client may usefully retry, so the routes can
+# answer 503 with a Retry-After instead of a permanent-looking error.
+UPSTREAM_BUSY_ERROR_CODE = "SYSTEM_BUSY"
+# Only used when a shedding service sent no parseable Retry-After of its own.
+DEFAULT_UPSTREAM_RETRY_AFTER_SECONDS = 5
+
 
 def utc_now() -> datetime:
     return datetime.now(timezone.utc)
@@ -339,6 +345,15 @@ def _mark_pipeline_failure(
     debug_info["total_duration"] = round(time.perf_counter() - start_total, 3)
 
 
+def _upstream_retry_after(response: Any) -> int:
+    """The upstream's own Retry-After, or a delay short enough to still be useful."""
+    headers = getattr(response, "headers", None) or {}
+    try:
+        return max(1, int(headers.get("Retry-After", "")))
+    except (TypeError, ValueError):
+        return DEFAULT_UPSTREAM_RETRY_AFTER_SECONDS
+
+
 def _pipeline_error_result(
     *,
     debug_info: Dict[str, Any],
@@ -348,7 +363,16 @@ def _pipeline_error_result(
     translation_text: Optional[str],
     audio_bytes: Optional[bytes],
     validation_result: Optional[Any] = None,
+    upstream_response: Optional[Any] = None,
 ) -> Dict[str, Any]:
+    """Flattens an upstream failure into the pipeline's result shape.
+
+    ``upstream_response`` exists so a 503 keeps its meaning. Since #190 the GPU
+    services shed load with a 503 and a Retry-After, which is transient, but
+    every failure here otherwise arrives at the routes as one undifferentiated
+    ``error`` — reported as 500 on the audio path and 400 on the text path, both
+    of which a client reads as permanent.
+    """
     _mark_pipeline_failure(debug_info, start_total, error_message)
     result = {
         "error": True,
@@ -360,6 +384,9 @@ def _pipeline_error_result(
     }
     if validation_result is not None:
         result["validation_result"] = validation_result
+    if getattr(upstream_response, "status_code", None) == 503:
+        result["error_code"] = UPSTREAM_BUSY_ERROR_CODE
+        result["retry_after_seconds"] = _upstream_retry_after(upstream_response)
     return result
 
 
@@ -1206,6 +1233,7 @@ def process_text_pipeline(
                 asr_text=processed_text,  # Original text as "ASR" result
                 translation_text=None,
                 audio_bytes=None,
+                upstream_response=translation_resp,
             )
 
         # Optional LLM refinement
@@ -1256,6 +1284,7 @@ def process_text_pipeline(
                 asr_text=processed_text,
                 translation_text=translation_text,
                 audio_bytes=None,
+                upstream_response=tts_resp,
             )
 
         audio_bytes = tts_resp.content
@@ -1411,6 +1440,7 @@ def process_wav(file_bytes, source_lang, target_lang, debug=False, validate_audi
             asr_text=asr_text,
             translation_text=None,
             audio_bytes=None,
+            upstream_response=translation_resp,
         )
     # Optional LLM refinement
     if translation_refiner.is_active:
@@ -1489,6 +1519,7 @@ def process_wav(file_bytes, source_lang, target_lang, debug=False, validate_audi
             asr_text=asr_text,
             translation_text=translation_text,
             audio_bytes=None,
+            upstream_response=tts_resp,
         )
     audio_bytes = tts_resp.content
     debug_info["steps"].append(

--- a/services/api_gateway/routes/pipeline.py
+++ b/services/api_gateway/routes/pipeline.py
@@ -1,9 +1,12 @@
 import base64
+import json
 import logging
+from typing import Dict, Optional
 
 from fastapi import File, Form, Request, Response, UploadFile
 
 from services.api_gateway.app import app
+from services.api_gateway.pipeline_admission import PipelineBusyError, run_pipeline
 from services.api_gateway.pipeline_logic import process_wav
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
@@ -28,9 +31,6 @@ async def pipeline(
         str(debug_query).lower() == "true"
     )
     file_bytes = await file.read()
-    result = process_wav(
-        file_bytes, source_lang, target_lang, debug=debug_active, validate_audio=True
-    )
 
     def get_origin(request: Request) -> str:
         o = request.headers.get("origin", "")
@@ -42,28 +42,57 @@ async def pipeline(
         return o if o in allowed else allowed[0]
 
     def pipeline_response(
-        request: Request, content: str, status_code: int = 200
+        request: Request,
+        content: str,
+        status_code: int = 200,
+        extra_headers: Optional[Dict[str, str]] = None,
     ) -> Response:
         origin = get_origin(request)
+        headers = {
+            "Access-Control-Allow-Origin": origin,
+            "Access-Control-Allow-Methods": "POST, OPTIONS",
+            "Access-Control-Allow-Headers": "Content-Type, Authorization, Accept",
+            "Access-Control-Allow-Credentials": "true",
+        }
+        if extra_headers:
+            headers.update(extra_headers)
         return Response(
             content=content,
             media_type="application/json",
             status_code=status_code,
-            headers={
-                "Access-Control-Allow-Origin": origin,
-                "Access-Control-Allow-Methods": "POST, OPTIONS",
-                "Access-Control-Allow-Headers": "Content-Type, Authorization, Accept",
-                "Access-Control-Allow-Credentials": "true",
-            },
+            headers=headers,
         )
 
     import logging
 
     logger = logging.getLogger("api_gateway")
 
-    def inner(request: Request) -> Response:
-        import json
+    try:
+        result = await run_pipeline(
+            request,
+            process_wav,
+            file_bytes,
+            source_lang,
+            target_lang,
+            debug=debug_active,
+            validate_audio=True,
+        )
+    except PipelineBusyError as busy:
+        logger.info("Frontend-Response: SYSTEM_BUSY, pipeline at capacity")
+        return pipeline_response(
+            request,
+            json.dumps(
+                {
+                    "success": False,
+                    "error_code": "SYSTEM_BUSY",
+                    "error": "The translation pipeline is at capacity. Please retry shortly.",
+                }
+            ),
+            status_code=503,
+            extra_headers={"Retry-After": busy.retry_after_header},
+        )
 
+    def inner(request: Request) -> Response:
         if result["error"]:
             logger.info(f"Frontend-Response: Fehler: {result['error_msg']}")
             response_obj = {

--- a/services/api_gateway/routes/session.py
+++ b/services/api_gateway/routes/session.py
@@ -29,6 +29,7 @@ from fastapi import (
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
 
 from ..log_safety import sanitize_log_value
+from ..pipeline_admission import PipelineBusyError, run_pipeline
 
 # Import der bestehenden Pipeline-Logik
 from ..pipeline_logic import process_text_pipeline, process_wav
@@ -405,6 +406,30 @@ def _supports_extended_session_message_args() -> bool:
     )
 
 
+def _system_busy_error(busy: PipelineBusyError) -> HTTPException:
+    """503 for a saturated pipeline (#191).
+
+    Uses the same envelope as every other failure on this endpoint, so the
+    frontend needs no new parsing; it maps any 5xx to its generic server error.
+    """
+    return HTTPException(
+        status_code=503,
+        detail=create_error_response(
+            "SYSTEM_BUSY",
+            "The translation pipeline is at capacity. Please retry shortly.",
+            {
+                "max_concurrent_pipelines": busy.max_concurrent,
+                # Deliberately the same value as the Retry-After header, so a
+                # client reading the body cannot retry sooner than advised.
+                "retry_after_seconds": busy.retry_after_seconds,
+                "queue_wait_seconds": busy.queue_wait_seconds,
+                "waited_seconds": round(busy.waited_seconds, 3),
+            },
+        ),
+        headers={"Retry-After": busy.retry_after_header},
+    )
+
+
 def _store_audio_artifacts(
     message_id: str, file_bytes: bytes, audio_bytes: Optional[bytes]
 ) -> Optional[str]:
@@ -669,9 +694,27 @@ NOT_FOUND_RESPONSE = {404: {"model": ErrorResponse, "description": "Not found"}}
 SERVER_ERROR_RESPONSE = {
     500: {"model": ErrorResponse, "description": "Internal server error"}
 }
+# Pipeline capacity is bounded (#191): one GPU hosts ASR, translation and TTS.
+# Carries error_code SYSTEM_BUSY and a Retry-After header; retrying works.
+SERVICE_BUSY_RESPONSE = {
+    503: {
+        "model": ErrorResponse,
+        "description": (
+            "Pipeline at capacity. Returns error_code SYSTEM_BUSY and a "
+            "Retry-After header in whole seconds; the request may be retried."
+        ),
+        "headers": {
+            "Retry-After": {
+                "description": "Whole seconds to wait before retrying; never below 1.",
+                "schema": {"type": "integer", "minimum": 1},
+            }
+        },
+    }
+}
 MESSAGE_ROUTE_RESPONSES = {
     **BAD_REQUEST_RESPONSE,
     **NOT_FOUND_RESPONSE,
+    **SERVICE_BUSY_RESPONSE,
     **SERVER_ERROR_RESPONSE,
 }
 ACTIVITY_ROUTE_RESPONSES = {
@@ -904,10 +947,23 @@ async def process_audio_input(
     processed_file_bytes = _validate_audio_payload(file, file_bytes)
     _validate_supported_languages(source_lang, target_lang)
 
-    # Audio-Pipeline ausführen (Validation bereits durchgeführt)
-    result = process_wav(
-        processed_file_bytes, source_lang, target_lang, validate_audio=False
-    )
+    # Audio-Pipeline ausführen (Validation bereits durchgeführt).
+    # process_wav is synchronous and spends its time in blocking HTTP calls to
+    # ASR/translation/TTS, so it runs on a worker thread to keep the gateway
+    # event loop free for other sessions, health checks and WS heartbeats.
+    # run_pipeline also bounds how many reach the GPU at once, and covers only
+    # the GPU call: form parsing and audio storage need no capacity.
+    try:
+        result = await run_pipeline(
+            request,
+            process_wav,
+            processed_file_bytes,
+            source_lang,
+            target_lang,
+            validate_audio=False,
+        )
+    except PipelineBusyError as busy:
+        raise _system_busy_error(busy) from busy
 
     if result.get("error", False):
         raise HTTPException(
@@ -998,13 +1054,19 @@ async def process_text_input(
             sanitize_log_value({"session_ref": _safe_identifier(session_id)}),
         )
 
-    # Text-Pipeline ausführen (ASR überspringen)
-    pipeline_result = process_text_pipeline(
-        text_request.text,
-        text_request.source_lang,
-        text_request.target_lang,
-        session_id=session_id,
-    )
+    # Text-Pipeline ausführen (ASR überspringen). Offloaded for the same reason
+    # as the audio pipeline: blocking translation/TTS calls must not hold the loop.
+    try:
+        pipeline_result = await run_pipeline(
+            request,
+            process_text_pipeline,
+            text_request.text,
+            text_request.source_lang,
+            text_request.target_lang,
+            session_id=session_id,
+        )
+    except PipelineBusyError as busy:
+        raise _system_busy_error(busy) from busy
 
     # Fehlerbehandlung
     if pipeline_result.get("error"):

--- a/services/api_gateway/routes/session.py
+++ b/services/api_gateway/routes/session.py
@@ -32,7 +32,12 @@ from ..log_safety import sanitize_log_value
 from ..pipeline_admission import PipelineBusyError, run_pipeline
 
 # Import der bestehenden Pipeline-Logik
-from ..pipeline_logic import process_text_pipeline, process_wav
+from ..pipeline_logic import (
+    DEFAULT_UPSTREAM_RETRY_AFTER_SECONDS,
+    UPSTREAM_BUSY_ERROR_CODE,
+    process_text_pipeline,
+    process_wav,
+)
 from ..session_manager import ClientType, SessionMessage, SessionStatus, session_manager
 from ..websocket import MessageType, WebSocketManager, get_websocket_manager
 
@@ -427,6 +432,34 @@ def _system_busy_error(busy: PipelineBusyError) -> HTTPException:
             },
         ),
         headers={"Retry-After": busy.retry_after_header},
+    )
+
+
+def _raise_if_upstream_busy(result: Dict[str, Any]) -> None:
+    """Re-raises an upstream capacity rejection as a retryable 503 (#190).
+
+    A GPU service that shed load answered 503 with a Retry-After, which clears
+    on its own. The pipeline flattens it into ``result["error"]`` like any other
+    failure, and without this the audio path would report 500 PIPELINE_ERROR and
+    the text path 400 TEXT_PIPELINE_ERROR — the latter blaming the client for a
+    condition it did not cause. Same envelope as _system_busy_error, so the
+    frontend needs no new parsing whichever layer ran out of capacity.
+    """
+    if result.get("error_code") != UPSTREAM_BUSY_ERROR_CODE:
+        return
+
+    retry_after = int(result.get("retry_after_seconds", DEFAULT_UPSTREAM_RETRY_AFTER_SECONDS))
+    raise HTTPException(
+        status_code=503,
+        detail=create_error_response(
+            "SYSTEM_BUSY",
+            "The translation pipeline is at capacity. Please retry shortly.",
+            {
+                "retry_after_seconds": retry_after,
+                "upstream_error": result.get("error_msg"),
+            },
+        ),
+        headers={"Retry-After": str(retry_after)},
     )
 
 
@@ -966,6 +999,7 @@ async def process_audio_input(
         raise _system_busy_error(busy) from busy
 
     if result.get("error", False):
+        _raise_if_upstream_busy(result)
         raise HTTPException(
             status_code=500,
             detail=create_error_response(
@@ -1070,6 +1104,7 @@ async def process_text_input(
 
     # Fehlerbehandlung
     if pipeline_result.get("error"):
+        _raise_if_upstream_busy(pipeline_result)
         raise HTTPException(
             status_code=400,
             detail=create_error_response(

--- a/services/api_gateway/routes/upload.py
+++ b/services/api_gateway/routes/upload.py
@@ -1,11 +1,12 @@
 import logging
 from html import escape
 
-from fastapi import File, Form, UploadFile
+from fastapi import File, Form, Request, UploadFile
 from fastapi.responses import HTMLResponse
 
 from services.api_gateway.app import app
 from services.api_gateway.log_safety import safe_language_code, sanitize_log_value
+from services.api_gateway.pipeline_admission import PipelineBusyError, run_pipeline
 from services.api_gateway.pipeline_logic import process_wav
 
 logger = logging.getLogger("api_gateway")
@@ -20,6 +21,7 @@ def _safe_text_preview(value: object) -> str:
 
 @app.post("/upload")
 async def upload(
+    request: Request,
     file: UploadFile = File(...),
     source_lang: str = Form(...),
     target_lang: str = Form(...),
@@ -40,7 +42,18 @@ async def upload(
             status_code=400,
         )
     file_bytes = await file.read()
-    result = process_wav(file_bytes, source_lang, target_lang)
+    try:
+        result = await run_pipeline(
+            request, process_wav, file_bytes, source_lang, target_lang
+        )
+    except PipelineBusyError as busy:
+        logger.info("Upload rejected: pipeline at capacity")
+        return HTMLResponse(
+            content="<html><body><h2>System ausgelastet</h2><p>Die Verarbeitung ist derzeit"
+            " ausgelastet. Bitte in wenigen Sekunden erneut versuchen.</p></body></html>",
+            status_code=503,
+            headers={"Retry-After": busy.retry_after_header},
+        )
     if result["error"]:
         logger.info(
             "Upload pipeline error: error=%s, has_transcript=%s, has_translation=%s",

--- a/services/asr/Dockerfile
+++ b/services/asr/Dockerfile
@@ -47,6 +47,7 @@ COPY --from=wheel-builder /wheels /wheels
 COPY services/asr/requirements.txt ./requirements.txt
 COPY services/asr/app.py ./app.py
 COPY services/gpu_metrics.py ./services/gpu_metrics.py
+COPY services/resource_metrics.py ./services/resource_metrics.py
 
 RUN printf '%s%s\n' \
     'pip==25.1.1 --hash=sha256:' \

--- a/services/translation/Dockerfile
+++ b/services/translation/Dockerfile
@@ -44,6 +44,7 @@ COPY --from=wheel-builder /wheels /wheels
 COPY services/translation/requirements.txt ./requirements.txt
 COPY services/translation/app.py ./app.py
 COPY services/gpu_metrics.py ./services/gpu_metrics.py
+COPY services/resource_metrics.py ./services/resource_metrics.py
 
 RUN printf '%s%s\n' \
     'pip==25.1.1 --hash=sha256:' \

--- a/services/translation/app.py
+++ b/services/translation/app.py
@@ -7,7 +7,7 @@ import threading
 import time
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, NoReturn, Optional
 
 import torch
 from fastapi import FastAPI, HTTPException, Request
@@ -129,16 +129,79 @@ DEFAULT_MAX_CONCURRENT_TRANSLATIONS = 2
 # answers with an attributable 503 rather than leaving the caller to time out.
 DEFAULT_TRANSLATION_QUEUE_WAIT_SECONDS = 25.0
 
-MAX_CONCURRENT_TRANSLATIONS = int(
-    os.getenv("MAX_CONCURRENT_TRANSLATIONS", str(DEFAULT_MAX_CONCURRENT_TRANSLATIONS))
+
+def _env_int(name: str, default: int) -> int:
+    """Reads an int env var, falling back rather than blocking service boot.
+
+    These are read at import, so an uncaught ValueError here happens before
+    uvicorn binds: the container never reports healthy and restarts forever over
+    one typo in an env file.
+    """
+    raw = os.getenv(name)
+    if raw is None or raw.strip() == "":
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        logger.warning("Ignoring unparseable %s=%r; using default %s", name, raw, default)
+        return default
+
+
+def _env_float(name: str, default: float) -> float:
+    raw = os.getenv(name)
+    if raw is None or raw.strip() == "":
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        logger.warning("Ignoring unparseable %s=%r; using default %s", name, raw, default)
+        return default
+
+
+MAX_CONCURRENT_TRANSLATIONS = _env_int(
+    "MAX_CONCURRENT_TRANSLATIONS", DEFAULT_MAX_CONCURRENT_TRANSLATIONS
 )
-TRANSLATION_QUEUE_WAIT_SECONDS = float(
-    os.getenv("TRANSLATION_QUEUE_WAIT_SECONDS", str(DEFAULT_TRANSLATION_QUEUE_WAIT_SECONDS))
+TRANSLATION_QUEUE_WAIT_SECONDS = _env_float(
+    "TRANSLATION_QUEUE_WAIT_SECONDS", DEFAULT_TRANSLATION_QUEUE_WAIT_SECONDS
 )
 
 # Spread across the plausible wait range: most requests should be seated
 # immediately, and anything near the timeout is a capacity signal.
 QUEUE_WAIT_BUCKETS = (0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.0, 5.0, 10.0, 25.0, float("inf"))
+
+
+class _SlotClaim:
+    """Settles which of two threads returns one inference slot, exactly once.
+
+    The awaiting task and the worker thread can both believe they own the
+    release, and a plain boolean cannot separate them: cancelling an
+    ``asyncio.to_thread`` resolves the awaiting task a loop tick *before* the
+    queued work item is cancelled, so the task's cleanup can observe "not
+    started" while the thread is on its way into the call. Whoever claims first
+    owns the release; the loser does nothing.
+    """
+
+    __slots__ = ("_lock", "_claimed")
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._claimed = False
+
+    def claim(self) -> bool:
+        with self._lock:
+            if self._claimed:
+                return False
+            self._claimed = True
+            return True
+
+
+class _WorkAbandoned(BaseException):
+    """The awaiting task gave up before this thread started; do not run inference.
+
+    Derived from BaseException so an ``except Exception`` inside the inference
+    path cannot swallow it. Never reaches a caller: by the time it is raised the
+    awaiting future is already cancelled, so the result is discarded.
+    """
 
 
 class TranslationBusyError(RuntimeError):
@@ -208,9 +271,12 @@ class TranslationAdmission:
             )
             limit = DEFAULT_MAX_CONCURRENT_TRANSLATIONS
 
-        if wait <= 0:
+        # Exactly 0 means "do not queue" and is handled in _acquire; a negative
+        # value is a typo, the same reading as the limit above.
+        if wait < 0:
             logger.warning(
-                "TRANSLATION_QUEUE_WAIT_SECONDS=%s is not positive; using default %s.",
+                "TRANSLATION_QUEUE_WAIT_SECONDS=%s is negative; using default %s. "
+                "Set exactly 0 to shed instead of queueing.",
                 wait,
                 DEFAULT_TRANSLATION_QUEUE_WAIT_SECONDS,
             )
@@ -243,8 +309,14 @@ class TranslationAdmission:
 
         await self._acquire()
         loop = asyncio.get_running_loop()
+        claim = _SlotClaim()
 
         def guarded() -> List[str]:
+            if not claim.claim():
+                # The awaiting task is gone and has already returned the slot.
+                # Starting inference now would exceed the bound to produce a
+                # result nobody is waiting for.
+                raise _WorkAbandoned
             try:
                 return func(*args, **kwargs)
             finally:
@@ -252,7 +324,14 @@ class TranslationAdmission:
                 # inference's real lifetime rather than the awaiting task's.
                 self._schedule_release(loop)
 
-        return await asyncio.to_thread(guarded)
+        try:
+            return await asyncio.to_thread(guarded)
+        finally:
+            # Only wins the claim when the work item was cancelled while still
+            # queued, in which case ``guarded`` never runs and no thread will
+            # ever release. Already on the loop thread, so release directly.
+            if claim.claim():
+                self._release()
 
     def _schedule_release(self, loop: asyncio.AbstractEventLoop) -> None:
         """Hands the slot back on the loop thread.
@@ -269,26 +348,43 @@ class TranslationAdmission:
 
     async def _acquire(self) -> None:
         started = time.perf_counter()
-        try:
-            # Python 3.11+ returns the permit if the waiter is cancelled, so a
-            # timeout here cannot leak capacity.
-            await asyncio.wait_for(self._semaphore.acquire(), timeout=self.queue_wait_seconds)
-        except TimeoutError:
-            # Observed on the rejection path too: a histogram that only sees
-            # admitted requests reports "everyone seated instantly" during the
-            # very saturation it exists to measure.
-            waited = time.perf_counter() - started
-            self._observe_wait(waited)
-            self._metrics.rejected.inc()
-            raise TranslationBusyError(
-                max_concurrent=self.max_concurrent,
-                queue_wait_seconds=self.queue_wait_seconds,
-                waited_seconds=waited,
-            ) from None
+
+        if self.queue_wait_seconds == 0:
+            # "Do not queue": shed straight away. This cannot go through
+            # wait_for, which wraps the acquire in a task and cancels it before
+            # it ever runs when the timeout is zero — rejecting every request,
+            # including on a completely idle service.
+            if self._semaphore.locked():
+                self._reject(time.perf_counter() - started)
+            # Uncontended, so this returns without suspending; there is no await
+            # point between the check above and the permit being taken.
+            await self._semaphore.acquire()
+        else:
+            try:
+                # Python 3.11+ returns the permit if the waiter is cancelled, so
+                # a timeout here cannot leak capacity.
+                await asyncio.wait_for(self._semaphore.acquire(), timeout=self.queue_wait_seconds)
+            except TimeoutError:
+                self._reject(time.perf_counter() - started)
 
         self._in_flight += 1
         self._metrics.in_flight.inc()
         self._observe_wait(time.perf_counter() - started)
+
+    def _reject(self, waited: float) -> NoReturn:
+        """Records the rejection and raises. One clock read, used everywhere.
+
+        The wait is observed on this path too: a histogram that only sees
+        admitted requests reports "everyone seated instantly" during the very
+        saturation it exists to measure.
+        """
+        self._observe_wait(waited)
+        self._metrics.rejected.inc()
+        raise TranslationBusyError(
+            max_concurrent=self.max_concurrent,
+            queue_wait_seconds=self.queue_wait_seconds,
+            waited_seconds=waited,
+        ) from None
 
     def _observe_wait(self, waited: float) -> None:
         self._metrics.queue_wait.observe(waited)

--- a/services/translation/app.py
+++ b/services/translation/app.py
@@ -1,8 +1,13 @@
+import asyncio
+import logging
+import math
 import os
 import re
 import threading
 import time
-from typing import Any, Dict, List
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, Optional
 
 import torch
 from fastapi import FastAPI, HTTPException, Request
@@ -26,11 +31,18 @@ try:
 except ImportError:  # pragma: no cover - optional dependency
     pynvml = None
 
+logger = logging.getLogger(__name__)
+
 _nvml_initialized = False
 TRANSLATION_ERROR_RESPONSES = {
     400: {"description": "Invalid translation request"},
     500: {"description": "Translation failed"},
-    503: {"description": "Translation model unavailable"},
+    503: {
+        "description": (
+            "Translation model unavailable, or no inference slot became available "
+            "within the configured queue wait. The latter carries a Retry-After header."
+        )
+    },
 }
 
 
@@ -105,9 +117,204 @@ MAX_INPUT_CHARS = int(os.getenv("MAX_INPUT_CHARS", "20000"))  # rudimentäres Sc
 DENY_EMPTY = os.getenv("DENY_EMPTY", "1") == "1"
 
 # ----------------------------
+# Inference admission control
+# ----------------------------
+# Matches the gateway's MAX_CONCURRENT_PIPELINES so this service is not a
+# tighter chokepoint than the system-level boundary. Exactly 0 disables the
+# bound. The figure is inferred from the hardware — one RTX 4000 Ada shared by
+# ASR, translation and TTS, one M2M100 instance here — not measured; the metrics
+# below exist so load tests can raise it.
+DEFAULT_MAX_CONCURRENT_TRANSLATIONS = 2
+# Under the gateway's 30s HTTP timeout for /translate, so a saturated queue
+# answers with an attributable 503 rather than leaving the caller to time out.
+DEFAULT_TRANSLATION_QUEUE_WAIT_SECONDS = 25.0
+
+MAX_CONCURRENT_TRANSLATIONS = int(
+    os.getenv("MAX_CONCURRENT_TRANSLATIONS", str(DEFAULT_MAX_CONCURRENT_TRANSLATIONS))
+)
+TRANSLATION_QUEUE_WAIT_SECONDS = float(
+    os.getenv("TRANSLATION_QUEUE_WAIT_SECONDS", str(DEFAULT_TRANSLATION_QUEUE_WAIT_SECONDS))
+)
+
+# Spread across the plausible wait range: most requests should be seated
+# immediately, and anything near the timeout is a capacity signal.
+QUEUE_WAIT_BUCKETS = (0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.0, 5.0, 10.0, 25.0, float("inf"))
+
+
+class TranslationBusyError(RuntimeError):
+    """Raised when no inference slot came free within the configured wait."""
+
+    def __init__(
+        self,
+        *,
+        max_concurrent: int,
+        queue_wait_seconds: float,
+        waited_seconds: float,
+    ) -> None:
+        super().__init__(
+            f"No inference slot available within {queue_wait_seconds:.2f}s "
+            f"(limit {max_concurrent})"
+        )
+        self.max_concurrent = max_concurrent
+        self.queue_wait_seconds = queue_wait_seconds
+        self.waited_seconds = waited_seconds
+        # Whole seconds and never below one, so a client reading the header and a
+        # client reading the message wait the same amount of time.
+        self.retry_after_seconds = max(1, math.ceil(queue_wait_seconds))
+
+    @property
+    def retry_after_header(self) -> str:
+        return str(self.retry_after_seconds)
+
+
+@dataclass(frozen=True)
+class TranslationAdmissionMetrics:
+    """The three series admission control reports on, injectable for tests."""
+
+    in_flight: Any
+    queue_wait: Any
+    rejected: Any
+
+
+class TranslationAdmission:
+    """Bounds concurrent GPU inference and keeps the event loop free.
+
+    ``run()`` is the sole entry point. The inference functions are synchronous
+    and execute on a worker thread, and ``asyncio.to_thread`` cannot interrupt a
+    call it has started; if the slot were released by the awaiting task instead,
+    a disconnected request would hand its capacity to the next caller while its
+    own thread was still on the GPU, and real concurrency could exceed the limit.
+    """
+
+    def __init__(
+        self,
+        max_concurrent: Optional[int] = None,
+        queue_wait_seconds: Optional[float] = None,
+        *,
+        metrics: Optional[Any] = None,
+    ) -> None:
+        limit = MAX_CONCURRENT_TRANSLATIONS if max_concurrent is None else max_concurrent
+        wait = TRANSLATION_QUEUE_WAIT_SECONDS if queue_wait_seconds is None else queue_wait_seconds
+
+        # A negative limit is a typo, not a request to run unbounded, and
+        # silently removing the bound is the dangerous reading of it. Only an
+        # explicit 0 disables.
+        if limit < 0:
+            logger.warning(
+                "MAX_CONCURRENT_TRANSLATIONS=%s is negative; using default %s. "
+                "Set exactly 0 to disable the bound.",
+                limit,
+                DEFAULT_MAX_CONCURRENT_TRANSLATIONS,
+            )
+            limit = DEFAULT_MAX_CONCURRENT_TRANSLATIONS
+
+        if wait <= 0:
+            logger.warning(
+                "TRANSLATION_QUEUE_WAIT_SECONDS=%s is not positive; using default %s.",
+                wait,
+                DEFAULT_TRANSLATION_QUEUE_WAIT_SECONDS,
+            )
+            wait = DEFAULT_TRANSLATION_QUEUE_WAIT_SECONDS
+
+        self.max_concurrent = limit
+        self.queue_wait_seconds = wait
+        self._metrics = metrics if metrics is not None else _admission_metrics()
+        self._in_flight = 0
+        # Sized once, so the limit cannot drift from the configuration it was
+        # built with.
+        self._semaphore = asyncio.Semaphore(max(1, limit))
+
+    @property
+    def enabled(self) -> bool:
+        return self.max_concurrent > 0
+
+    @property
+    def in_flight(self) -> int:
+        return self._in_flight
+
+    async def run(self, func: Callable[..., List[str]], /, *args: Any, **kwargs: Any) -> List[str]:
+        """Runs a synchronous inference function on a worker thread under the bound.
+
+        Raises ``TranslationBusyError`` if no slot comes free within the
+        configured wait.
+        """
+        if not self.enabled:
+            return await asyncio.to_thread(func, *args, **kwargs)
+
+        await self._acquire()
+        loop = asyncio.get_running_loop()
+
+        def guarded() -> List[str]:
+            try:
+                return func(*args, **kwargs)
+            finally:
+                # Released from inside the worker thread, so the slot tracks the
+                # inference's real lifetime rather than the awaiting task's.
+                self._schedule_release(loop)
+
+        return await asyncio.to_thread(guarded)
+
+    def _schedule_release(self, loop: asyncio.AbstractEventLoop) -> None:
+        """Hands the slot back on the loop thread.
+
+        The semaphore is not thread-safe, so the release is marshalled out of the
+        worker thread. This runs in a ``finally`` inside that thread and must
+        never raise: at shutdown the loop can already be gone, and by then there
+        is no capacity left to account for.
+        """
+        try:
+            loop.call_soon_threadsafe(self._release)
+        except RuntimeError:
+            logger.debug("Event loop closed before inference slot release")
+
+    async def _acquire(self) -> None:
+        started = time.perf_counter()
+        try:
+            # Python 3.11+ returns the permit if the waiter is cancelled, so a
+            # timeout here cannot leak capacity.
+            await asyncio.wait_for(self._semaphore.acquire(), timeout=self.queue_wait_seconds)
+        except TimeoutError:
+            # Observed on the rejection path too: a histogram that only sees
+            # admitted requests reports "everyone seated instantly" during the
+            # very saturation it exists to measure.
+            waited = time.perf_counter() - started
+            self._observe_wait(waited)
+            self._metrics.rejected.inc()
+            raise TranslationBusyError(
+                max_concurrent=self.max_concurrent,
+                queue_wait_seconds=self.queue_wait_seconds,
+                waited_seconds=waited,
+            ) from None
+
+        self._in_flight += 1
+        self._metrics.in_flight.inc()
+        self._observe_wait(time.perf_counter() - started)
+
+    def _observe_wait(self, waited: float) -> None:
+        self._metrics.queue_wait.observe(waited)
+
+    def _release(self) -> None:
+        self._semaphore.release()
+        self._in_flight -= 1
+        self._metrics.in_flight.dec()
+
+
+def _resolve_admission(request: Any) -> Optional[TranslationAdmission]:
+    """The app's admission component, or ``None`` when there isn't one.
+
+    The isinstance check is load-bearing: this handler is also driven directly
+    with fake requests that have no ``app``, where attribute access invents a
+    truthy object rather than raising. Unbounded offload is the right answer
+    there, and for any request reached before lifespan startup.
+    """
+    state = getattr(getattr(request, "app", None), "state", None)
+    candidate = getattr(state, "translation_admission", None)
+    return candidate if isinstance(candidate, TranslationAdmission) else None
+
+
+# ----------------------------
 # App & Metrics
 # ----------------------------
-app = FastAPI(title="Translation Service (M2M100)")
 requests_total = Counter("translation_requests_total", "Total translation requests")
 errors_total = Counter("translation_errors_total", "Total translation errors")
 tokens_generated_total = Counter(
@@ -121,6 +328,48 @@ request_latency = Histogram(
     "Latency of translation requests",
     buckets=(0.05, 0.1, 0.2, 0.5, 1, 2, 4, 8, 16, 32),
 )
+translation_in_flight = Gauge(
+    "translation_in_flight", "Translations currently holding an inference slot"
+)
+translation_queue_wait_seconds = Histogram(
+    "translation_queue_wait_seconds",
+    "Time a request waited for an inference slot, admitted or rejected",
+    buckets=QUEUE_WAIT_BUCKETS,
+)
+translation_rejected_total = Counter(
+    "translation_rejected_total",
+    "Requests rejected because no inference slot came free",
+)
+
+
+def _admission_metrics() -> TranslationAdmissionMetrics:
+    return TranslationAdmissionMetrics(
+        in_flight=translation_in_flight,
+        queue_wait=translation_queue_wait_seconds,
+        rejected=translation_rejected_total,
+    )
+
+
+@asynccontextmanager
+async def lifespan(app_: Any):
+    """Owns the admission component for the life of the running app.
+
+    Built here rather than at import so the semaphore belongs to the loop that
+    will actually serve requests, and so tests can construct their own.
+    """
+    app_.state.translation_admission = TranslationAdmission()
+    logger.info(
+        "Translation admission control active: limit=%s queue_wait=%ss",
+        MAX_CONCURRENT_TRANSLATIONS,
+        TRANSLATION_QUEUE_WAIT_SECONDS,
+    )
+    try:
+        yield
+    finally:
+        app_.state.translation_admission = None
+
+
+app = FastAPI(title="Translation Service (M2M100)", lifespan=lifespan)
 
 # ----------------------------
 # Model Loading
@@ -224,6 +473,53 @@ def _translate_texts(
                 _generate_single(text, source_lang, target_lang, gen_overrides)
             )
     return outputs
+
+
+async def _run_inference_off_loop(
+    request: Any,
+    texts: List[str],
+    source_lang: str,
+    target_lang: str,
+    gen_overrides: Dict[str, Any],
+) -> List[str]:
+    """Runs blocking M2M100 inference on a worker thread, under the service bound.
+
+    Without an admission component the offload still happens: keeping the event
+    loop free is the point, and bounding is the defence that comes with it.
+    """
+    admission = _resolve_admission(request)
+    if admission is None:
+        return await asyncio.to_thread(
+            _translate_texts, texts, source_lang, target_lang, gen_overrides
+        )
+
+    return await admission.run(_translate_texts, texts, source_lang, target_lang, gen_overrides)
+
+
+def _busy_response(
+    busy: TranslationBusyError, *, debug_active: bool, debug_info: Dict[str, Any]
+) -> JSONResponse:
+    """503 for a saturated inference queue, carrying Retry-After.
+
+    Returns the debug envelope when debug is active and raises otherwise, rather
+    than going through ``_raise_http_error``: that one cannot attach headers, and
+    a Retry-After the client never receives is not a contract.
+    """
+    detail = (
+        f"Translation service busy: no inference slot became available within "
+        f"{busy.queue_wait_seconds:.1f}s (limit {busy.max_concurrent})"
+    )
+    debug_info["error"] = detail
+    debug_response = _build_debug_response(debug_active, debug_info, 503)
+    if debug_response is None:
+        raise HTTPException(
+            status_code=503,
+            detail=detail,
+            headers={"Retry-After": busy.retry_after_header},
+        )
+
+    debug_response.headers["retry-after"] = busy.retry_after_header
+    return debug_response
 
 
 def _maybe_uromanize(outputs: List[str], expect_list: bool) -> str | List[str] | None:
@@ -445,7 +741,9 @@ async def translate(request: Request):
     start = time.perf_counter()
 
     try:
-        outputs = _translate_texts(texts, source_lang, target_lang, gen_overrides)
+        outputs = await _run_inference_off_loop(
+            request, texts, source_lang, target_lang, gen_overrides
+        )
         elapsed = time.perf_counter() - start
         return _build_translation_response(
             outputs,
@@ -456,6 +754,10 @@ async def translate(request: Request):
             debug_active,
             debug_info,
         )
+    except TranslationBusyError as busy:
+        # Ahead of `except Exception`, which would otherwise turn a capacity
+        # rejection into a 500 "Translation failed".
+        return _busy_response(busy, debug_active=debug_active, debug_info=debug_info)
     except HTTPException as exc:
         try:
             _raise_http_error(

--- a/services/tts/Dockerfile
+++ b/services/tts/Dockerfile
@@ -45,6 +45,7 @@ COPY --from=wheel-builder /wheels /wheels
 COPY services/tts/requirements.txt ./requirements.txt
 COPY services/tts/app.py ./app.py
 COPY services/gpu_metrics.py ./services/gpu_metrics.py
+COPY services/resource_metrics.py ./services/resource_metrics.py
 
 RUN printf '%s%s\n' \
     'pip==25.1.1 --hash=sha256:' \

--- a/tests/pipeline_helpers.py
+++ b/tests/pipeline_helpers.py
@@ -1,0 +1,106 @@
+"""Shared fixtures for the gateway pipeline suites (#189 non-blocking, #191 bound).
+
+Both suites drive the same four handlers with the same fake requests. Keeping the
+builders here stops the two files from drifting apart as the handlers change.
+
+Not named ``test_*``, so pytest does not collect it.
+"""
+
+import importlib
+from typing import Any, Dict, Optional
+from unittest.mock import AsyncMock, Mock
+
+from services.api_gateway.session_manager import SessionStatus
+
+# routes/__init__.py re-exports the endpoint functions under their module names,
+# so `routes.upload` is the handler rather than the module. Import by path.
+upload_route = importlib.import_module("services.api_gateway.routes.upload")
+pipeline_route = importlib.import_module("services.api_gateway.routes.pipeline")
+health_route = importlib.import_module("services.api_gateway.routes.health")
+
+AUDIO_BYTES = b"RIFF" + b"fake_wav_audio_data" + b"\x00" * 100
+
+PIPELINE_SUCCESS: Dict[str, Any] = {
+    "error": False,
+    "asr_text": "Guten Tag",
+    "translation_text": "Good day",
+    "audio_bytes": b"fake_output_audio",
+}
+
+TEXT_PIPELINE_SUCCESS: Dict[str, Any] = {
+    "error": False,
+    "translation_text": "Guten Tag",
+    "audio_bytes": b"fake_output_audio",
+    "debug": {},
+}
+
+# Generous: every assertion in these suites is about ordering, thread identity or
+# rejection, never about how long something took.
+SAFETY_TIMEOUT = 15.0
+
+
+async def make_active_session(manager) -> str:
+    """An ACTIVE admin session whose customer speaks English.
+
+    Admin sends de -> en, which is what the request builders below produce; a
+    mismatch trips validate_session_languages before the pipeline is reached.
+    """
+    session_id = await manager.create_admin_session()
+    session = manager.get_session(session_id)
+    session.status = SessionStatus.ACTIVE
+    session.customer_language = "en"
+    return session_id
+
+
+def request_with(admission: Optional[Any] = None) -> Mock:
+    """A fake request whose app state carries ``admission``.
+
+    ``None`` leaves the handler unbounded, which is what the non-blocking suite
+    wants and what any route reached before lifespan startup gets.
+    """
+    request = Mock()
+    request.app.state.pipeline_admission = admission
+    return request
+
+
+def audio_request(admission: Optional[Any] = None) -> Mock:
+    request = request_with(admission)
+    request.headers = {"content-type": "multipart/form-data; boundary=boundary"}
+    request.form = AsyncMock(
+        return_value={
+            "file": upload_file(),
+            "source_lang": "de",
+            "target_lang": "en",
+            "client_type": "admin",
+        }
+    )
+    return request
+
+
+def text_request(admission: Optional[Any] = None) -> Mock:
+    request = request_with(admission)
+    request.headers = {"content-type": "application/json"}
+    request.json = AsyncMock(
+        return_value={
+            "text": "Guten Tag",
+            "source_lang": "de",
+            "target_lang": "en",
+            "client_type": "admin",
+        }
+    )
+    return request
+
+
+def upload_file() -> Mock:
+    """Stands in for an UploadFile the handlers only ever ``await .read()`` on."""
+    handle = Mock()
+    handle.read = AsyncMock(return_value=AUDIO_BYTES)
+    return handle
+
+
+def legacy_pipeline_request(admission: Optional[Any] = None) -> Mock:
+    """The /pipeline handler also reads query params and origin headers."""
+    request = request_with(admission)
+    request.query_params = {}
+    request.headers = {}
+    return request

--- a/tests/test_gateway_event_loop_non_blocking.py
+++ b/tests/test_gateway_event_loop_non_blocking.py
@@ -1,94 +1,33 @@
-"""Regression coverage for issue #189.
-
-The gateway pipeline entry points are synchronous and spend their time in
-blocking ``requests.post`` calls. Calling them straight from an ``async def``
-route handler pins the single event loop thread for the whole pipeline, which
-serialises every session and starves health checks and WebSocket heartbeats.
-
-These tests pin the non-blocking property itself, not an implementation detail:
-the pipeline must not run on the event loop thread, two messages must make
-progress at the same time, and the loop must keep ticking while a pipeline is
-in flight.
-"""
-
 import asyncio
-import importlib
 import threading
 import time
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import patch
 
 import pytest
 
-from services.api_gateway.session_manager import SessionManager, SessionStatus
-
-# routes/__init__.py re-exports the endpoint functions under their module names,
-# so `routes.upload` is the handler rather than the module. Import by path.
-upload_route = importlib.import_module("services.api_gateway.routes.upload")
-pipeline_route = importlib.import_module("services.api_gateway.routes.pipeline")
-
-AUDIO_BYTES = b"RIFF" + b"fake_wav_audio_data" + b"\x00" * 100
-
-PIPELINE_SUCCESS = {
-    "error": False,
-    "asr_text": "Guten Tag",
-    "translation_text": "Good day",
-    "audio_bytes": b"fake_output_audio",
-}
-
-TEXT_PIPELINE_SUCCESS = {
-    "error": False,
-    "translation_text": "Guten Tag",
-    "audio_bytes": b"fake_output_audio",
-    "debug": {},
-}
+from services.api_gateway.session_manager import SessionManager
+from tests.pipeline_helpers import (
+    PIPELINE_SUCCESS,
+    SAFETY_TIMEOUT,
+    TEXT_PIPELINE_SUCCESS,
+    audio_request,
+    legacy_pipeline_request,
+    make_active_session,
+    pipeline_route,
+    request_with,
+    text_request,
+    upload_file,
+    upload_route,
+)
 
 # Long enough that a blocked loop is unmistakable, short enough to keep the
 # suite fast. The assertions carry a wide margin so CI jitter cannot flip them.
 BLOCK_SECONDS = 0.4
-SAFETY_TIMEOUT = 15.0
 
 
 @pytest.fixture
 def session_manager():
     return SessionManager()
-
-
-async def _make_active_session(manager: SessionManager) -> str:
-    session_id = await manager.create_admin_session()
-    session = manager.get_session(session_id)
-    session.status = SessionStatus.ACTIVE
-    session.customer_language = "en"
-    return session_id
-
-
-def _audio_request() -> Mock:
-    request = Mock()
-    request.headers = {"content-type": "multipart/form-data; boundary=boundary"}
-    mock_file = Mock()
-    mock_file.read = AsyncMock(return_value=AUDIO_BYTES)
-    request.form = AsyncMock(
-        return_value={
-            "file": mock_file,
-            "source_lang": "de",
-            "target_lang": "en",
-            "client_type": "admin",
-        }
-    )
-    return request
-
-
-def _text_request() -> Mock:
-    request = Mock()
-    request.headers = {"content-type": "application/json"}
-    request.json = AsyncMock(
-        return_value={
-            "text": "Guten Tag",
-            "source_lang": "de",
-            "target_lang": "en",
-            "client_type": "admin",
-        }
-    )
-    return request
 
 
 class _ThreadRecorder:
@@ -110,7 +49,7 @@ class TestPipelineRunsOffTheEventLoop:
     async def test_audio_pipeline_runs_off_event_loop(self, session_manager):
         from services.api_gateway.routes import session as session_routes
 
-        session_id = await _make_active_session(session_manager)
+        session_id = await make_active_session(session_manager)
         recorder = _ThreadRecorder(PIPELINE_SUCCESS)
         loop_thread_id = threading.get_ident()
 
@@ -118,7 +57,7 @@ class TestPipelineRunsOffTheEventLoop:
             patch.object(session_routes, "session_manager", session_manager),
             patch.object(session_routes, "process_wav", new=recorder),
         ):
-            await session_routes.process_audio_input(session_id, _audio_request(), 0.0)
+            await session_routes.process_audio_input(session_id, audio_request(), 0.0)
 
         assert recorder.thread_ids, "process_wav was never called"
         assert recorder.thread_ids[0] != loop_thread_id, (
@@ -130,7 +69,7 @@ class TestPipelineRunsOffTheEventLoop:
     async def test_text_pipeline_runs_off_event_loop(self, session_manager):
         from services.api_gateway.routes import session as session_routes
 
-        session_id = await _make_active_session(session_manager)
+        session_id = await make_active_session(session_manager)
         recorder = _ThreadRecorder(TEXT_PIPELINE_SUCCESS)
         loop_thread_id = threading.get_ident()
 
@@ -138,7 +77,7 @@ class TestPipelineRunsOffTheEventLoop:
             patch.object(session_routes, "session_manager", session_manager),
             patch.object(session_routes, "process_text_pipeline", new=recorder),
         ):
-            await session_routes.process_text_input(session_id, _text_request(), 0.0)
+            await session_routes.process_text_input(session_id, text_request(), 0.0)
 
         assert recorder.thread_ids, "process_text_pipeline was never called"
         assert (
@@ -150,12 +89,12 @@ class TestPipelineRunsOffTheEventLoop:
         recorder = _ThreadRecorder(PIPELINE_SUCCESS)
         loop_thread_id = threading.get_ident()
 
-        upload_file = Mock()
-        upload_file.read = AsyncMock(return_value=AUDIO_BYTES)
-
         with patch.object(upload_route, "process_wav", new=recorder):
             await upload_route.upload(
-                request=Mock(), file=upload_file, source_lang="de", target_lang="en"
+                request=request_with(),
+                file=upload_file(),
+                source_lang="de",
+                target_lang="en",
             )
 
         assert recorder.thread_ids, "process_wav was never called"
@@ -168,17 +107,10 @@ class TestPipelineRunsOffTheEventLoop:
         recorder = _ThreadRecorder(PIPELINE_SUCCESS)
         loop_thread_id = threading.get_ident()
 
-        upload_file = Mock()
-        upload_file.read = AsyncMock(return_value=AUDIO_BYTES)
-
-        request = Mock()
-        request.query_params = {}
-        request.headers = {}
-
         with patch.object(pipeline_route, "process_wav", new=recorder):
             await pipeline_route.pipeline(
-                request=request,
-                file=upload_file,
+                request=legacy_pipeline_request(),
+                file=upload_file(),
                 source_lang="de",
                 target_lang="en",
                 debug=None,
@@ -197,8 +129,8 @@ class TestConcurrentProgress:
     async def test_two_audio_messages_progress_concurrently(self, session_manager):
         from services.api_gateway.routes import session as session_routes
 
-        first = await _make_active_session(session_manager)
-        second = await _make_active_session(session_manager)
+        first = await make_active_session(session_manager)
+        second = await make_active_session(session_manager)
 
         # Trips only if both pipelines are inside the barrier at the same time.
         # Serialised execution breaks it instead, which fails the test.
@@ -214,8 +146,8 @@ class TestConcurrentProgress:
         ):
             results = await asyncio.wait_for(
                 asyncio.gather(
-                    session_routes.process_audio_input(first, _audio_request(), 0.0),
-                    session_routes.process_audio_input(second, _audio_request(), 0.0),
+                    session_routes.process_audio_input(first, audio_request(), 0.0),
+                    session_routes.process_audio_input(second, audio_request(), 0.0),
                 ),
                 timeout=SAFETY_TIMEOUT,
             )
@@ -261,7 +193,7 @@ class TestEventLoopResponsiveness:
     async def test_loop_keeps_ticking_during_audio_pipeline(self, session_manager):
         from services.api_gateway.routes import session as session_routes
 
-        session_id = await _make_active_session(session_manager)
+        session_id = await make_active_session(session_manager)
         entered = threading.Event()
 
         with (
@@ -273,7 +205,7 @@ class TestEventLoopResponsiveness:
             ),
         ):
             ticks = await self._count_ticks_during(
-                session_routes.process_audio_input(session_id, _audio_request(), 0.0),
+                session_routes.process_audio_input(session_id, audio_request(), 0.0),
                 entered,
             )
 
@@ -289,7 +221,7 @@ class TestEventLoopResponsiveness:
     async def test_loop_keeps_ticking_during_text_pipeline(self, session_manager):
         from services.api_gateway.routes import session as session_routes
 
-        session_id = await _make_active_session(session_manager)
+        session_id = await make_active_session(session_manager)
         entered = threading.Event()
 
         with (
@@ -301,7 +233,7 @@ class TestEventLoopResponsiveness:
             ),
         ):
             ticks = await self._count_ticks_during(
-                session_routes.process_text_input(session_id, _text_request(), 0.0),
+                session_routes.process_text_input(session_id, text_request(), 0.0),
                 entered,
             )
 

--- a/tests/test_gateway_event_loop_non_blocking.py
+++ b/tests/test_gateway_event_loop_non_blocking.py
@@ -1,0 +1,318 @@
+"""Regression coverage for issue #189.
+
+The gateway pipeline entry points are synchronous and spend their time in
+blocking ``requests.post`` calls. Calling them straight from an ``async def``
+route handler pins the single event loop thread for the whole pipeline, which
+serialises every session and starves health checks and WebSocket heartbeats.
+
+These tests pin the non-blocking property itself, not an implementation detail:
+the pipeline must not run on the event loop thread, two messages must make
+progress at the same time, and the loop must keep ticking while a pipeline is
+in flight.
+"""
+
+import asyncio
+import importlib
+import threading
+import time
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from services.api_gateway.session_manager import SessionManager, SessionStatus
+
+# routes/__init__.py re-exports the endpoint functions under their module names,
+# so `routes.upload` is the handler rather than the module. Import by path.
+upload_route = importlib.import_module("services.api_gateway.routes.upload")
+pipeline_route = importlib.import_module("services.api_gateway.routes.pipeline")
+
+AUDIO_BYTES = b"RIFF" + b"fake_wav_audio_data" + b"\x00" * 100
+
+PIPELINE_SUCCESS = {
+    "error": False,
+    "asr_text": "Guten Tag",
+    "translation_text": "Good day",
+    "audio_bytes": b"fake_output_audio",
+}
+
+TEXT_PIPELINE_SUCCESS = {
+    "error": False,
+    "translation_text": "Guten Tag",
+    "audio_bytes": b"fake_output_audio",
+    "debug": {},
+}
+
+# Long enough that a blocked loop is unmistakable, short enough to keep the
+# suite fast. The assertions carry a wide margin so CI jitter cannot flip them.
+BLOCK_SECONDS = 0.4
+SAFETY_TIMEOUT = 15.0
+
+
+@pytest.fixture
+def session_manager():
+    return SessionManager()
+
+
+async def _make_active_session(manager: SessionManager) -> str:
+    session_id = await manager.create_admin_session()
+    session = manager.get_session(session_id)
+    session.status = SessionStatus.ACTIVE
+    session.customer_language = "en"
+    return session_id
+
+
+def _audio_request() -> Mock:
+    request = Mock()
+    request.headers = {"content-type": "multipart/form-data; boundary=boundary"}
+    mock_file = Mock()
+    mock_file.read = AsyncMock(return_value=AUDIO_BYTES)
+    request.form = AsyncMock(
+        return_value={
+            "file": mock_file,
+            "source_lang": "de",
+            "target_lang": "en",
+            "client_type": "admin",
+        }
+    )
+    return request
+
+
+def _text_request() -> Mock:
+    request = Mock()
+    request.headers = {"content-type": "application/json"}
+    request.json = AsyncMock(
+        return_value={
+            "text": "Guten Tag",
+            "source_lang": "de",
+            "target_lang": "en",
+            "client_type": "admin",
+        }
+    )
+    return request
+
+
+class _ThreadRecorder:
+    """Stands in for a pipeline function and records where it ran."""
+
+    def __init__(self, result):
+        self._result = result
+        self.thread_ids: list[int] = []
+
+    def __call__(self, *args, **kwargs):
+        self.thread_ids.append(threading.get_ident())
+        return dict(self._result)
+
+
+class TestPipelineRunsOffTheEventLoop:
+    """The pipeline body must execute on a worker thread, not the loop thread."""
+
+    @pytest.mark.asyncio
+    async def test_audio_pipeline_runs_off_event_loop(self, session_manager):
+        from services.api_gateway.routes import session as session_routes
+
+        session_id = await _make_active_session(session_manager)
+        recorder = _ThreadRecorder(PIPELINE_SUCCESS)
+        loop_thread_id = threading.get_ident()
+
+        with (
+            patch.object(session_routes, "session_manager", session_manager),
+            patch.object(session_routes, "process_wav", new=recorder),
+        ):
+            await session_routes.process_audio_input(session_id, _audio_request(), 0.0)
+
+        assert recorder.thread_ids, "process_wav was never called"
+        assert recorder.thread_ids[0] != loop_thread_id, (
+            "process_wav ran on the event loop thread; its blocking HTTP calls "
+            "hold the loop for the whole pipeline"
+        )
+
+    @pytest.mark.asyncio
+    async def test_text_pipeline_runs_off_event_loop(self, session_manager):
+        from services.api_gateway.routes import session as session_routes
+
+        session_id = await _make_active_session(session_manager)
+        recorder = _ThreadRecorder(TEXT_PIPELINE_SUCCESS)
+        loop_thread_id = threading.get_ident()
+
+        with (
+            patch.object(session_routes, "session_manager", session_manager),
+            patch.object(session_routes, "process_text_pipeline", new=recorder),
+        ):
+            await session_routes.process_text_input(session_id, _text_request(), 0.0)
+
+        assert recorder.thread_ids, "process_text_pipeline was never called"
+        assert (
+            recorder.thread_ids[0] != loop_thread_id
+        ), "process_text_pipeline ran on the event loop thread"
+
+    @pytest.mark.asyncio
+    async def test_legacy_upload_route_runs_off_event_loop(self):
+        recorder = _ThreadRecorder(PIPELINE_SUCCESS)
+        loop_thread_id = threading.get_ident()
+
+        upload_file = Mock()
+        upload_file.read = AsyncMock(return_value=AUDIO_BYTES)
+
+        with patch.object(upload_route, "process_wav", new=recorder):
+            await upload_route.upload(
+                request=Mock(), file=upload_file, source_lang="de", target_lang="en"
+            )
+
+        assert recorder.thread_ids, "process_wav was never called"
+        assert (
+            recorder.thread_ids[0] != loop_thread_id
+        ), "the /upload route ran the pipeline on the event loop thread"
+
+    @pytest.mark.asyncio
+    async def test_legacy_pipeline_route_runs_off_event_loop(self):
+        recorder = _ThreadRecorder(PIPELINE_SUCCESS)
+        loop_thread_id = threading.get_ident()
+
+        upload_file = Mock()
+        upload_file.read = AsyncMock(return_value=AUDIO_BYTES)
+
+        request = Mock()
+        request.query_params = {}
+        request.headers = {}
+
+        with patch.object(pipeline_route, "process_wav", new=recorder):
+            await pipeline_route.pipeline(
+                request=request,
+                file=upload_file,
+                source_lang="de",
+                target_lang="en",
+                debug=None,
+            )
+
+        assert recorder.thread_ids, "process_wav was never called"
+        assert (
+            recorder.thread_ids[0] != loop_thread_id
+        ), "the /pipeline route ran the pipeline on the event loop thread"
+
+
+class TestConcurrentProgress:
+    """Two independent messages must make progress concurrently."""
+
+    @pytest.mark.asyncio
+    async def test_two_audio_messages_progress_concurrently(self, session_manager):
+        from services.api_gateway.routes import session as session_routes
+
+        first = await _make_active_session(session_manager)
+        second = await _make_active_session(session_manager)
+
+        # Trips only if both pipelines are inside the barrier at the same time.
+        # Serialised execution breaks it instead, which fails the test.
+        barrier = threading.Barrier(2)
+
+        def rendezvous(*args, **kwargs):
+            barrier.wait(timeout=BLOCK_SECONDS * 10)
+            return dict(PIPELINE_SUCCESS)
+
+        with (
+            patch.object(session_routes, "session_manager", session_manager),
+            patch.object(session_routes, "process_wav", new=rendezvous),
+        ):
+            results = await asyncio.wait_for(
+                asyncio.gather(
+                    session_routes.process_audio_input(first, _audio_request(), 0.0),
+                    session_routes.process_audio_input(second, _audio_request(), 0.0),
+                ),
+                timeout=SAFETY_TIMEOUT,
+            )
+
+        assert [result.status for result in results] == ["success", "success"]
+
+
+class TestEventLoopResponsiveness:
+    """Health checks and heartbeats must still be served mid-pipeline."""
+
+    @staticmethod
+    def _blocking_pipeline(entered: threading.Event, result):
+        def run(*args, **kwargs):
+            entered.set()
+            time.sleep(BLOCK_SECONDS)
+            return dict(result)
+
+        return run
+
+    async def _count_ticks_during(self, coro, entered: threading.Event) -> int:
+        """Ticks the loop while ``coro`` runs, counting only in-flight ticks."""
+        task = asyncio.create_task(coro)
+        deadline = time.perf_counter() + SAFETY_TIMEOUT
+
+        while not entered.is_set() and not task.done():
+            if time.perf_counter() > deadline:
+                task.cancel()
+                pytest.fail("pipeline never started")
+            await asyncio.sleep(0.005)
+
+        ticks = 0
+        while not task.done():
+            if time.perf_counter() > deadline:
+                task.cancel()
+                pytest.fail("pipeline never finished")
+            await asyncio.sleep(0.01)
+            ticks += 1
+
+        await task
+        return ticks
+
+    @pytest.mark.asyncio
+    async def test_loop_keeps_ticking_during_audio_pipeline(self, session_manager):
+        from services.api_gateway.routes import session as session_routes
+
+        session_id = await _make_active_session(session_manager)
+        entered = threading.Event()
+
+        with (
+            patch.object(session_routes, "session_manager", session_manager),
+            patch.object(
+                session_routes,
+                "process_wav",
+                new=self._blocking_pipeline(entered, PIPELINE_SUCCESS),
+            ),
+        ):
+            ticks = await self._count_ticks_during(
+                session_routes.process_audio_input(session_id, _audio_request(), 0.0),
+                entered,
+            )
+
+        # A free loop manages roughly BLOCK_SECONDS / 0.01 ticks; a blocked one
+        # manages none. The threshold sits an order of magnitude below the
+        # expected count so scheduling jitter cannot flip the result.
+        assert ticks >= 5, (
+            f"event loop completed only {ticks} ticks while the audio pipeline "
+            "was in flight; it was blocked"
+        )
+
+    @pytest.mark.asyncio
+    async def test_loop_keeps_ticking_during_text_pipeline(self, session_manager):
+        from services.api_gateway.routes import session as session_routes
+
+        session_id = await _make_active_session(session_manager)
+        entered = threading.Event()
+
+        with (
+            patch.object(session_routes, "session_manager", session_manager),
+            patch.object(
+                session_routes,
+                "process_text_pipeline",
+                new=self._blocking_pipeline(entered, TEXT_PIPELINE_SUCCESS),
+            ),
+        ):
+            ticks = await self._count_ticks_during(
+                session_routes.process_text_input(session_id, _text_request(), 0.0),
+                entered,
+            )
+
+        assert ticks >= 5, (
+            f"event loop completed only {ticks} ticks while the text pipeline "
+            "was in flight; it was blocked"
+        )
+
+
+def test_unused_process_wav_for_session_helper_is_gone():
+    """#189 asks for the dead session helper to be removed."""
+    from services.api_gateway import pipeline_logic
+
+    assert not hasattr(pipeline_logic, "process_wav_for_session")

--- a/tests/test_pipeline_admission.py
+++ b/tests/test_pipeline_admission.py
@@ -1,0 +1,730 @@
+"""Coverage for issue #191: bounded pipeline admission control.
+
+One RTX 4000 Ada serves ASR, translation and TTS, and each of those services
+holds a single shared model with no lock of its own. Once #189 let pipelines run
+concurrently, nothing bounded how many reached the GPU at once. These tests pin
+the bound, the `SYSTEM_BUSY` rejection contract, and the property that the bound
+never touches non-pipeline traffic.
+"""
+
+import asyncio
+import importlib
+import threading
+import time
+from unittest.mock import AsyncMock, Mock, patch
+
+import httpx
+import pytest
+from prometheus_client import CollectorRegistry
+
+from services.api_gateway.pipeline_admission import (
+    PipelineAdmission,
+    PipelineAdmissionConfig,
+    PipelineAdmissionMetrics,
+    PipelineBusyError,
+    run_pipeline,
+)
+from services.api_gateway.session_manager import SessionManager, SessionStatus
+
+# routes/__init__.py re-exports the endpoint functions under their module names,
+# so `routes.upload` is the handler rather than the module. Import by path.
+upload_route = importlib.import_module("services.api_gateway.routes.upload")
+pipeline_route = importlib.import_module("services.api_gateway.routes.pipeline")
+health_route = importlib.import_module("services.api_gateway.routes.health")
+
+AUDIO_BYTES = b"RIFF" + b"fake_wav_audio_data" + b"\x00" * 100
+
+PIPELINE_SUCCESS = {
+    "error": False,
+    "asr_text": "Guten Tag",
+    "translation_text": "Good day",
+    "audio_bytes": b"fake_output_audio",
+}
+
+TEXT_PIPELINE_SUCCESS = {
+    "error": False,
+    "translation_text": "Guten Tag",
+    "audio_bytes": b"fake_output_audio",
+    "debug": {},
+}
+
+# Short enough to keep the suite fast; every assertion below is about ordering
+# or rejection, never about a wall-clock duration.
+SHORT_WAIT = 0.05
+SAFETY_TIMEOUT = 15.0
+
+
+def _metrics() -> PipelineAdmissionMetrics:
+    """Metrics on a throwaway registry, so each test registers its own series."""
+    return PipelineAdmissionMetrics(CollectorRegistry())
+
+
+def _admission(max_concurrent: int, wait: float = SHORT_WAIT, *, metrics=None) -> PipelineAdmission:
+    return PipelineAdmission(
+        PipelineAdmissionConfig(max_concurrent=max_concurrent, queue_wait_seconds=wait),
+        metrics=metrics,
+    )
+
+
+def _noop() -> None:
+    return None
+
+
+async def _wait_for_in_flight(admission: PipelineAdmission, count: int) -> None:
+    """Slots are released from worker threads, so settling takes a loop tick."""
+    deadline = time.perf_counter() + SAFETY_TIMEOUT
+    while admission.in_flight != count:
+        if time.perf_counter() > deadline:
+            raise AssertionError(f"in_flight settled at {admission.in_flight}, expected {count}")
+        await asyncio.sleep(0.005)
+
+
+class _Saturated:
+    """Holds every slot with real thread work, so the next request is rejected."""
+
+    def __init__(self, admission: PipelineAdmission) -> None:
+        self._admission = admission
+        self._finish = threading.Event()
+        self._holders: list[asyncio.Task] = []
+
+    def _block(self):
+        self._finish.wait(SAFETY_TIMEOUT)
+        return dict(PIPELINE_SUCCESS)
+
+    async def __aenter__(self) -> "_Saturated":
+        wanted = self._admission.config.max_concurrent
+        self._holders = [
+            asyncio.create_task(self._admission.run(self._block)) for _ in range(wanted)
+        ]
+        await _wait_for_in_flight(self._admission, wanted)
+        return self
+
+    async def __aexit__(self, *_exc_info) -> bool:
+        self._finish.set()
+        await asyncio.wait_for(asyncio.gather(*self._holders), timeout=SAFETY_TIMEOUT)
+        return False
+
+
+@pytest.fixture
+def session_manager():
+    return SessionManager()
+
+
+async def _make_active_session(manager) -> str:
+    session_id = await manager.create_admin_session()
+    session = manager.get_session(session_id)
+    session.status = SessionStatus.ACTIVE
+    session.customer_language = "en"
+    return session_id
+
+
+def _request_with(admission) -> Mock:
+    request = Mock()
+    request.app.state.pipeline_admission = admission
+    return request
+
+
+def _audio_request(admission=None) -> Mock:
+    request = _request_with(admission)
+    request.headers = {"content-type": "multipart/form-data; boundary=boundary"}
+    mock_file = Mock()
+    mock_file.read = AsyncMock(return_value=AUDIO_BYTES)
+    request.form = AsyncMock(
+        return_value={
+            "file": mock_file,
+            "source_lang": "de",
+            "target_lang": "en",
+            "client_type": "admin",
+        }
+    )
+    return request
+
+
+def _text_request(admission=None) -> Mock:
+    request = _request_with(admission)
+    request.headers = {"content-type": "application/json"}
+    request.json = AsyncMock(
+        return_value={
+            "text": "Guten Tag",
+            "source_lang": "de",
+            "target_lang": "en",
+            "client_type": "admin",
+        }
+    )
+    return request
+
+
+class TestConfiguration:
+    """The limit and wait timeout are typed, documented configuration."""
+
+    def test_defaults_are_conservative(self, monkeypatch):
+        monkeypatch.delenv("MAX_CONCURRENT_PIPELINES", raising=False)
+        monkeypatch.delenv("PIPELINE_QUEUE_WAIT_SECONDS", raising=False)
+
+        config = PipelineAdmissionConfig()
+
+        assert config.max_concurrent == 2
+        assert config.queue_wait_seconds == pytest.approx(10.0)
+
+    def test_reads_environment_at_instantiation(self, monkeypatch):
+        monkeypatch.setenv("MAX_CONCURRENT_PIPELINES", "7")
+        monkeypatch.setenv("PIPELINE_QUEUE_WAIT_SECONDS", "2.5")
+
+        config = PipelineAdmissionConfig()
+
+        assert config.max_concurrent == 7
+        assert config.queue_wait_seconds == pytest.approx(2.5)
+
+    def test_unparseable_environment_falls_back_to_default(self, monkeypatch):
+        """A typo in an env var must not stop the gateway from booting."""
+        monkeypatch.setenv("MAX_CONCURRENT_PIPELINES", "not-a-number")
+        monkeypatch.setenv("PIPELINE_QUEUE_WAIT_SECONDS", "")
+
+        config = PipelineAdmissionConfig()
+
+        assert config.max_concurrent == 2
+        assert config.queue_wait_seconds == pytest.approx(10.0)
+
+    def test_negative_limit_falls_back_rather_than_disabling(self, monkeypatch):
+        """Only an explicit 0 disables; a negative is a typo, not consent."""
+        monkeypatch.setenv("MAX_CONCURRENT_PIPELINES", "-1")
+
+        config = PipelineAdmissionConfig()
+
+        assert config.max_concurrent == 2
+        assert PipelineAdmission(config).enabled is True
+
+    def test_negative_wait_falls_back_to_default(self):
+        config = PipelineAdmissionConfig(max_concurrent=1, queue_wait_seconds=-5.0)
+
+        assert config.queue_wait_seconds == pytest.approx(10.0)
+
+    def test_zero_is_the_documented_kill_switch(self, monkeypatch):
+        monkeypatch.setenv("MAX_CONCURRENT_PIPELINES", "0")
+
+        config = PipelineAdmissionConfig()
+
+        assert config.max_concurrent == 0
+        assert PipelineAdmission(config).enabled is False
+
+
+class TestSlotBounding:
+    """The component admits up to the limit and rejects beyond it."""
+
+    @pytest.mark.asyncio
+    async def test_admits_up_to_the_limit_concurrently(self):
+        admission = _admission(2, wait=SAFETY_TIMEOUT)
+        # Trips only if both pipelines are inside their slots at the same time.
+        barrier = threading.Barrier(2)
+
+        def rendezvous():
+            barrier.wait(timeout=SAFETY_TIMEOUT)
+            return dict(PIPELINE_SUCCESS)
+
+        await asyncio.wait_for(
+            asyncio.gather(admission.run(rendezvous), admission.run(rendezvous)),
+            timeout=SAFETY_TIMEOUT,
+        )
+
+    @pytest.mark.asyncio
+    async def test_rejects_beyond_the_limit(self):
+        admission = _admission(1)
+
+        async with _Saturated(admission):
+            with pytest.raises(PipelineBusyError) as excinfo:
+                await admission.run(_noop)
+
+        assert excinfo.value.max_concurrent == 1
+        assert excinfo.value.retry_after_seconds >= 1
+        assert excinfo.value.retry_after_header == "1"
+
+    @pytest.mark.asyncio
+    async def test_slot_is_returned_after_use(self):
+        admission = _admission(1)
+
+        await admission.run(_noop)
+        # Would raise PipelineBusyError if the first slot had leaked.
+        await admission.run(_noop)
+        assert admission.in_flight == 0
+
+    @pytest.mark.asyncio
+    async def test_slot_is_returned_when_the_pipeline_raises(self):
+        admission = _admission(1)
+
+        def boom():
+            raise ValueError("pipeline blew up")
+
+        with pytest.raises(ValueError):
+            await admission.run(boom)
+
+        await admission.run(_noop)
+
+    @pytest.mark.asyncio
+    async def test_a_waiter_is_admitted_once_a_slot_frees(self):
+        admission = _admission(1, wait=SAFETY_TIMEOUT)
+        order: list[str] = []
+        finish = threading.Event()
+
+        def first():
+            order.append("first-in")
+            finish.wait(SAFETY_TIMEOUT)
+            order.append("first-out")
+
+        def second():
+            order.append("second-in")
+
+        first_task = asyncio.create_task(admission.run(first))
+        await _wait_for_in_flight(admission, 1)
+        second_task = asyncio.create_task(admission.run(second))
+
+        finish.set()
+        await asyncio.wait_for(asyncio.gather(first_task, second_task), timeout=SAFETY_TIMEOUT)
+
+        assert order == ["first-in", "first-out", "second-in"]
+
+    @pytest.mark.asyncio
+    async def test_zero_limit_disables_the_bound(self):
+        admission = _admission(0)
+        barrier = threading.Barrier(3)
+
+        def rendezvous():
+            barrier.wait(timeout=SAFETY_TIMEOUT)
+
+        await asyncio.wait_for(
+            asyncio.gather(*(admission.run(rendezvous) for _ in range(3))),
+            timeout=SAFETY_TIMEOUT,
+        )
+
+
+class TestCancellationCannotFreeCapacityEarly:
+    """A cancelled request must not hand back a slot its thread is still using."""
+
+    @pytest.mark.asyncio
+    async def test_cancelled_request_keeps_its_slot_until_the_thread_finishes(self):
+        admission = _admission(1)
+        running = threading.Event()
+        finish = threading.Event()
+
+        def blocking():
+            running.set()
+            finish.wait(SAFETY_TIMEOUT)
+            return dict(PIPELINE_SUCCESS)
+
+        task = asyncio.create_task(admission.run(blocking))
+        await asyncio.wait_for(
+            asyncio.to_thread(running.wait, SAFETY_TIMEOUT), timeout=SAFETY_TIMEOUT
+        )
+
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        # asyncio.to_thread cannot interrupt the call it started, so the
+        # pipeline is still on the GPU and its slot must stay taken.
+        assert admission.in_flight == 1
+        with pytest.raises(PipelineBusyError):
+            await admission.run(_noop)
+
+        finish.set()
+        await _wait_for_in_flight(admission, 0)
+        # Capacity comes back once the thread really is done.
+        await admission.run(_noop)
+
+
+class TestMetrics:
+    """Metrics support capacity tuning through load tests."""
+
+    @staticmethod
+    def _sample(metric, suffix=""):
+        name = metric._name + suffix
+        for collected in metric.collect():
+            for sample in collected.samples:
+                if sample.name == name:
+                    return sample.value
+        raise AssertionError(f"no sample named {name}")
+
+    @pytest.mark.asyncio
+    async def test_in_flight_rises_and_falls(self):
+        metrics = _metrics()
+        admission = _admission(1, metrics=metrics)
+        inside = None
+        release = threading.Event()
+
+        def observe():
+            release.wait(SAFETY_TIMEOUT)
+
+        task = asyncio.create_task(admission.run(observe))
+        await _wait_for_in_flight(admission, 1)
+        inside = self._sample(metrics.in_flight)
+        release.set()
+        await asyncio.wait_for(task, timeout=SAFETY_TIMEOUT)
+
+        assert inside == 1
+        assert self._sample(metrics.in_flight) == 0
+
+    @pytest.mark.asyncio
+    async def test_queue_wait_is_observed_when_admitted(self):
+        metrics = _metrics()
+        admission = _admission(1, metrics=metrics)
+
+        await admission.run(_noop)
+
+        assert self._sample(metrics.queue_wait, "_count") == 1
+
+    @pytest.mark.asyncio
+    async def test_queue_wait_is_observed_on_rejection(self):
+        """A histogram blind to rejections reports 'seated instantly' at saturation."""
+        metrics = _metrics()
+        admission = _admission(1, metrics=metrics)
+
+        async with _Saturated(admission):
+            with pytest.raises(PipelineBusyError):
+                await admission.run(_noop)
+
+        # One holder was admitted, one request was rejected: both waited.
+        assert self._sample(metrics.queue_wait, "_count") == 2
+        assert self._sample(metrics.rejected, "_total") == 1
+        # The rejected request waited the full window, so the sum must reflect
+        # it rather than rounding to nothing.
+        assert self._sample(metrics.queue_wait, "_sum") >= SHORT_WAIT
+
+    @pytest.mark.asyncio
+    async def test_rejection_is_counted(self):
+        metrics = _metrics()
+        admission = _admission(1, metrics=metrics)
+
+        async with _Saturated(admission):
+            with pytest.raises(PipelineBusyError):
+                await admission.run(_noop)
+
+        assert self._sample(metrics.rejected, "_total") == 1
+
+
+class TestRunPipelineHelper:
+    """The handlers must degrade to unbounded rather than fail on a mock request."""
+
+    @pytest.mark.asyncio
+    async def test_runs_unbounded_when_state_has_no_admission(self):
+        assert await run_pipeline(Mock(), lambda: "ran") == "ran"
+
+    @pytest.mark.asyncio
+    async def test_runs_unbounded_when_request_has_no_app(self):
+        assert await run_pipeline(object(), lambda: "ran") == "ran"
+
+    @pytest.mark.asyncio
+    async def test_passes_arguments_through(self):
+        result = await run_pipeline(Mock(), lambda a, b, c=None: (a, b, c), 1, 2, c=3)
+
+        assert result == (1, 2, 3)
+
+    @pytest.mark.asyncio
+    async def test_enforces_when_a_real_component_is_present(self):
+        admission = _admission(1)
+        request = _request_with(admission)
+
+        async with _Saturated(admission):
+            with pytest.raises(PipelineBusyError):
+                await run_pipeline(request, _noop)
+
+
+class TestSystemBusyResponse:
+    """A saturated system returns the standard envelope with SYSTEM_BUSY."""
+
+    @pytest.mark.asyncio
+    async def test_audio_path_returns_503_system_busy(self, session_manager):
+        from fastapi import HTTPException
+
+        from services.api_gateway.routes import session as session_routes
+
+        session_id = await _make_active_session(session_manager)
+        admission = _admission(1)
+
+        with (
+            patch.object(session_routes, "session_manager", session_manager),
+            patch.object(session_routes, "process_wav", return_value=dict(PIPELINE_SUCCESS)),
+        ):
+            async with _Saturated(admission):
+                with pytest.raises(HTTPException) as excinfo:
+                    await session_routes.process_audio_input(
+                        session_id, _audio_request(admission), 0.0
+                    )
+
+        error = excinfo.value
+        assert error.status_code == 503
+        assert error.detail["error_code"] == "SYSTEM_BUSY"
+        assert error.headers["Retry-After"] == "1"
+
+    @pytest.mark.asyncio
+    async def test_text_path_returns_503_system_busy(self, session_manager):
+        from fastapi import HTTPException
+
+        from services.api_gateway.routes import session as session_routes
+
+        session_id = await _make_active_session(session_manager)
+        admission = _admission(1)
+
+        with (
+            patch.object(session_routes, "session_manager", session_manager),
+            patch.object(
+                session_routes, "process_text_pipeline", return_value=dict(TEXT_PIPELINE_SUCCESS)
+            ),
+        ):
+            async with _Saturated(admission):
+                with pytest.raises(HTTPException) as excinfo:
+                    await session_routes.process_text_input(
+                        session_id, _text_request(admission), 0.0
+                    )
+
+        error = excinfo.value
+        assert error.status_code == 503
+        assert error.detail["error_code"] == "SYSTEM_BUSY"
+        assert error.headers["Retry-After"] == "1"
+
+    @pytest.mark.asyncio
+    async def test_body_advises_the_same_delay_as_the_header(self, session_manager):
+        """A client reading the body must not retry sooner than the header allows."""
+        from fastapi import HTTPException
+
+        from services.api_gateway.routes import session as session_routes
+
+        session_id = await _make_active_session(session_manager)
+        admission = _admission(1, wait=0.2)
+
+        with (
+            patch.object(session_routes, "session_manager", session_manager),
+            patch.object(
+                session_routes, "process_text_pipeline", return_value=dict(TEXT_PIPELINE_SUCCESS)
+            ),
+        ):
+            async with _Saturated(admission):
+                with pytest.raises(HTTPException) as excinfo:
+                    await session_routes.process_text_input(
+                        session_id, _text_request(admission), 0.0
+                    )
+
+        error = excinfo.value
+        assert error.detail["details"]["retry_after_seconds"] == int(error.headers["Retry-After"])
+        # The raw window stays available, under a name that cannot be mistaken
+        # for an advised delay.
+        assert error.detail["details"]["queue_wait_seconds"] == pytest.approx(0.2)
+
+    @pytest.mark.asyncio
+    async def test_busy_error_does_not_become_a_500(self, session_manager):
+        """send_unified_message catches broad Exceptions; SYSTEM_BUSY must survive."""
+        from fastapi import HTTPException
+
+        from services.api_gateway.routes import session as session_routes
+
+        session_id = await _make_active_session(session_manager)
+        admission = _admission(1)
+
+        with (
+            patch.object(session_routes, "session_manager", session_manager),
+            patch.object(
+                session_routes, "process_text_pipeline", return_value=dict(TEXT_PIPELINE_SUCCESS)
+            ),
+        ):
+            async with _Saturated(admission):
+                with pytest.raises(HTTPException) as excinfo:
+                    await session_routes.send_unified_message(session_id, _text_request(admission))
+
+        assert excinfo.value.status_code == 503
+        assert excinfo.value.detail["error_code"] == "SYSTEM_BUSY"
+
+    @pytest.mark.asyncio
+    async def test_slot_is_released_so_the_next_message_succeeds(self, session_manager):
+        from services.api_gateway.routes import session as session_routes
+
+        session_id = await _make_active_session(session_manager)
+        admission = _admission(1)
+
+        with (
+            patch.object(session_routes, "session_manager", session_manager),
+            patch.object(
+                session_routes, "process_text_pipeline", return_value=dict(TEXT_PIPELINE_SUCCESS)
+            ),
+        ):
+            first = await session_routes.process_text_input(
+                session_id, _text_request(admission), 0.0
+            )
+            second = await session_routes.process_text_input(
+                session_id, _text_request(admission), 0.0
+            )
+
+        assert first.status == "success"
+        assert second.status == "success"
+        assert admission.in_flight == 0
+
+
+class TestEndToEndOverTheWire:
+    """Proves env -> lifespan -> app.state -> route -> HTTP response, headers included."""
+
+    @pytest.mark.asyncio
+    async def test_saturated_gateway_answers_503_with_retry_after(self, monkeypatch):
+        from services.api_gateway.app import app, lifespan
+        from services.api_gateway.routes import session as session_routes
+        from services.api_gateway.session_manager import session_manager as live_manager
+
+        monkeypatch.setenv("MAX_CONCURRENT_PIPELINES", "1")
+        monkeypatch.setenv("PIPELINE_QUEUE_WAIT_SECONDS", "0.1")
+
+        started = threading.Event()
+        finish = threading.Event()
+
+        def blocking_text(*_args, **_kwargs):
+            started.set()
+            finish.wait(SAFETY_TIMEOUT)
+            return dict(TEXT_PIPELINE_SUCCESS)
+
+        payload = {
+            "text": "Guten Tag",
+            "source_lang": "de",
+            "target_lang": "en",
+            "client_type": "admin",
+        }
+
+        async with lifespan(app):
+            assert app.state.pipeline_admission.config.max_concurrent == 1
+
+            session_id = await _make_active_session(live_manager)
+            url = f"/api/session/{session_id}/message"
+
+            with patch.object(session_routes, "process_text_pipeline", new=blocking_text):
+                transport = httpx.ASGITransport(app=app)
+                async with httpx.AsyncClient(
+                    transport=transport, base_url="http://gateway.test"
+                ) as client:
+                    holder = asyncio.create_task(client.post(url, json=payload))
+                    await asyncio.wait_for(
+                        asyncio.to_thread(started.wait, SAFETY_TIMEOUT),
+                        timeout=SAFETY_TIMEOUT,
+                    )
+
+                    rejected = await asyncio.wait_for(
+                        client.post(url, json=payload), timeout=SAFETY_TIMEOUT
+                    )
+
+                    finish.set()
+                    admitted = await asyncio.wait_for(holder, timeout=SAFETY_TIMEOUT)
+
+        assert rejected.status_code == 503
+        assert rejected.headers["retry-after"] == "1"
+        body = rejected.json()
+        assert body["detail"]["error_code"] == "SYSTEM_BUSY"
+        assert body["detail"]["details"]["retry_after_seconds"] == 1
+        assert admitted.status_code == 200
+
+
+class TestLegacyRoutesAreGated:
+    """All four GPU call sites are bounded, not just the unified endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_upload_route_reports_busy(self):
+        admission = _admission(1)
+
+        upload_file = Mock()
+        upload_file.read = AsyncMock(return_value=AUDIO_BYTES)
+
+        with patch.object(upload_route, "process_wav", return_value=dict(PIPELINE_SUCCESS)):
+            async with _Saturated(admission):
+                response = await upload_route.upload(
+                    request=_request_with(admission),
+                    file=upload_file,
+                    source_lang="de",
+                    target_lang="en",
+                )
+
+        assert response.status_code == 503
+        assert response.headers["Retry-After"] == "1"
+
+    @pytest.mark.asyncio
+    async def test_pipeline_route_reports_busy(self):
+        admission = _admission(1)
+
+        upload_file = Mock()
+        upload_file.read = AsyncMock(return_value=AUDIO_BYTES)
+
+        request = _request_with(admission)
+        request.query_params = {}
+        request.headers = {}
+
+        with patch.object(pipeline_route, "process_wav", return_value=dict(PIPELINE_SUCCESS)):
+            async with _Saturated(admission):
+                response = await pipeline_route.pipeline(
+                    request=request,
+                    file=upload_file,
+                    source_lang="de",
+                    target_lang="en",
+                    debug=None,
+                )
+
+        assert response.status_code == 503
+        assert response.headers["Retry-After"] == "1"
+        assert b"SYSTEM_BUSY" in response.body
+
+
+class TestNonPipelineTrafficIsUnaffected:
+    """Health and session-management traffic bypass the bound."""
+
+    @pytest.mark.asyncio
+    async def test_session_management_responds_while_saturated(self, session_manager):
+        from services.api_gateway.routes import session as session_routes
+
+        session_id = await _make_active_session(session_manager)
+        admission = _admission(1)
+
+        async with _Saturated(admission):
+            with patch.object(session_routes, "session_manager", session_manager):
+                info = await asyncio.wait_for(
+                    session_routes.get_session_info(session_id), timeout=1.0
+                )
+                active = await asyncio.wait_for(session_routes.get_active_sessions(), timeout=1.0)
+
+        assert info["id"] == session_id
+        assert "sessions" in active
+
+    @pytest.mark.asyncio
+    async def test_health_route_never_touches_the_bound(self):
+        """/health is a sync def served off the loop and holds no slot."""
+        admission = _admission(1)
+
+        async with _Saturated(admission):
+            with patch.object(health_route, "requests") as mock_requests:
+                mock_requests.get.return_value = Mock(status_code=200)
+                result = await asyncio.wait_for(asyncio.to_thread(health_route.health), timeout=1.0)
+
+        assert set(result["services"].values()) == {"ok"}
+
+
+class TestLifespanOwnership:
+    """The component is created by the app lifespan, per #191."""
+
+    def test_lifespan_publishes_admission_on_app_state(self):
+        from fastapi.testclient import TestClient
+
+        from services.api_gateway.app import app
+
+        with TestClient(app):
+            admission = app.state.pipeline_admission
+            assert isinstance(admission, PipelineAdmission)
+            # Not >= 1: 0 is the documented kill switch, and this test must not
+            # fail for an operator who has set it.
+            assert admission.config.max_concurrent >= 0
+
+    def test_admission_is_not_a_module_level_singleton(self):
+        """The semaphore must belong to the running app, not import time."""
+        import services.api_gateway.pipeline_admission as module
+
+        assert not hasattr(module, "pipeline_admission")
+
+
+@pytest.mark.asyncio
+async def test_bound_is_process_local_by_design():
+    """Documents the #227 boundary: this bounds one replica, not the fleet."""
+    first = _admission(1)
+    second = _admission(1)
+
+    async with _Saturated(first):
+        # A second gateway process is unaffected by the first one's saturation.
+        await second.run(_noop)
+        assert first.in_flight == 1

--- a/tests/test_pipeline_admission.py
+++ b/tests/test_pipeline_admission.py
@@ -1,17 +1,7 @@
-"""Coverage for issue #191: bounded pipeline admission control.
-
-One RTX 4000 Ada serves ASR, translation and TTS, and each of those services
-holds a single shared model with no lock of its own. Once #189 let pipelines run
-concurrently, nothing bounded how many reached the GPU at once. These tests pin
-the bound, the `SYSTEM_BUSY` rejection contract, and the property that the bound
-never touches non-pipeline traffic.
-"""
-
 import asyncio
-import importlib
 import threading
 import time
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import Mock, patch
 
 import httpx
 import pytest
@@ -24,34 +14,25 @@ from services.api_gateway.pipeline_admission import (
     PipelineBusyError,
     run_pipeline,
 )
-from services.api_gateway.session_manager import SessionManager, SessionStatus
-
-# routes/__init__.py re-exports the endpoint functions under their module names,
-# so `routes.upload` is the handler rather than the module. Import by path.
-upload_route = importlib.import_module("services.api_gateway.routes.upload")
-pipeline_route = importlib.import_module("services.api_gateway.routes.pipeline")
-health_route = importlib.import_module("services.api_gateway.routes.health")
-
-AUDIO_BYTES = b"RIFF" + b"fake_wav_audio_data" + b"\x00" * 100
-
-PIPELINE_SUCCESS = {
-    "error": False,
-    "asr_text": "Guten Tag",
-    "translation_text": "Good day",
-    "audio_bytes": b"fake_output_audio",
-}
-
-TEXT_PIPELINE_SUCCESS = {
-    "error": False,
-    "translation_text": "Guten Tag",
-    "audio_bytes": b"fake_output_audio",
-    "debug": {},
-}
+from services.api_gateway.session_manager import SessionManager
+from tests.pipeline_helpers import (
+    PIPELINE_SUCCESS,
+    SAFETY_TIMEOUT,
+    TEXT_PIPELINE_SUCCESS,
+    audio_request,
+    health_route,
+    legacy_pipeline_request,
+    make_active_session,
+    pipeline_route,
+    request_with,
+    text_request,
+    upload_file,
+    upload_route,
+)
 
 # Short enough to keep the suite fast; every assertion below is about ordering
 # or rejection, never about a wall-clock duration.
 SHORT_WAIT = 0.05
-SAFETY_TIMEOUT = 15.0
 
 
 def _metrics() -> PipelineAdmissionMetrics:
@@ -110,50 +91,6 @@ def session_manager():
     return SessionManager()
 
 
-async def _make_active_session(manager) -> str:
-    session_id = await manager.create_admin_session()
-    session = manager.get_session(session_id)
-    session.status = SessionStatus.ACTIVE
-    session.customer_language = "en"
-    return session_id
-
-
-def _request_with(admission) -> Mock:
-    request = Mock()
-    request.app.state.pipeline_admission = admission
-    return request
-
-
-def _audio_request(admission=None) -> Mock:
-    request = _request_with(admission)
-    request.headers = {"content-type": "multipart/form-data; boundary=boundary"}
-    mock_file = Mock()
-    mock_file.read = AsyncMock(return_value=AUDIO_BYTES)
-    request.form = AsyncMock(
-        return_value={
-            "file": mock_file,
-            "source_lang": "de",
-            "target_lang": "en",
-            "client_type": "admin",
-        }
-    )
-    return request
-
-
-def _text_request(admission=None) -> Mock:
-    request = _request_with(admission)
-    request.headers = {"content-type": "application/json"}
-    request.json = AsyncMock(
-        return_value={
-            "text": "Guten Tag",
-            "source_lang": "de",
-            "target_lang": "en",
-            "client_type": "admin",
-        }
-    )
-    return request
-
-
 class TestConfiguration:
     """The limit and wait timeout are typed, documented configuration."""
 
@@ -198,6 +135,11 @@ class TestConfiguration:
         config = PipelineAdmissionConfig(max_concurrent=1, queue_wait_seconds=-5.0)
 
         assert config.queue_wait_seconds == pytest.approx(10.0)
+
+    def test_unparseable_wait_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv("PIPELINE_QUEUE_WAIT_SECONDS", "ten-seconds")
+
+        assert PipelineAdmissionConfig().queue_wait_seconds == pytest.approx(10.0)
 
     def test_zero_is_the_documented_kill_switch(self, monkeypatch):
         monkeypatch.setenv("MAX_CONCURRENT_PIPELINES", "0")
@@ -330,6 +272,21 @@ class TestCancellationCannotFreeCapacityEarly:
         # Capacity comes back once the thread really is done.
         await admission.run(_noop)
 
+    def test_release_never_raises_when_the_loop_is_already_gone(self):
+        """Reaches for the private because this runs in a worker thread's finally.
+
+        At shutdown the loop can be closed before the pipeline returns. Raising
+        there would surface as a spurious pipeline error, and there is no
+        capacity left to account for anyway.
+        """
+        admission = _admission(1)
+        closed_loop = Mock()
+        closed_loop.call_soon_threadsafe.side_effect = RuntimeError("Event loop is closed")
+
+        admission._schedule_release(closed_loop)
+
+        closed_loop.call_soon_threadsafe.assert_called_once()
+
 
 class TestMetrics:
     """Metrics support capacity tuning through load tests."""
@@ -420,7 +377,7 @@ class TestRunPipelineHelper:
     @pytest.mark.asyncio
     async def test_enforces_when_a_real_component_is_present(self):
         admission = _admission(1)
-        request = _request_with(admission)
+        request = request_with(admission)
 
         async with _Saturated(admission):
             with pytest.raises(PipelineBusyError):
@@ -436,7 +393,7 @@ class TestSystemBusyResponse:
 
         from services.api_gateway.routes import session as session_routes
 
-        session_id = await _make_active_session(session_manager)
+        session_id = await make_active_session(session_manager)
         admission = _admission(1)
 
         with (
@@ -446,7 +403,7 @@ class TestSystemBusyResponse:
             async with _Saturated(admission):
                 with pytest.raises(HTTPException) as excinfo:
                     await session_routes.process_audio_input(
-                        session_id, _audio_request(admission), 0.0
+                        session_id, audio_request(admission), 0.0
                     )
 
         error = excinfo.value
@@ -460,7 +417,7 @@ class TestSystemBusyResponse:
 
         from services.api_gateway.routes import session as session_routes
 
-        session_id = await _make_active_session(session_manager)
+        session_id = await make_active_session(session_manager)
         admission = _admission(1)
 
         with (
@@ -472,7 +429,7 @@ class TestSystemBusyResponse:
             async with _Saturated(admission):
                 with pytest.raises(HTTPException) as excinfo:
                     await session_routes.process_text_input(
-                        session_id, _text_request(admission), 0.0
+                        session_id, text_request(admission), 0.0
                     )
 
         error = excinfo.value
@@ -487,7 +444,7 @@ class TestSystemBusyResponse:
 
         from services.api_gateway.routes import session as session_routes
 
-        session_id = await _make_active_session(session_manager)
+        session_id = await make_active_session(session_manager)
         admission = _admission(1, wait=0.2)
 
         with (
@@ -499,7 +456,7 @@ class TestSystemBusyResponse:
             async with _Saturated(admission):
                 with pytest.raises(HTTPException) as excinfo:
                     await session_routes.process_text_input(
-                        session_id, _text_request(admission), 0.0
+                        session_id, text_request(admission), 0.0
                     )
 
         error = excinfo.value
@@ -515,7 +472,7 @@ class TestSystemBusyResponse:
 
         from services.api_gateway.routes import session as session_routes
 
-        session_id = await _make_active_session(session_manager)
+        session_id = await make_active_session(session_manager)
         admission = _admission(1)
 
         with (
@@ -526,7 +483,7 @@ class TestSystemBusyResponse:
         ):
             async with _Saturated(admission):
                 with pytest.raises(HTTPException) as excinfo:
-                    await session_routes.send_unified_message(session_id, _text_request(admission))
+                    await session_routes.send_unified_message(session_id, text_request(admission))
 
         assert excinfo.value.status_code == 503
         assert excinfo.value.detail["error_code"] == "SYSTEM_BUSY"
@@ -535,7 +492,7 @@ class TestSystemBusyResponse:
     async def test_slot_is_released_so_the_next_message_succeeds(self, session_manager):
         from services.api_gateway.routes import session as session_routes
 
-        session_id = await _make_active_session(session_manager)
+        session_id = await make_active_session(session_manager)
         admission = _admission(1)
 
         with (
@@ -545,10 +502,10 @@ class TestSystemBusyResponse:
             ),
         ):
             first = await session_routes.process_text_input(
-                session_id, _text_request(admission), 0.0
+                session_id, text_request(admission), 0.0
             )
             second = await session_routes.process_text_input(
-                session_id, _text_request(admission), 0.0
+                session_id, text_request(admission), 0.0
             )
 
         assert first.status == "success"
@@ -586,7 +543,7 @@ class TestEndToEndOverTheWire:
         async with lifespan(app):
             assert app.state.pipeline_admission.config.max_concurrent == 1
 
-            session_id = await _make_active_session(live_manager)
+            session_id = await make_active_session(live_manager)
             url = f"/api/session/{session_id}/message"
 
             with patch.object(session_routes, "process_text_pipeline", new=blocking_text):
@@ -622,14 +579,11 @@ class TestLegacyRoutesAreGated:
     async def test_upload_route_reports_busy(self):
         admission = _admission(1)
 
-        upload_file = Mock()
-        upload_file.read = AsyncMock(return_value=AUDIO_BYTES)
-
         with patch.object(upload_route, "process_wav", return_value=dict(PIPELINE_SUCCESS)):
             async with _Saturated(admission):
                 response = await upload_route.upload(
-                    request=_request_with(admission),
-                    file=upload_file,
+                    request=request_with(admission),
+                    file=upload_file(),
                     source_lang="de",
                     target_lang="en",
                 )
@@ -641,18 +595,11 @@ class TestLegacyRoutesAreGated:
     async def test_pipeline_route_reports_busy(self):
         admission = _admission(1)
 
-        upload_file = Mock()
-        upload_file.read = AsyncMock(return_value=AUDIO_BYTES)
-
-        request = _request_with(admission)
-        request.query_params = {}
-        request.headers = {}
-
         with patch.object(pipeline_route, "process_wav", return_value=dict(PIPELINE_SUCCESS)):
             async with _Saturated(admission):
                 response = await pipeline_route.pipeline(
-                    request=request,
-                    file=upload_file,
+                    request=legacy_pipeline_request(admission),
+                    file=upload_file(),
                     source_lang="de",
                     target_lang="en",
                     debug=None,
@@ -670,7 +617,7 @@ class TestNonPipelineTrafficIsUnaffected:
     async def test_session_management_responds_while_saturated(self, session_manager):
         from services.api_gateway.routes import session as session_routes
 
-        session_id = await _make_active_session(session_manager)
+        session_id = await make_active_session(session_manager)
         admission = _admission(1)
 
         async with _Saturated(admission):

--- a/tests/test_pipeline_admission.py
+++ b/tests/test_pipeline_admission.py
@@ -1,6 +1,8 @@
 import asyncio
+import contextlib
 import threading
 import time
+from concurrent.futures import ThreadPoolExecutor
 from unittest.mock import Mock, patch
 
 import httpx
@@ -12,6 +14,7 @@ from services.api_gateway.pipeline_admission import (
     PipelineAdmissionConfig,
     PipelineAdmissionMetrics,
     PipelineBusyError,
+    _SlotClaim,
     run_pipeline,
 )
 from services.api_gateway.session_manager import SessionManager
@@ -58,6 +61,35 @@ async def _wait_for_in_flight(admission: PipelineAdmission, count: int) -> None:
         if time.perf_counter() > deadline:
             raise AssertionError(f"in_flight settled at {admission.in_flight}, expected {count}")
         await asyncio.sleep(0.005)
+
+
+@contextlib.asynccontextmanager
+async def _pinned_default_executor():
+    """Occupies the loop's only worker, so the next ``to_thread`` item stays queued.
+
+    This is the sole way to observe a cancellation that lands after a slot is
+    acquired but before the worker thread picks the work up — the window in
+    which ``guarded`` never runs and therefore never releases.
+    """
+    loop = asyncio.get_running_loop()
+    pool = ThreadPoolExecutor(max_workers=1)
+    loop.set_default_executor(pool)
+    holding = threading.Event()
+    release = threading.Event()
+
+    def hold() -> None:
+        holding.set()
+        release.wait(SAFETY_TIMEOUT)
+
+    pool.submit(hold)
+    holding.wait(SAFETY_TIMEOUT)
+    try:
+        yield
+    finally:
+        release.set()
+        pool.shutdown(wait=False)
+        # set_default_executor rejects None, so hand the loop a usable pool back.
+        loop.set_default_executor(ThreadPoolExecutor())
 
 
 class _Saturated:
@@ -272,6 +304,111 @@ class TestCancellationCannotFreeCapacityEarly:
         # Capacity comes back once the thread really is done.
         await admission.run(_noop)
 
+    @pytest.mark.asyncio
+    async def test_cancelled_before_the_thread_starts_returns_its_slot(self):
+        """The inverse hole: no thread ever runs, so nothing ever releases.
+
+        ``asyncio.to_thread`` does cancel a work item that is still queued, so
+        ``guarded`` never executes. Releasing only from inside the worker thread
+        therefore loses the slot for the life of the process.
+        """
+        admission = _admission(1)
+        ran = threading.Event()
+
+        async with _pinned_default_executor():
+            task = asyncio.create_task(admission.run(ran.set))
+            await _wait_for_in_flight(admission, 1)
+
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+            assert not ran.is_set(), "work started; this test no longer covers its window"
+            await _wait_for_in_flight(admission, 0)
+
+        # Counted as free is not enough; the permit has to be usable again.
+        assert await asyncio.wait_for(admission.run(lambda: "ok"), SAFETY_TIMEOUT) == "ok"
+
+    def test_only_one_party_can_claim_a_slot(self):
+        """The claim is the whole safety argument, so it is tested directly.
+
+        Both the awaiting task and the worker thread reach for the release, and
+        the window between them is a few bytecodes wide: ``to_thread`` attempts
+        to cancel the work item *before* the awaiting task resumes, so a failed
+        cancel means the worker is already RUNNING but may not yet have executed
+        the first line of ``guarded``. A plain boolean can be read as False in
+        exactly that gap, and both parties release. Too narrow to reproduce from
+        a test, which is why the invariant is asserted rather than the race.
+        """
+        claim = _SlotClaim()
+        winners = []
+        barrier = threading.Barrier(8)
+
+        def contend():
+            barrier.wait(SAFETY_TIMEOUT)
+            if claim.claim():
+                winners.append(threading.get_ident())
+
+        threads = [threading.Thread(target=contend) for _ in range(8)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(SAFETY_TIMEOUT)
+
+        assert len(winners) == 1
+
+    @pytest.mark.asyncio
+    async def test_work_is_abandoned_rather_than_run_without_a_slot(self):
+        """If the awaiting task won the claim, the thread must not start the call.
+
+        Its slot has already gone back to the pool, so running now would put one
+        more pipeline on the GPU than the bound allows — for a result the
+        cancelled caller will never read.
+        """
+        admission = _admission(1)
+        ran = threading.Event()
+
+        async with _pinned_default_executor():
+            task = asyncio.create_task(admission.run(ran.set))
+            await _wait_for_in_flight(admission, 1)
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+        # The pool is free again here, so the abandoned item gets its turn.
+        await asyncio.sleep(0.1)
+        assert not ran.is_set()
+        assert admission.in_flight == 0
+
+    @pytest.mark.asyncio
+    async def test_a_cancelled_started_request_releases_once_it_finishes(self):
+        """The slot comes back exactly once, and only when the thread is done."""
+        admission = _admission(1)
+        running = threading.Event()
+        finish = threading.Event()
+
+        def blocking():
+            running.set()
+            finish.wait(SAFETY_TIMEOUT)
+            return dict(PIPELINE_SUCCESS)
+
+        task = asyncio.create_task(admission.run(blocking))
+        await asyncio.wait_for(
+            asyncio.to_thread(running.wait, SAFETY_TIMEOUT), timeout=SAFETY_TIMEOUT
+        )
+
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        finish.set()
+        await _wait_for_in_flight(admission, 0)
+
+        # A double release would leave two permits behind a limit of one.
+        async with _Saturated(admission):
+            with pytest.raises(PipelineBusyError):
+                await admission.run(_noop)
+
     def test_release_never_raises_when_the_loop_is_already_gone(self):
         """Reaches for the private because this runs in a worker thread's finally.
 
@@ -286,6 +423,50 @@ class TestCancellationCannotFreeCapacityEarly:
         admission._schedule_release(closed_loop)
 
         closed_loop.call_soon_threadsafe.assert_called_once()
+
+
+class TestZeroQueueWaitShedsRatherThanQueues:
+    """``PIPELINE_QUEUE_WAIT_SECONDS=0`` means "do not queue", not "reject everything".
+
+    ``asyncio.wait_for`` with a zero timeout cancels the acquire before it runs,
+    so the obvious implementation rejects even a completely idle gateway.
+    """
+
+    @pytest.mark.asyncio
+    async def test_idle_gateway_still_admits(self):
+        admission = _admission(2, wait=0.0)
+
+        assert await asyncio.wait_for(admission.run(lambda: "ok"), SAFETY_TIMEOUT) == "ok"
+
+    @pytest.mark.asyncio
+    async def test_every_slot_remains_usable(self):
+        """Not just the first: a fast path must not skip the accounting."""
+        admission = _admission(2, wait=0.0)
+
+        async with _Saturated(admission):
+            assert admission.in_flight == 2
+
+        await _wait_for_in_flight(admission, 0)
+
+    @pytest.mark.asyncio
+    async def test_saturated_gateway_is_rejected_without_waiting(self):
+        admission = _admission(1, wait=0.0)
+
+        async with _Saturated(admission):
+            started = time.perf_counter()
+            with pytest.raises(PipelineBusyError) as excinfo:
+                await admission.run(_noop)
+            elapsed = time.perf_counter() - started
+
+        assert elapsed < 1.0
+        # Never below one second, so the advice stays a valid Retry-After.
+        assert excinfo.value.retry_after_seconds == 1
+
+    def test_negative_wait_is_still_a_typo_not_an_opt_out(self):
+        """Only an exact 0 opts out; a negative value falls back to the default."""
+        config = PipelineAdmissionConfig(max_concurrent=2, queue_wait_seconds=-1.0)
+
+        assert config.queue_wait_seconds == 10.0
 
 
 class TestMetrics:
@@ -341,6 +522,26 @@ class TestMetrics:
         # One holder was admitted, one request was rejected: both waited.
         assert self._sample(metrics.queue_wait, "_count") == 2
         assert self._sample(metrics.rejected, "_total") == 1
+
+    @pytest.mark.asyncio
+    async def test_reported_wait_is_the_wait_that_was_observed(self):
+        """The histogram sample and the advice in the body come from one clock read.
+
+        Two separate ``perf_counter()`` calls make the metric and the response
+        body disagree about the same request, which is what docs/openapi.yaml
+        documents ``waited_seconds`` against.
+        """
+        metrics = _metrics()
+        admission = _admission(1, metrics=metrics)
+        # Takes the only permit without going through run(), so the histogram
+        # holds exactly one sample and the comparison can be exact.
+        await admission._semaphore.acquire()
+
+        with pytest.raises(PipelineBusyError) as excinfo:
+            await admission.run(_noop)
+
+        assert self._sample(metrics.queue_wait, "_count") == 1
+        assert self._sample(metrics.queue_wait, "_sum") == excinfo.value.waited_seconds
         # The rejected request waited the full window, so the sum must reflect
         # it rather than rounding to nothing.
         assert self._sample(metrics.queue_wait, "_sum") >= SHORT_WAIT
@@ -570,6 +771,145 @@ class TestEndToEndOverTheWire:
         assert body["detail"]["error_code"] == "SYSTEM_BUSY"
         assert body["detail"]["details"]["retry_after_seconds"] == 1
         assert admitted.status_code == 200
+
+
+class TestUpstreamSaturationStaysRetryable:
+    """Translation's own 503 must not arrive as a permanent error (#190).
+
+    ``process_wav`` flattens every upstream failure into ``result["error"]``, so
+    without a marker the audio route reports 500 PIPELINE_ERROR and the text
+    route 400 TEXT_PIPELINE_ERROR — the second of which blames the client for a
+    condition that clears on its own.
+    """
+
+    @staticmethod
+    def _busy_upstream(status_code=503, retry_after="25"):
+        response = Mock()
+        response.status_code = status_code
+        response.headers = {"Retry-After": retry_after} if retry_after else {}
+        response.json.return_value = {"detail": "at capacity"}
+        return response
+
+    def test_pipeline_result_marks_an_upstream_503(self):
+        from services.api_gateway import pipeline_logic
+
+        result = pipeline_logic._pipeline_error_result(
+            debug_info={"steps": []},
+            start_total=time.perf_counter(),
+            error_message="Translation-Fehler: at capacity",
+            asr_text="Guten Tag",
+            translation_text=None,
+            audio_bytes=None,
+            upstream_response=self._busy_upstream(),
+        )
+
+        assert result["error"] is True
+        assert result["error_code"] == "SYSTEM_BUSY"
+        assert result["retry_after_seconds"] == 25
+
+    def test_other_upstream_failures_are_not_marked_retryable(self):
+        from services.api_gateway import pipeline_logic
+
+        result = pipeline_logic._pipeline_error_result(
+            debug_info={"steps": []},
+            start_total=time.perf_counter(),
+            error_message="Translation-Fehler: boom",
+            asr_text=None,
+            translation_text=None,
+            audio_bytes=None,
+            upstream_response=self._busy_upstream(status_code=500),
+        )
+
+        assert "error_code" not in result
+
+    def test_unparseable_retry_after_falls_back_to_a_usable_delay(self):
+        from services.api_gateway import pipeline_logic
+
+        result = pipeline_logic._pipeline_error_result(
+            debug_info={"steps": []},
+            start_total=time.perf_counter(),
+            error_message="Translation-Fehler: at capacity",
+            asr_text=None,
+            translation_text=None,
+            audio_bytes=None,
+            upstream_response=self._busy_upstream(retry_after="soon"),
+        )
+
+        assert result["retry_after_seconds"] >= 1
+
+    @pytest.mark.asyncio
+    async def test_audio_route_reports_503_not_500(self, session_manager):
+        from fastapi import HTTPException
+
+        from services.api_gateway.routes import session as session_routes
+
+        session_id = await make_active_session(session_manager)
+        busy_result = {
+            "error": True,
+            "error_msg": "Translation-Fehler: at capacity",
+            "error_code": "SYSTEM_BUSY",
+            "retry_after_seconds": 25,
+            "debug": {},
+        }
+
+        with (
+            patch.object(session_routes, "session_manager", session_manager),
+            patch.object(session_routes, "process_wav", return_value=busy_result),
+        ):
+            with pytest.raises(HTTPException) as excinfo:
+                await session_routes.process_audio_input(session_id, audio_request(), 0.0)
+
+        error = excinfo.value
+        assert error.status_code == 503
+        assert error.detail["error_code"] == "SYSTEM_BUSY"
+        assert error.headers["Retry-After"] == "25"
+
+    @pytest.mark.asyncio
+    async def test_text_route_reports_503_not_400(self, session_manager):
+        from fastapi import HTTPException
+
+        from services.api_gateway.routes import session as session_routes
+
+        session_id = await make_active_session(session_manager)
+        busy_result = {
+            "error": True,
+            "error_msg": "Translation-Fehler: at capacity",
+            "error_code": "SYSTEM_BUSY",
+            "retry_after_seconds": 25,
+            "debug": {},
+        }
+
+        with (
+            patch.object(session_routes, "session_manager", session_manager),
+            patch.object(session_routes, "process_text_pipeline", return_value=busy_result),
+        ):
+            with pytest.raises(HTTPException) as excinfo:
+                await session_routes.process_text_input(session_id, text_request(), 0.0)
+
+        error = excinfo.value
+        assert error.status_code == 503
+        assert error.detail["error_code"] == "SYSTEM_BUSY"
+        assert error.headers["Retry-After"] == "25"
+
+    @pytest.mark.asyncio
+    async def test_ordinary_pipeline_failures_still_report_their_own_error(self, session_manager):
+        """The marker must not swallow the existing contract for real failures."""
+        from fastapi import HTTPException
+
+        from services.api_gateway.routes import session as session_routes
+
+        session_id = await make_active_session(session_manager)
+        failed = {"error": True, "error_msg": "TTS-Fehler: boom", "debug": {}}
+
+        with (
+            patch.object(session_routes, "session_manager", session_manager),
+            patch.object(session_routes, "process_wav", return_value=failed),
+        ):
+            with pytest.raises(HTTPException) as excinfo:
+                await session_routes.process_audio_input(session_id, audio_request(), 0.0)
+
+        assert excinfo.value.status_code == 500
+        assert excinfo.value.detail["error_code"] == "PIPELINE_ERROR"
 
 
 class TestLegacyRoutesAreGated:

--- a/tests/test_service_app_helpers.py
+++ b/tests/test_service_app_helpers.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import importlib
 import importlib.util
 import inspect
@@ -22,6 +23,9 @@ class DummyMetric:
     def inc(self, *args, **kwargs):
         return None
 
+    def dec(self, *args, **kwargs):
+        return None
+
     def set(self, *args, **kwargs):
         return None
 
@@ -36,10 +40,13 @@ class DummyMetric:
 
 
 class StubHTTPException(Exception):
-    def __init__(self, status_code: int, detail: str):
+    # Mirrors fastapi.HTTPException, headers included: the translation service
+    # returns Retry-After on a saturation 503.
+    def __init__(self, status_code: int, detail: str, headers: dict | None = None):
         super().__init__(detail)
         self.status_code = status_code
         self.detail = detail
+        self.headers = headers
 
 
 class FakeDevice(str):
@@ -81,6 +88,9 @@ def build_torch_stub(cuda_available: bool = False) -> types.ModuleType:
     torch_stub.float32 = "float32"
     torch_stub.manual_seed = lambda seed: None
     torch_stub.device = lambda value: FakeDevice(value)
+    # Needed to reach the real inference bodies (translation's _generate_single).
+    torch_stub.inference_mode = contextlib.nullcontext
+    torch_stub.no_grad = contextlib.nullcontext
     return torch_stub
 
 

--- a/tests/test_service_app_helpers.py
+++ b/tests/test_service_app_helpers.py
@@ -987,7 +987,10 @@ async def test_upload_route_escapes_html_and_handles_success(upload_module, monk
             "audio_bytes": b"",
         },
     )
-    error_response = await upload_module.upload(FakeUploadFile(b"audio"), "de", "en")
+    # A request with no app carries no admission component, so the route runs
+    # unbounded — this test is about HTML escaping, not capacity.
+    request = SimpleNamespace()
+    error_response = await upload_module.upload(request, FakeUploadFile(b"audio"), "de", "en")
     assert error_response.status_code == 400
     assert b"&lt;script&gt;alert(1)&lt;/script&gt;" in error_response.body
     assert b"Keine Ausgabe verfuegbar." in error_response.body
@@ -1003,6 +1006,7 @@ async def test_upload_route_escapes_html_and_handles_success(upload_module, monk
         },
     )
     success_response = await upload_module.upload(
+        request,
         FakeUploadFile(b"audio"),
         "<de>",
         "<en>",

--- a/tests/test_translation_inference_offload.py
+++ b/tests/test_translation_inference_offload.py
@@ -11,11 +11,13 @@ would never run.
 """
 
 import asyncio
+import contextlib
 import importlib.util
 import sys
 import threading
 import time
 import uuid
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -80,6 +82,34 @@ def request_with(admission=None, payload=None, query_params=None):
             return PAYLOAD if payload is None else payload
 
     return FakeRequest()
+
+
+@contextlib.asynccontextmanager
+async def _pinned_default_executor():
+    """Occupies the loop's only worker so the next ``to_thread`` item stays queued.
+
+    The only way to observe a cancellation landing after a slot is acquired but
+    before any thread picks the inference up.
+    """
+    loop = asyncio.get_running_loop()
+    pool = ThreadPoolExecutor(max_workers=1)
+    loop.set_default_executor(pool)
+    holding = threading.Event()
+    release = threading.Event()
+
+    def hold() -> None:
+        holding.set()
+        release.wait(SAFETY_TIMEOUT)
+
+    pool.submit(hold)
+    holding.wait(SAFETY_TIMEOUT)
+    try:
+        yield
+    finally:
+        release.set()
+        pool.shutdown(wait=False)
+        # set_default_executor rejects None, so hand the loop a usable pool back.
+        loop.set_default_executor(ThreadPoolExecutor())
 
 
 class _ThreadRecorder:
@@ -264,8 +294,10 @@ class TestConcurrencyBound:
         assert admission.max_concurrent == translation.DEFAULT_MAX_CONCURRENT_TRANSLATIONS
 
     @pytest.mark.asyncio
-    async def test_non_positive_queue_wait_falls_back_to_the_default(self, translation):
-        admission = translation.TranslationAdmission(queue_wait_seconds=0)
+    async def test_negative_queue_wait_falls_back_to_the_default(self, translation):
+        """A negative wait is a typo. Exactly 0 is the "do not queue" opt-out,
+        covered in TestAdmissionWiring."""
+        admission = translation.TranslationAdmission(queue_wait_seconds=-1)
 
         assert admission.queue_wait_seconds == translation.DEFAULT_TRANSLATION_QUEUE_WAIT_SECONDS
 
@@ -427,6 +459,100 @@ class TestSlotOwnership:
         assert admission.in_flight == 0, "the slot was never returned"
 
     @pytest.mark.asyncio
+    async def test_cancelled_before_the_thread_starts_returns_its_slot(self, translation):
+        """The inverse case: to_thread does cancel a work item still in the queue.
+
+        The inference function then never runs, so a release that only ever
+        happens inside the worker thread never happens at all, and the slot is
+        gone for the life of the process.
+        """
+        admission = translation.TranslationAdmission(
+            max_concurrent=1, queue_wait_seconds=5.0, metrics=_MetricsRecorder()
+        )
+        ran = threading.Event()
+
+        def never_reached(texts, *_args, **_kwargs):
+            ran.set()
+            return ["translated"]
+
+        translation._translate_texts = never_reached
+
+        async with _pinned_default_executor():
+            task = asyncio.create_task(translation.translate(request_with(admission)))
+            for _ in range(int(SAFETY_TIMEOUT / 0.01)):
+                await asyncio.sleep(0.01)
+                if admission.in_flight == 1:
+                    break
+            assert admission.in_flight == 1, "never acquired a slot to begin with"
+
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+            assert not ran.is_set(), "inference started; this no longer covers the window"
+            assert admission.in_flight == 0, "the slot was lost when the work never ran"
+
+        # Counted as free is not enough; the permit has to be usable again.
+        translation._translate_texts = lambda texts, *a, **k: ["translated"]
+        response = await asyncio.wait_for(
+            translation.translate(request_with(admission)), SAFETY_TIMEOUT
+        )
+        assert response.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_a_cancelled_started_request_releases_once_it_finishes(self, translation):
+        """The slot comes back exactly once, so the bound is not quietly lifted.
+
+        Both the awaiting task and the worker thread reach for the release. The
+        window where a plain boolean lets both act is a few bytecodes wide and
+        cannot be reproduced from a test; ``_SlotClaim`` closes it, and the
+        gateway suite asserts that invariant directly.
+        """
+        admission = translation.TranslationAdmission(
+            max_concurrent=1, queue_wait_seconds=0.05, metrics=_MetricsRecorder()
+        )
+        release = threading.Event()
+        started = threading.Event()
+
+        def hold(texts, *_args, **_kwargs):
+            started.set()
+            release.wait(timeout=SAFETY_TIMEOUT)
+            return ["translated"]
+
+        translation._translate_texts = hold
+
+        task = asyncio.create_task(translation.translate(request_with(admission)))
+        await asyncio.to_thread(started.wait, SAFETY_TIMEOUT)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        release.set()
+        for _ in range(int(SAFETY_TIMEOUT / 0.01)):
+            await asyncio.sleep(0.01)
+            if admission.in_flight == 0:
+                break
+        assert admission.in_flight == 0
+
+        # Two permits behind a limit of one would let both of these run.
+        hold_again = threading.Event()
+        translation._translate_texts = lambda texts, *a, **k: (
+            hold_again.wait(SAFETY_TIMEOUT),
+            ["translated"],
+        )[1]
+        holder = asyncio.create_task(translation.translate(request_with(admission)))
+        for _ in range(int(SAFETY_TIMEOUT / 0.01)):
+            await asyncio.sleep(0.01)
+            if admission.in_flight == 1:
+                break
+
+        with pytest.raises(translation.TranslationBusyError):
+            await admission._acquire()
+
+        hold_again.set()
+        await asyncio.wait_for(holder, SAFETY_TIMEOUT)
+
+    @pytest.mark.asyncio
     async def test_release_survives_a_loop_that_is_already_closed(self, translation):
         """The release runs in a `finally` inside a worker thread. At shutdown the
         loop can already be gone, and raising there would kill the thread for a
@@ -513,6 +639,63 @@ class TestAdmissionWiring:
         assert module.MAX_CONCURRENT_TRANSLATIONS == 3
         assert module.TRANSLATION_QUEUE_WAIT_SECONDS == 7.5
         assert module.TranslationAdmission().max_concurrent == 3
+
+    def test_unparseable_settings_do_not_stop_the_service_booting(self, monkeypatch):
+        """An unparseable value must not crash-loop the container.
+
+        These are read at module scope, so an uncaught ValueError happens before
+        uvicorn binds: the service never reports healthy and the pod restarts
+        forever over one typo in an env file.
+        """
+        module = load_translation(
+            monkeypatch,
+            MAX_CONCURRENT_TRANSLATIONS="two",
+            TRANSLATION_QUEUE_WAIT_SECONDS="25s",
+        )
+
+        assert module.MAX_CONCURRENT_TRANSLATIONS == module.DEFAULT_MAX_CONCURRENT_TRANSLATIONS
+        assert (
+            module.TRANSLATION_QUEUE_WAIT_SECONDS == module.DEFAULT_TRANSLATION_QUEUE_WAIT_SECONDS
+        )
+
+    def test_blank_settings_fall_back_to_the_defaults(self, monkeypatch):
+        """A declared-but-empty variable is how compose passes "unset"."""
+        module = load_translation(
+            monkeypatch,
+            MAX_CONCURRENT_TRANSLATIONS="",
+            TRANSLATION_QUEUE_WAIT_SECONDS="   ",
+        )
+
+        assert module.MAX_CONCURRENT_TRANSLATIONS == module.DEFAULT_MAX_CONCURRENT_TRANSLATIONS
+        assert (
+            module.TRANSLATION_QUEUE_WAIT_SECONDS == module.DEFAULT_TRANSLATION_QUEUE_WAIT_SECONDS
+        )
+
+    @pytest.mark.asyncio
+    async def test_zero_wait_still_admits_an_idle_service(self, translation):
+        """0 means "do not queue", and must not reject on an idle service.
+
+        asyncio.wait_for with a zero timeout cancels the acquire before it runs.
+        """
+        admission = translation.TranslationAdmission(
+            max_concurrent=2, queue_wait_seconds=0, metrics=_MetricsRecorder()
+        )
+        translation._translate_texts = lambda texts, *a, **k: ["translated"]
+
+        response = await asyncio.wait_for(
+            translation.translate(request_with(admission)), SAFETY_TIMEOUT
+        )
+
+        assert response.status_code == 200
+        assert admission.queue_wait_seconds == 0
+
+    @pytest.mark.asyncio
+    async def test_negative_wait_is_a_typo_and_falls_back(self, translation):
+        admission = translation.TranslationAdmission(
+            max_concurrent=2, queue_wait_seconds=-1, metrics=_MetricsRecorder()
+        )
+
+        assert admission.queue_wait_seconds == translation.DEFAULT_TRANSLATION_QUEUE_WAIT_SECONDS
 
     @pytest.mark.asyncio
     async def test_request_without_app_state_runs_unbounded(self, translation):

--- a/tests/test_translation_inference_offload.py
+++ b/tests/test_translation_inference_offload.py
@@ -1,0 +1,572 @@
+"""#190: translation inference must leave the event loop free, under a bound.
+
+The module is loaded with ``torch``, ``transformers`` and ``prometheus_client``
+stubbed, so CI needs no GPU wheels and no global metric registry. ``fastapi``
+stays real: it is the only way to prove the ``Retry-After`` header on a
+saturation 503 actually reaches a client rather than just existing in a dict.
+
+Lives in ``tests/`` deliberately. CI runs ``pytest tests/`` and ``pytest.ini``
+pins ``testpaths = tests``, so a guard placed in ``services/translation/tests/``
+would never run.
+"""
+
+import asyncio
+import importlib.util
+import sys
+import threading
+import time
+import uuid
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from test_service_app_helpers import (
+    build_prometheus_stub,
+    build_torch_stub,
+    build_transformers_stub,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# Long enough that a blocked loop is unmistakable, short enough to keep the
+# suite quick. Every assertion carries a wide margin so CI jitter cannot flip it.
+BLOCK_SECONDS = 0.4
+SAFETY_TIMEOUT = 15.0
+
+PAYLOAD = {"text": "Hallo Welt", "source_lang": "de", "target_lang": "en"}
+
+
+def load_translation(monkeypatch, **env):
+    """Loads services/translation/app.py fresh, with GPU deps stubbed.
+
+    ``env`` is applied before import because the module reads its admission
+    settings into constants at import time, exactly as the rest of its config.
+    """
+    for key, value in env.items():
+        monkeypatch.setenv(key, str(value))
+
+    for name, stub in (
+        ("torch", build_torch_stub()),
+        ("transformers", build_transformers_stub()),
+        ("prometheus_client", build_prometheus_stub()),
+    ):
+        monkeypatch.setitem(sys.modules, name, stub)
+
+    unique = f"translation_app_{uuid.uuid4().hex}"
+    spec = importlib.util.spec_from_file_location(unique, ROOT / "services/translation/app.py")
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[unique] = module
+    monkeypatch.setitem(sys.modules, unique, module)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def translation(monkeypatch):
+    return load_translation(monkeypatch)
+
+
+def request_with(admission=None, payload=None, query_params=None):
+    """A fake request whose app state carries ``admission`` (``None`` = unbounded)."""
+    app = SimpleNamespace(state=SimpleNamespace(translation_admission=admission))
+
+    class FakeRequest:
+        def __init__(self):
+            self.app = app
+            self.query_params = query_params or {}
+
+        async def json(self):
+            return PAYLOAD if payload is None else payload
+
+    return FakeRequest()
+
+
+class _ThreadRecorder:
+    """Stands in for _translate_texts and records where it ran."""
+
+    def __init__(self, result=None, delay=0.0):
+        self._result = result or ["translated"]
+        self._delay = delay
+        self.thread_ids: list[int] = []
+        self.entered = threading.Event()
+
+    def __call__(self, texts, *_args, **_kwargs):
+        self.thread_ids.append(threading.get_ident())
+        self.entered.set()
+        if self._delay:
+            time.sleep(self._delay)
+        return list(self._result)
+
+
+class _MetricsRecorder:
+    """Captures what the admission component reports, since the stub metrics drop it."""
+
+    def __init__(self):
+        self.waits: list[float] = []
+        self.rejections = 0
+        self.in_flight_delta = 0
+
+        recorder = self
+
+        class _Gauge:
+            def inc(self, *_a, **_k):
+                recorder.in_flight_delta += 1
+
+            def dec(self, *_a, **_k):
+                recorder.in_flight_delta -= 1
+
+        class _Histogram:
+            def observe(self, value, *_a, **_k):
+                recorder.waits.append(value)
+
+        class _Counter:
+            def inc(self, *_a, **_k):
+                recorder.rejections += 1
+
+        self.in_flight = _Gauge()
+        self.queue_wait = _Histogram()
+        self.rejected = _Counter()
+
+
+class TestOffloadedFromTheEventLoop:
+    """The blocking generate() call must not run on the loop thread."""
+
+    @pytest.mark.asyncio
+    async def test_translation_runs_off_the_event_loop(self, translation):
+        recorder = _ThreadRecorder()
+        translation._translate_texts = recorder
+        loop_thread_id = threading.get_ident()
+
+        await translation.translate(request_with())
+
+        assert recorder.thread_ids, "_translate_texts was never called"
+        assert recorder.thread_ids[0] != loop_thread_id, (
+            "_translate_texts ran on the event loop thread; m2m_model.generate() "
+            "holds the loop for the whole beam search"
+        )
+
+    @pytest.mark.asyncio
+    async def test_loop_keeps_ticking_during_translation(self, translation):
+        recorder = _ThreadRecorder(delay=BLOCK_SECONDS)
+        translation._translate_texts = recorder
+
+        task = asyncio.create_task(translation.translate(request_with()))
+        deadline = time.perf_counter() + SAFETY_TIMEOUT
+
+        while not recorder.entered.is_set() and not task.done():
+            if time.perf_counter() > deadline:
+                task.cancel()
+                pytest.fail("translation never started")
+            await asyncio.sleep(0.005)
+
+        ticks = 0
+        while not task.done():
+            if time.perf_counter() > deadline:
+                task.cancel()
+                pytest.fail("translation never finished")
+            await asyncio.sleep(0.01)
+            ticks += 1
+
+        await task
+
+        # A free loop manages roughly BLOCK_SECONDS / 0.01 ticks; a blocked one
+        # manages none. The threshold sits well below the expected count.
+        assert ticks >= 5, (
+            f"event loop completed only {ticks} ticks while translation was in "
+            "flight; it was blocked"
+        )
+
+    @pytest.mark.asyncio
+    async def test_health_stays_responsive_during_translation(self, translation):
+        """The acceptance criterion, asserted against the handler itself."""
+        recorder = _ThreadRecorder(delay=BLOCK_SECONDS)
+        translation._translate_texts = recorder
+
+        task = asyncio.create_task(translation.translate(request_with()))
+        await asyncio.wait_for(
+            asyncio.get_running_loop().run_in_executor(None, recorder.entered.wait),
+            timeout=SAFETY_TIMEOUT,
+        )
+
+        probe = await asyncio.wait_for(asyncio.to_thread(translation.health), timeout=2.0)
+        assert probe["status"] == "ok"
+        assert not task.done(), "translation finished before the probe; test proved nothing"
+
+        await asyncio.wait_for(task, timeout=SAFETY_TIMEOUT)
+
+
+class TestConcurrencyBound:
+    """Concurrent translations progress, but never more than the limit at once."""
+
+    @pytest.mark.asyncio
+    async def test_two_translations_progress_concurrently(self, translation):
+        admission = translation.TranslationAdmission(max_concurrent=2, queue_wait_seconds=5.0)
+        # Trips only if both translations are inside the barrier at the same time.
+        barrier = threading.Barrier(2)
+
+        def rendezvous(texts, *_args, **_kwargs):
+            barrier.wait(timeout=SAFETY_TIMEOUT)
+            return ["translated"]
+
+        translation._translate_texts = rendezvous
+
+        responses = await asyncio.wait_for(
+            asyncio.gather(
+                translation.translate(request_with(admission)),
+                translation.translate(request_with(admission)),
+            ),
+            timeout=SAFETY_TIMEOUT,
+        )
+
+        assert [response.status_code for response in responses] == [200, 200]
+
+    @pytest.mark.asyncio
+    async def test_bound_of_one_never_admits_two_at_once(self, translation):
+        admission = translation.TranslationAdmission(max_concurrent=1, queue_wait_seconds=5.0)
+        lock = threading.Lock()
+        state = {"current": 0, "peak": 0}
+
+        def observe(texts, *_args, **_kwargs):
+            with lock:
+                state["current"] += 1
+                state["peak"] = max(state["peak"], state["current"])
+            time.sleep(0.05)
+            with lock:
+                state["current"] -= 1
+            return ["translated"]
+
+        translation._translate_texts = observe
+
+        await asyncio.wait_for(
+            asyncio.gather(*(translation.translate(request_with(admission)) for _ in range(4))),
+            timeout=SAFETY_TIMEOUT,
+        )
+
+        assert state["peak"] == 1, f"{state['peak']} translations ran at once under a limit of 1"
+
+    @pytest.mark.asyncio
+    async def test_zero_disables_the_bound(self, translation):
+        admission = translation.TranslationAdmission(max_concurrent=0)
+        assert admission.enabled is False
+
+        translation._translate_texts = _ThreadRecorder()
+        response = await translation.translate(request_with(admission))
+        assert response.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_negative_limit_falls_back_to_the_default(self, translation):
+        """A negative value is a typo, and silently unbounding the GPU is the
+        dangerous reading of it. Only an explicit 0 disables."""
+        admission = translation.TranslationAdmission(max_concurrent=-1)
+
+        assert admission.enabled is True
+        assert admission.max_concurrent == translation.DEFAULT_MAX_CONCURRENT_TRANSLATIONS
+
+    @pytest.mark.asyncio
+    async def test_non_positive_queue_wait_falls_back_to_the_default(self, translation):
+        admission = translation.TranslationAdmission(queue_wait_seconds=0)
+
+        assert admission.queue_wait_seconds == translation.DEFAULT_TRANSLATION_QUEUE_WAIT_SECONDS
+
+
+class TestSaturationResponse:
+    """A saturated queue must produce an attributable 503, not a timeout."""
+
+    @staticmethod
+    def _saturate(translation, admission):
+        """Occupies every slot until the returned event is set."""
+        release = threading.Event()
+        occupied = threading.Barrier(admission.max_concurrent + 1)
+
+        def hold(texts, *_args, **_kwargs):
+            occupied.wait(timeout=SAFETY_TIMEOUT)
+            release.wait(timeout=SAFETY_TIMEOUT)
+            return ["translated"]
+
+        translation._translate_texts = hold
+        holders = [
+            asyncio.create_task(translation.translate(request_with(admission)))
+            for _ in range(admission.max_concurrent)
+        ]
+        return release, occupied, holders
+
+    @pytest.mark.asyncio
+    async def test_saturated_request_returns_503_with_retry_after(self, translation):
+        admission = translation.TranslationAdmission(max_concurrent=1, queue_wait_seconds=0.05)
+        release, occupied, holders = self._saturate(translation, admission)
+
+        await asyncio.to_thread(occupied.wait, SAFETY_TIMEOUT)
+
+        with pytest.raises(translation.HTTPException) as caught:
+            await translation.translate(request_with(admission))
+
+        assert caught.value.status_code == 503
+        assert caught.value.headers["Retry-After"] == "1"
+
+        release.set()
+        await asyncio.wait_for(asyncio.gather(*holders), timeout=SAFETY_TIMEOUT)
+
+    @pytest.mark.asyncio
+    async def test_busy_does_not_become_a_500(self, translation):
+        """translate() ends in a broad `except Exception` that would happily
+        turn a RuntimeError subclass into 'Translation failed: ...'."""
+        admission = translation.TranslationAdmission(max_concurrent=1, queue_wait_seconds=0.05)
+        release, occupied, holders = self._saturate(translation, admission)
+
+        await asyncio.to_thread(occupied.wait, SAFETY_TIMEOUT)
+
+        with pytest.raises(translation.HTTPException) as caught:
+            await translation.translate(request_with(admission))
+
+        assert caught.value.status_code != 500
+        assert "Translation failed" not in str(caught.value.detail)
+
+        release.set()
+        await asyncio.wait_for(asyncio.gather(*holders), timeout=SAFETY_TIMEOUT)
+
+    @pytest.mark.asyncio
+    async def test_busy_returns_the_debug_envelope_when_debug_is_requested(self, translation):
+        """The gateway passes `debug` through on every pipeline call, so the
+        saturation path has to honour it like every other failure here."""
+        admission = translation.TranslationAdmission(max_concurrent=1, queue_wait_seconds=0.05)
+        release, occupied, holders = self._saturate(translation, admission)
+
+        await asyncio.to_thread(occupied.wait, SAFETY_TIMEOUT)
+
+        response = await translation.translate(
+            request_with(admission, payload={**PAYLOAD, "debug": "true"})
+        )
+
+        assert response.status_code == 503
+        assert response.headers["retry-after"] == "1"
+        assert b'"translations":null' in response.body
+        assert b"Translation service busy" in response.body
+
+        release.set()
+        await asyncio.wait_for(asyncio.gather(*holders), timeout=SAFETY_TIMEOUT)
+
+    @pytest.mark.asyncio
+    async def test_busy_reports_retry_after_consistently_in_body_and_header(self, translation):
+        admission = translation.TranslationAdmission(max_concurrent=1, queue_wait_seconds=2.4)
+        busy = translation.TranslationBusyError(
+            max_concurrent=admission.max_concurrent,
+            queue_wait_seconds=admission.queue_wait_seconds,
+            waited_seconds=2.4,
+        )
+
+        # Whole seconds, never below one, so a client reading the header and a
+        # client reading the message wait the same amount of time.
+        assert busy.retry_after_seconds == 3
+        assert busy.retry_after_header == "3"
+
+    @pytest.mark.asyncio
+    async def test_rejection_is_recorded_in_the_queue_wait_histogram(self, translation):
+        """A histogram that only sees admitted requests reports 'everyone seated
+        instantly' during the exact saturation it exists to measure."""
+        metrics = _MetricsRecorder()
+        admission = translation.TranslationAdmission(
+            max_concurrent=1, queue_wait_seconds=0.05, metrics=metrics
+        )
+        release, occupied, holders = self._saturate(translation, admission)
+
+        await asyncio.to_thread(occupied.wait, SAFETY_TIMEOUT)
+        admitted_waits = len(metrics.waits)
+
+        with pytest.raises(translation.HTTPException):
+            await translation.translate(request_with(admission))
+
+        assert metrics.rejections == 1
+        assert len(metrics.waits) == admitted_waits + 1, "rejection was not observed"
+        assert metrics.waits[-1] >= 0.05
+
+        release.set()
+        await asyncio.wait_for(asyncio.gather(*holders), timeout=SAFETY_TIMEOUT)
+
+
+class TestSlotOwnership:
+    """A slot may only be held by work that is actually running."""
+
+    @pytest.mark.asyncio
+    async def test_cancelled_request_keeps_its_slot_until_the_thread_finishes(self, translation):
+        """asyncio.to_thread cannot interrupt a call it has started. Releasing on
+        the awaiting task's finally would hand capacity to the next caller while
+        this request's thread was still on the GPU."""
+        metrics = _MetricsRecorder()
+        admission = translation.TranslationAdmission(
+            max_concurrent=1, queue_wait_seconds=5.0, metrics=metrics
+        )
+        release = threading.Event()
+        started = threading.Event()
+
+        def hold(texts, *_args, **_kwargs):
+            started.set()
+            release.wait(timeout=SAFETY_TIMEOUT)
+            return ["translated"]
+
+        translation._translate_texts = hold
+
+        task = asyncio.create_task(translation.translate(request_with(admission)))
+        await asyncio.to_thread(started.wait, SAFETY_TIMEOUT)
+
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        # The thread is still inside hold(), so the slot must still be taken.
+        assert admission.in_flight == 1, (
+            "the cancelled request released its slot while its worker thread was "
+            "still running the pipeline"
+        )
+
+        release.set()
+        for _ in range(int(SAFETY_TIMEOUT / 0.01)):
+            await asyncio.sleep(0.01)
+            if admission.in_flight == 0:
+                break
+        assert admission.in_flight == 0, "the slot was never returned"
+
+    @pytest.mark.asyncio
+    async def test_release_survives_a_loop_that_is_already_closed(self, translation):
+        """The release runs in a `finally` inside a worker thread. At shutdown the
+        loop can already be gone, and raising there would kill the thread for a
+        slot nobody is waiting on any more."""
+        admission = translation.TranslationAdmission(max_concurrent=1)
+        dead_loop = asyncio.new_event_loop()
+        dead_loop.close()
+
+        admission._schedule_release(dead_loop)  # must not raise
+
+        # The slot is simply never handed back, which is correct at shutdown.
+        assert admission.in_flight == 0
+
+
+class TestTokenizerSafety:
+    """src_lang is mutable shared state; the lock must actually exclude."""
+
+    @pytest.mark.asyncio
+    async def test_tokenizer_lock_excludes_concurrent_encoding(self, translation):
+        rendezvous: list[bool] = []
+        # Two parties, so it can only be satisfied if both threads are inside
+        # the tokenizer at the same moment. Under the lock, neither can be.
+        barrier = threading.Barrier(2)
+
+        class _Tensor:
+            def to(self, _device):
+                return self
+
+        class LockProbeTokenizer:
+            lang_code_to_id = {"de": 0, "en": 1}
+
+            def __init__(self):
+                self.src_lang = None
+
+            def __call__(self, _text, **_kwargs):
+                try:
+                    barrier.wait(timeout=0.25)
+                    rendezvous.append(True)
+                except threading.BrokenBarrierError:
+                    pass
+                return {"input_ids": _Tensor()}
+
+            def get_lang_id(self, lang):
+                return self.lang_code_to_id[lang]
+
+            def batch_decode(self, _outputs, skip_special_tokens=True):
+                return ["decoded"]
+
+        translation.m2m_tokenizer = LockProbeTokenizer()
+
+        await asyncio.gather(
+            asyncio.to_thread(translation._generate_single, "a", "de", "en", {}),
+            asyncio.to_thread(translation._generate_single, "b", "de", "en", {}),
+        )
+
+        assert rendezvous == [], (
+            "two threads were inside the tokenizer at once; the src_lang mutation "
+            "in _generate_single is unguarded"
+        )
+
+
+class TestAdmissionWiring:
+    """The component is owned by the lifespan, and absent before it runs."""
+
+    @pytest.mark.asyncio
+    async def test_lifespan_installs_and_clears_the_admission_component(self, translation):
+        app = SimpleNamespace(state=SimpleNamespace())
+
+        async with translation.lifespan(app):
+            installed = app.state.translation_admission
+            assert isinstance(installed, translation.TranslationAdmission)
+            assert installed.max_concurrent == translation.MAX_CONCURRENT_TRANSLATIONS
+
+        assert app.state.translation_admission is None
+
+    @pytest.mark.asyncio
+    async def test_settings_come_from_the_environment(self, monkeypatch):
+        module = load_translation(
+            monkeypatch,
+            MAX_CONCURRENT_TRANSLATIONS=3,
+            TRANSLATION_QUEUE_WAIT_SECONDS=7.5,
+        )
+
+        assert module.MAX_CONCURRENT_TRANSLATIONS == 3
+        assert module.TRANSLATION_QUEUE_WAIT_SECONDS == 7.5
+        assert module.TranslationAdmission().max_concurrent == 3
+
+    @pytest.mark.asyncio
+    async def test_request_without_app_state_runs_unbounded(self, translation):
+        """Model-service tests drive translate() with requests that have no app,
+        and every route reached before startup is in the same position."""
+        recorder = _ThreadRecorder()
+        translation._translate_texts = recorder
+
+        class BareRequest:
+            query_params: dict = {}
+
+            async def json(self):
+                return PAYLOAD
+
+        response = await translation.translate(BareRequest())
+
+        assert response.status_code == 200
+        assert recorder.thread_ids and recorder.thread_ids[0] != threading.get_ident()
+
+
+class TestWireContract:
+    """The 503 and its Retry-After have to survive real FastAPI, not just a dict."""
+
+    @pytest.mark.asyncio
+    async def test_retry_after_reaches_the_wire(self, monkeypatch):
+        import httpx
+
+        module = load_translation(
+            monkeypatch,
+            MAX_CONCURRENT_TRANSLATIONS=1,
+            TRANSLATION_QUEUE_WAIT_SECONDS=0.05,
+        )
+
+        release = threading.Event()
+        occupied = threading.Barrier(2)
+
+        def hold(texts, *_args, **_kwargs):
+            occupied.wait(timeout=SAFETY_TIMEOUT)
+            release.wait(timeout=SAFETY_TIMEOUT)
+            return ["translated"]
+
+        module._translate_texts = hold
+
+        transport = httpx.ASGITransport(app=module.app)
+        async with module.lifespan(module.app):
+            async with httpx.AsyncClient(transport=transport, base_url="http://t") as client:
+                holder = asyncio.create_task(client.post("/translate", json=PAYLOAD))
+                await asyncio.to_thread(occupied.wait, SAFETY_TIMEOUT)
+
+                busy = await client.post("/translate", json=PAYLOAD)
+
+                assert busy.status_code == 503
+                assert busy.headers["retry-after"] == "1"
+                assert "detail" in busy.json()
+
+                release.set()
+                assert (await asyncio.wait_for(holder, timeout=SAFETY_TIMEOUT)).status_code == 200


### PR DESCRIPTION
## Description

Two services were holding their event loops for the whole duration of GPU work, and removing that accidental serialisation removes the only thing that was bounding GPU capacity. All three issues therefore ship together, which is what #191 asks for.

**#189, the gateway.** `process_wav` and `process_text_pipeline` were called synchronously from `async def` handlers, so their blocking `requests.post` calls to ASR, translation and TTS held the single event loop thread for the whole pipeline. Every session was serialised, and health checks, WebSocket heartbeats and background tasks were starved behind them.

**#190, the translation service.** The same defect one layer down: `async def translate` called `_translate_texts` inline, so `m2m_model.generate()` held that service's only loop thread for the whole beam search. Its `/health`, `/languages` and `/metrics` handlers are synchronous and would run in a threadpool, but a blocked loop never gets as far as accepting the connection, so probes hung too. Fixing only the gateway would have left translation as the real serialisation point, so raising `MAX_CONCURRENT_PIPELINES` would have bought nothing.

**#191, the bound.** One RTX 4000 Ada hosts all three model services, and each holds a single shared model instance with no lock of its own (`services/asr/app.py:132`, `services/tts/app.py:143`), so unbounded concurrency means concurrent CUDA work on one shared model per service. Both fixes above ship with a bound, at both layers.

Note on prior state: a correct `asyncio.to_thread` wrapper already existed in `services/api_gateway/session.py` and in `pipeline_logic.process_wav_for_session`, but neither was reachable — `app.py` registers `.routes.session`, not `.session`, and the helper had no callers. Confirmed against the live OpenAPI surface.

## Type of Change
- [x]  Bug fix (non-breaking change which fixes an issue)
- [x]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation update
- [ ]  Code style update (formatting, renaming)
- [ ]  Refactoring (no functional changes)
- [x] Performance improvement
- [ ]  Test update
- [x] Build/CI configuration change

## Related Issues

Closes #189
Closes #190
Closes #191

#191 carried a maintainer note keeping it "in discussion", and its Dependencies section asks it to ship with #189 **and** #190. Both are now in this PR, so the set it describes is complete rather than partial. The design question it raised is recorded below under **Open question for reviewers** rather than settled unilaterally.

## Changes Made

**Gateway (#189, #191)**
- Run all four GPU call sites on a worker thread: `POST /api/session/{id}/message` (audio and text), `POST /pipeline`, `POST /upload`.
- Add a lifespan-owned `PipelineAdmission` component bounding in-flight pipelines, configured by `MAX_CONCURRENT_PIPELINES` (default `2`) and `PIPELINE_QUEUE_WAIT_SECONDS` (default `10.0`). Exactly `0` disables the bound; a negative value is refused and the default used.
- Reject saturation with `503`, a `Retry-After` header and a stable `SYSTEM_BUSY` error code, in the envelope this endpoint already uses.
- Expose `gateway_pipeline_in_flight`, `gateway_pipeline_queue_wait_seconds` and `gateway_pipeline_rejected_total`.
- Remove the unused `process_wav_for_session` helper.

**Translation service (#190)**
- Run `_translate_texts` on a worker thread, as ASR and TTS already did.
- Add a lifespan-owned `TranslationAdmission` with `MAX_CONCURRENT_TRANSLATIONS` (default `2`, matching the gateway so this service is not a tighter chokepoint than the system-level boundary) and `TRANSLATION_QUEUE_WAIT_SECONDS` (default `25.0`, deliberately under the gateway's 30s HTTP timeout for `/translate` so saturation is attributable rather than a caller-side timeout).
- Reject saturation with `503` and `Retry-After`, registered in `TRANSLATION_ERROR_RESPONSES` so it reaches the generated schema. Both gateway call sites already check `status_code != 200` and surface `detail` (`pipeline_logic.py:1200`, `:1405`), so this becomes a clean pipeline error rather than a silent empty translation.
- Expose `translation_in_flight`, `translation_queue_wait_seconds` and `translation_rejected_total`.

**Documentation and configuration**
- Document the `SYSTEM_BUSY` consumer contract in `docs/openapi.yaml` and the route's `responses=` dict; document all four settings in `.env.example` and `docker-compose.yml`.
- Extend the OpenSpec change `add-pipeline-admission-control` to cover #190.

Four design points worth a reviewer's attention:

**The slot is tied to the worker thread, not the awaiting task.** `asyncio.to_thread` cannot interrupt a call it has started. Releasing on the awaiting task's `finally` meant a cancelled request handed its capacity to the next caller while its own thread was still on the GPU, letting real concurrency exceed the limit. `run()` is therefore the only entry point in both components, and releases from inside the thread, so no API remains that can hold a slot without running work.

**The queue-wait histograms record rejections too.** Observing only admitted requests made them report "everyone seated instantly" during the exact saturation they exist to measure.

**The busy clause precedes the broad `except Exception`.** Both `send_unified_message` and `translate` end in one, and either would have reported a capacity rejection as a `500`.

**The tokenizer lock is now load-bearing.** `_generate_single` guards the mutable `src_lang` with a `threading.Lock`, which was correct but had never contended because everything ran on one thread. It is covered by a test that proves mutual exclusion rather than assuming it.

## Testing

Three new suites, 64 tests, all written before the code and watched failing first.

### Test Coverage
- [x] All existing tests pass (`pytest`)
- [x] New tests added for this change
- [x] Manual testing completed
- [ ] Integration tests pass — skipped by default in CI, unchanged by this PR
- [ ] Load tests pass (if applicable) — not run; raising the limits from load evidence is deliberate follow-up work

`434 passed, 25 skipped` on the CI subset, verified against a worktree at the committed tree rather than a working directory. Baseline on `main` was 370, so 64 tests are new and none regressed.

**New-code coverage is 100%** — 271 of 271 added executable lines across every changed file in `services/`, measured from `coverage.xml` intersected with the diff against `main`:

| File | New-code coverage |
| --- | --- |
| `api_gateway/pipeline_admission.py` | 119/119 |
| `translation/app.py` | 114/114 |
| `api_gateway/routes/session.py` | 12/12 |
| `api_gateway/routes/pipeline.py` | 12/12 |
| `api_gateway/routes/upload.py` | 7/7 |
| `api_gateway/app.py` | 7/7 |

Guards were proven by reintroducing each bug and watching the suite reject it:

| Reintroduced defect | Test that caught it |
| --- | --- |
| Gateway gate removed from the text path | `test_text_path_returns_503_system_busy`, `test_busy_error_does_not_become_a_500` |
| Gateway slot released by the awaiting task | `test_cancelled_request_keeps_its_slot_until_the_thread_finishes` |
| Pipeline called directly on the loop | all 8 tests in `test_gateway_event_loop_non_blocking.py` |
| Translation offload removed | all 3 tests in `TestOffloadedFromTheEventLoop` (0 loop ticks in flight) |
| Translation tokenizer lock removed | `test_tokenizer_lock_excludes_concurrent_encoding` |
| Translation slot released by the awaiting task | `test_cancelled_request_keeps_its_slot_until_the_thread_finishes` |
| Translation busy clause removed | `TestSaturationResponse` — surfaced the exact `500 "Translation failed: No inference slot available"` |
| Translation rejection left unobserved | `test_rejection_is_recorded_in_the_queue_wait_histogram` |

Note on test placement: the #190 tests live in `tests/`, not `services/translation/tests/`. CI runs `pytest tests/` and `pytest.ini` pins `testpaths = tests`, so the existing per-service suites never execute in CI and a guard placed beside the service would have been decorative. They stub `torch`, `transformers` and `prometheus_client` but keep `fastapi` real, which is the only way to prove the `Retry-After` header reaches the wire.

### How to Test

```bash
# Full CI-equivalent subset
PYTHONPATH=. pytest tests/ -q \
  -m "not integration and not real_system" \
  --ignore=tests/integration --ignore=tests/load \
  --ignore=tests/integration_test_audio_validation.py

# Just this change
PYTHONPATH=. pytest tests/test_pipeline_admission.py \
  tests/test_gateway_event_loop_non_blocking.py \
  tests/test_translation_inference_offload.py -q
```

Gateway behaviour by hand, with `MAX_CONCURRENT_PIPELINES=1` and `PIPELINE_QUEUE_WAIT_SECONDS=2`: send two overlapping messages and the second returns `503` with `Retry-After: 2` and `error_code: SYSTEM_BUSY`, while `GET /health` and `GET /api/sessions/active` stay responsive throughout.

Verified in a running container that the gateway changes are live, not merely on disk: `/metrics` exposes the three `gateway_pipeline_*` series, the generated `/openapi.json` carries the `503` on `/api/session/{session_id}/message`, and the log reports `Pipeline admission ready (max_concurrent=2, queue_wait_seconds=10.0)`.

## Checklist

### Code Quality
- [x] Code follows the project's style guidelines
- [x] Self-review of code completed
- [x] Code is commented where necessary
- [x] No new warnings generated
- [x] Pre-commit hooks pass

`flake8` is clean on every file touched. `mypy` reports the same 22 pre-existing errors as `main` — zero introduced, verified by diffing against a worktree at the merge base. `black --check` adds **zero new drift**: `services/translation/app.py` was already non-conforming at `HEAD` under the configured `line-length = 100`, and the remaining hunks are byte-identical to the ones `main` produces, verified by diffing black's output on both revisions. `translate`'s cyclomatic complexity went 14 → 15, at the project's `max-complexity = 15` rather than over it, which is why the busy path is a single `return` into a helper.

### Testing
- [x] Tests added/updated for new functionality
- [x] All tests pass locally
- [x] Test coverage maintained or improved

### Documentation
- [x] Documentation updated (README, docs/, docstrings)
- [x] API documentation updated (if applicable)
- [ ] CHANGELOG.md updated (for significant changes) — no CHANGELOG.md in the repository
- [ ] Migration guide added (for breaking changes) — not a breaking change

### Dependencies
- [x] No new dependencies added
- [ ] OR: New dependencies justified and documented
- [x] requirements.txt / requirements-dev.txt updated — no change needed; `httpx` and `prometheus-client` were already pinned in both

### Security
- [x] No sensitive data exposed
- [x] Security best practices followed
- [x] Input validation added where needed

`bandit -r services/` reports 0 high and 2 medium, unchanged from `main` (the gate fails above 5; both mediums are the pre-existing `from_pretrained` revision pinning in the translation service, which this PR does not touch). The only new configuration is four numeric tuning values; no credentials, hosts or secrets appear anywhere in the diff.

## Performance Impact
- [ ] No performance impact
- [x] Performance improved
- [ ] Performance may be impacted (explain below)

Concurrent sessions now make progress instead of queueing behind one another, at both layers, and health and WebSocket traffic is no longer starved during a pipeline. Because #190 lands with #189, `MAX_CONCURRENT_PIPELINES` can actually be raised from evidence: with the gateway alone, extra pipelines would simply have re-queued inside the translation service.

The honest trade-off: offloading converts event-loop blocking into thread-pool demand, which is why the bounds ship in the same PR. Under saturation, throughput is deliberately capped and excess requests are rejected quickly rather than queued indefinitely — a request that would previously have waited behind every other session now gets a fast, actionable `503`.

## Breaking Changes

None. `POST /api/session/{id}/message` gains a `503` it could not previously return, which existing clients already handle: the SPA's `core/http/AppError.ts` maps status codes without reading the body, so a `503` becomes `AppError('server')` and surfaces as `errors.server`. No frontend change is required, and none is included.

`POST /translate` likewise gains a `503`. It is an internal service, and both gateway call sites already branch on `status_code != 200`.

`upload()` gains a `request` parameter so it can reach application state. Internal signature only; the HTTP contract of `/upload` is unchanged, confirmed against the generated OpenAPI surface.

## Additional Notes

**A deployment defect found on the way, covered by no issue.** The ASR, translation and TTS Dockerfiles copy `services/gpu_metrics.py` but never `services/resource_metrics.py`, which all three `app.py` files import at module level. `1fb7f09` created the shared module and moved the helpers out of each service without touching the Dockerfiles. Reproducing the layout those Dockerfiles build shows `services.gpu_metrics` resolving and `services.resource_metrics` not, so `uvicorn` never starts. Production is healthy only because it runs an image built before `1fb7f09`, whose `/health` returned an identical shape with the helpers inline; the next rebuild of any of the three would have failed. No CI job builds these images, which is why nothing caught it. Fixed in a separate commit (`8d4db5e`) — one `COPY` line each — because without it the #190 fix in this PR is not deployable. Happy to split it into its own PR if a reviewer prefers.

**Open question for reviewers.** Both default limits of `2` are inferred from the hardware, not measured — no pipeline throughput benchmark exists in the repository. The metrics in this PR exist so the figures can be raised from evidence, and `docs/openapi.yaml` plus `.env.example` document how. This is the part most worth disagreeing with, and it is a configuration change either way.

**Scope deliberately left out.** The bounds are per-process semaphores, so they bound one replica each; cross-replica coordination, a durable queue and queue-position UX remain #227. Putting the AI-service calls behind the existing resilience layer remains #219. Retiring the legacy `/pipeline` and `/upload` routes remains #230 — they are bounded here rather than skipped, since they reach the same GPU. ASR and TTS already offload their inference and are left alone; neither is bounded yet, which is a reasonable follow-up now that the pattern exists in two places.

## Deployment Notes
- [x] No special deployment steps needed
- [ ] Requires database migration
- [x] Requires configuration changes
- [x] Requires service restart
- [ ] Other (specify below):

All four settings have working defaults, so no configuration is required to deploy. `docker-compose.yml` passes them through with the defaults applied. The gateway and the translation service must both restart to pick up their new lifespan components — and the translation, ASR and TTS images must be **rebuilt** for the `resource_metrics` fix, which is also what makes them able to start from the committed Dockerfiles at all.

After rollout, watch `gateway_pipeline_rejected_total` and `translation_rejected_total`: a nonzero value under normal load means the corresponding limit is set below real capacity.

## Reviewer Checklist
- [ ] Code quality acceptable
- [ ] Tests are comprehensive
- [ ] Documentation is clear
- [ ] No security concerns
- [ ] CI/CD passes
- [ ] Ready to merge
