### PR TITLE
feat: add Keycloak infrastructure foundation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,7 @@ CLICKHOUSE_USER=ssf_telemetry
 CLICKHOUSE_PASSWORD=replace_with_a_unique_strong_password
 
 # Keycloak identity provider and private PostgreSQL database
+KEYCLOAK_HOSTNAME=auth.example.com
 KEYCLOAK_DB_NAME=keycloak
 KEYCLOAK_DB_USER=keycloak
 KEYCLOAK_DB_PASSWORD=replace_with_a_unique_strong_database_password

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -221,6 +221,63 @@ services:
       retries: 5
       start_period: 30s
 
+  keycloak-postgres:
+    image: postgres:17.7-alpine
+    restart: always
+    environment:
+      POSTGRES_DB: ${KEYCLOAK_DB_NAME:?required}
+      POSTGRES_USER: ${KEYCLOAK_DB_USER:?required}
+      POSTGRES_PASSWORD: ${KEYCLOAK_DB_PASSWORD:?required}
+    volumes:
+      - keycloak-postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 20s
+
+  keycloak:
+    image: ssf-keycloak:26.7.2
+    build:
+      context: ./services/keycloak
+      dockerfile: Dockerfile
+    command: ["start", "--optimized"]
+    restart: always
+    expose:
+      - "8080"
+    environment:
+      KC_DB: postgres
+      KC_DB_URL_HOST: keycloak-postgres
+      KC_DB_URL_DATABASE: ${KEYCLOAK_DB_NAME:?required}
+      KC_DB_USERNAME: ${KEYCLOAK_DB_USER:?required}
+      KC_DB_PASSWORD: ${KEYCLOAK_DB_PASSWORD:?required}
+      KC_BOOTSTRAP_ADMIN_USERNAME: ${KEYCLOAK_BOOTSTRAP_ADMIN_USERNAME:?required}
+      KC_BOOTSTRAP_ADMIN_PASSWORD: ${KEYCLOAK_BOOTSTRAP_ADMIN_PASSWORD:?required}
+      KC_HOSTNAME: https://auth.kassel.smartspeechflow.de
+      KC_PROXY_HEADERS: xforwarded
+      KC_HTTP_ENABLED: "true"
+      KC_HEALTH_ENABLED: "true"
+    depends_on:
+      keycloak-postgres:
+        condition: service_healthy
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "bash -ec 'exec 3<>/dev/tcp/127.0.0.1/9000; printf \"GET /health/ready HTTP/1.1\\r\\nHost: localhost\\r\\nConnection: close\\r\\n\\r\\n\" >&3; grep -q \"200 OK\" <&3'",
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 60s
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.keycloak.rule=Host(`auth.kassel.smartspeechflow.de`)"
+      - "traefik.http.routers.keycloak.entrypoints=websecure"
+      - "traefik.http.routers.keycloak.tls.certresolver=le"
+      - "traefik.http.services.keycloak.loadbalancer.server.port=8080"
+
   frontend-archive:
     build:
       context: ../ssf-frontend
@@ -383,3 +440,4 @@ volumes:
   ollama-data:
   audio-data:
   clickhouse-data:
+  keycloak-postgres-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -254,7 +254,7 @@ services:
       KC_DB_PASSWORD: ${KEYCLOAK_DB_PASSWORD:?required}
       KC_BOOTSTRAP_ADMIN_USERNAME: ${KEYCLOAK_BOOTSTRAP_ADMIN_USERNAME:?required}
       KC_BOOTSTRAP_ADMIN_PASSWORD: ${KEYCLOAK_BOOTSTRAP_ADMIN_PASSWORD:?required}
-      KC_HOSTNAME: https://auth.kassel.smartspeechflow.de
+      KC_HOSTNAME: https://${KEYCLOAK_HOSTNAME:?required}
       KC_PROXY_HEADERS: xforwarded
       KC_HTTP_ENABLED: "true"
       KC_HEALTH_ENABLED: "true"
@@ -273,7 +273,7 @@ services:
       start_period: 60s
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.keycloak.rule=Host(`auth.kassel.smartspeechflow.de`)"
+      - "traefik.http.routers.keycloak.rule=Host(`${KEYCLOAK_HOSTNAME:?required}`)"
       - "traefik.http.routers.keycloak.entrypoints=websecure"
       - "traefik.http.routers.keycloak.tls.certresolver=le"
       - "traefik.http.services.keycloak.loadbalancer.server.port=8080"

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,7 @@ Welcome to the Smart Speech Flow Backend documentation! This guide helps you fin
 - [Audio Recording Rollback Strategy](operations/AUDIO_RECORDING_ROLLBACK_STRATEGY.md) - Rollback procedures
 - [WebSocket Broadcast Failures Runbook](operations/runbooks/websocket-broadcast-failures.md) - Troubleshooting guide
 - [ClickHouse Operations Runbook](operations/runbooks/clickhouse-operations.md) - Internal analytics database operations
+- [Keycloak Operations Runbook](operations/runbooks/keycloak-operations.md) - Identity-provider operations and recovery
 - [Conversation Quality KPI Catalog](operations/conversation-quality-kpis.en.md) - Precise quality, reliability, and privacy-aware telemetry definitions ([German](operations/conversation-quality-kpis.md))
 
 ### For KasselDIALOG Rollout

--- a/docs/deployment/BACKUP_STRATEGY.md
+++ b/docs/deployment/BACKUP_STRATEGY.md
@@ -38,12 +38,18 @@
 - Archive metadata: image version, table, UTC timestamp, checksum, and restore result
 - Never include credentials, audio, transcripts, translations, or other content data
 
-### 4. System Configuration (Weekly)
+### 4. Keycloak Identity Data (Before Every Upgrade)
+- Compressed logical PostgreSQL dump of the Keycloak database
+- SHA-256 checksum and UTC timestamp for each archive
+- Restore verification into a temporary PostgreSQL database before an upgrade
+- Encrypted storage; never include bootstrap credentials or access tokens
+
+### 5. System Configuration (Weekly)
 - Docker volumes
 - Traefik certificates
 - Alert rules & monitoring configs
 
-### 5. Models (One-time + updates)
+### 6. Models (One-time + updates)
 - ASR models
 - Translation models
 - TTS models
@@ -128,6 +134,9 @@ ClickHouse exports are table-specific and begin only after the future telemetry
 schema is approved. Use the [ClickHouse Operations Runbook](../operations/runbooks/clickhouse-operations.md)
 for the export and temporary-restore procedure; include the resulting encrypted
 archive in the existing retention rotation.
+
+Keycloak backups use PostgreSQL logical dumps and require a temporary restore
+verification before upgrades. Follow the [Keycloak Operations Runbook](../operations/runbooks/keycloak-operations.md).
 
 ### 1. Daily Backup Script
 ```bash

--- a/docs/deployment/SECURITY.md
+++ b/docs/deployment/SECURITY.md
@@ -34,7 +34,7 @@ The following services are now **only accessible within Docker network** (not ex
 | cAdvisor | 8080 (public) | `expose: 8080` (internal) | Via Prometheus |
 | Ollama | 11434 (public) | `expose: 11434` (internal) | Via API Gateway |
 | ClickHouse | 8123 (public) | `expose: 8123` (internal) | Via authenticated Compose exec only |
-| Keycloak PostgreSQL | 5432 (public) | No host port or Traefik route | Via Keycloak on the Compose network only |
+| Keycloak PostgreSQL | N/A | No host port or Traefik route | Via Keycloak on the Compose network only |
 
 **Benefits:**
 - ✅ No direct public access to metrics

--- a/docs/deployment/SECURITY.md
+++ b/docs/deployment/SECURITY.md
@@ -58,7 +58,7 @@ The following services are now **only accessible within Docker network** (not ex
 - [ ] Generate a ClickHouse password: `openssl rand -base64 32`
 - [ ] Set `CLICKHOUSE_DB`, `CLICKHOUSE_USER`, and `CLICKHOUSE_PASSWORD` in `.env`
 - [ ] Generate Keycloak database and bootstrap-admin passwords: `openssl rand -base64 32`
-- [ ] Set the five required `KEYCLOAK_*` variables in `.env`
+- [ ] Set the six required `KEYCLOAK_*` variables in `.env`, including the non-secret `KEYCLOAK_HOSTNAME`
 - [ ] Review all other environment variables in `.env`
 
 ### Security Verification
@@ -123,7 +123,7 @@ curl -u "admin:YOUR_PASSWORD" http://localhost:3000/api/health
 For start-up, verification, backup, restore, upgrade, rollback, and incident
 procedures, see the [ClickHouse Operations Runbook](../operations/runbooks/clickhouse-operations.md).
 
-Keycloak is public only through Traefik at `auth.kassel.smartspeechflow.de`;
+Keycloak is public only through Traefik at the deployment-specific `KEYCLOAK_HOSTNAME`;
 its PostgreSQL database and management endpoint have no public route. See the
 [Keycloak Operations Runbook](../operations/runbooks/keycloak-operations.md).
 

--- a/docs/deployment/SECURITY.md
+++ b/docs/deployment/SECURITY.md
@@ -34,6 +34,7 @@ The following services are now **only accessible within Docker network** (not ex
 | cAdvisor | 8080 (public) | `expose: 8080` (internal) | Via Prometheus |
 | Ollama | 11434 (public) | `expose: 11434` (internal) | Via API Gateway |
 | ClickHouse | 8123 (public) | `expose: 8123` (internal) | Via authenticated Compose exec only |
+| Keycloak PostgreSQL | 5432 (public) | No host port or Traefik route | Via Keycloak on the Compose network only |
 
 **Benefits:**
 - ✅ No direct public access to metrics
@@ -56,6 +57,8 @@ The following services are now **only accessible within Docker network** (not ex
 - [ ] Verify `GRAFANA_ADMIN_USER` (default: `admin`)
 - [ ] Generate a ClickHouse password: `openssl rand -base64 32`
 - [ ] Set `CLICKHOUSE_DB`, `CLICKHOUSE_USER`, and `CLICKHOUSE_PASSWORD` in `.env`
+- [ ] Generate Keycloak database and bootstrap-admin passwords: `openssl rand -base64 32`
+- [ ] Set the five required `KEYCLOAK_*` variables in `.env`
 - [ ] Review all other environment variables in `.env`
 
 ### Security Verification
@@ -120,6 +123,10 @@ curl -u "admin:YOUR_PASSWORD" http://localhost:3000/api/health
 For start-up, verification, backup, restore, upgrade, rollback, and incident
 procedures, see the [ClickHouse Operations Runbook](../operations/runbooks/clickhouse-operations.md).
 
+Keycloak is public only through Traefik at `auth.kassel.smartspeechflow.de`;
+its PostgreSQL database and management endpoint have no public route. See the
+[Keycloak Operations Runbook](../operations/runbooks/keycloak-operations.md).
+
 ## Default Passwords
 
 ### ⚠️ Frontend Demo Access Code
@@ -130,6 +137,9 @@ The frontend uses a client-visible demo access code for the landing page:
 - **Docker:** `FRONTEND_DEMO_PASSWORD` is mapped to the intentionally public `VITE_DEMO_ACCESS_CODE` build argument and then embedded in the browser bundle
 - **Security:** Client-side only, with no backend validation; never treat it as authentication or authorization
 - **Production:** Customize it if desired, but enforce access restrictions through server-side authentication
+
+The Keycloak infrastructure does not yet replace this demo gate. SSF login and
+authorization integration require a separate approved change.
 
 ### ✅ Grafana Admin Password
 

--- a/docs/operations/runbooks/keycloak-operations.md
+++ b/docs/operations/runbooks/keycloak-operations.md
@@ -1,0 +1,51 @@
+# Keycloak Operations Runbook
+
+Keycloak is public only through Traefik at `https://auth.kassel.smartspeechflow.de`.
+Its PostgreSQL database and management endpoint remain private to the Compose network.
+This infrastructure does not yet authenticate SSF users.
+
+## First deployment
+
+Confirm DNS resolves to the SSF host before starting Keycloak:
+
+```bash
+test "$(dig +short A auth.kassel.smartspeechflow.de | head -n1)" = "$(dig +short A translate.smart-village.solutions | head -n1)"
+```
+
+If this fails, stop: Traefik cannot obtain a TLS certificate. Generate database
+and bootstrap-admin passwords with `openssl rand -base64 32`, set the required
+`KEYCLOAK_*` values only in the ignored `.env`, then run `chmod 600 .env`.
+
+```bash
+docker compose build keycloak
+docker compose up -d keycloak-postgres keycloak
+docker compose ps keycloak-postgres keycloak
+```
+
+## Verification
+
+```bash
+docker compose exec -T keycloak bash -ec 'exec 3<>/dev/tcp/127.0.0.1/9000; printf "GET /health/ready HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n" >&3; grep -q "200 OK" <&3'
+curl --fail --silent --show-error https://auth.kassel.smartspeechflow.de/realms/master >/dev/null
+docker inspect "$(docker compose ps -q keycloak-postgres)" --format '{{json .HostConfig.PortBindings}}'
+```
+
+The first two commands must pass and the final command must return `{}`. Verify
+the bootstrap administrator with `kcadm.sh` without printing its password, then
+rotate the initial administrator password after first login.
+
+## Backup and recovery
+
+Before every upgrade, create an encrypted compressed PostgreSQL logical backup
+with `pg_dump`, store a SHA-256 checksum, and restore it into a temporary
+database to verify it. Review Keycloak migration notes, change only the pinned
+Keycloak tag, rebuild, recreate only Keycloak, and repeat verification. On
+failure, restore the preceding pinned tag; never remove `keycloak-postgres-data`.
+
+Never expose PostgreSQL or Keycloak management port 9000 to work around an
+incident.
+
+## References
+
+- [Keycloak container guide](https://www.keycloak.org/server/containers)
+- [Keycloak reverse-proxy configuration](https://www.keycloak.org/server/reverseproxy)

--- a/docs/operations/runbooks/keycloak-operations.md
+++ b/docs/operations/runbooks/keycloak-operations.md
@@ -1,15 +1,20 @@
 # Keycloak Operations Runbook
 
-Keycloak is public only through Traefik at `https://auth.kassel.smartspeechflow.de`.
+Keycloak is public only through Traefik at `https://${KEYCLOAK_HOSTNAME}`.
 Its PostgreSQL database and management endpoint remain private to the Compose network.
 This infrastructure does not yet authenticate SSF users.
 
 ## First deployment
 
-Confirm DNS resolves to the SSF host before starting Keycloak:
+Set `KEYCLOAK_HOSTNAME` in the ignored deployment `.env`, export it for the
+following checks, and confirm that its DNS record resolves to the SSF host
+before starting Keycloak:
 
 ```bash
-test "$(dig +short A auth.kassel.smartspeechflow.de | head -n1)" = "$(dig +short A translate.smart-village.solutions | head -n1)"
+set -a
+. ./.env
+set +a
+test -n "$(dig +short A "$KEYCLOAK_HOSTNAME" | head -n1)"
 ```
 
 If this fails, stop: Traefik cannot obtain a TLS certificate. Generate database
@@ -26,7 +31,7 @@ docker compose ps keycloak-postgres keycloak
 
 ```bash
 docker compose exec -T keycloak bash -ec 'exec 3<>/dev/tcp/127.0.0.1/9000; printf "GET /health/ready HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n" >&3; grep -q "200 OK" <&3'
-curl --fail --silent --show-error https://auth.kassel.smartspeechflow.de/realms/master >/dev/null
+curl --fail --silent --show-error "https://${KEYCLOAK_HOSTNAME}/realms/master" >/dev/null
 docker inspect "$(docker compose ps -q keycloak-postgres)" --format '{{json .HostConfig.PortBindings}}'
 ```
 

--- a/docs/superpowers/plans/2026-09-01-keycloak-infrastructure-foundation.md
+++ b/docs/superpowers/plans/2026-09-01-keycloak-infrastructure-foundation.md
@@ -142,7 +142,7 @@ Run:
 
 ```bash
 pytest tests/test_keycloak_compose_configuration.py -q
-docker compose --env-file <(printf '%s\\n' 'CLICKHOUSE_DB=test' 'CLICKHOUSE_USER=test' 'CLICKHOUSE_PASSWORD=test' 'KEYCLOAK_HOSTNAME=auth.test.example' 'KEYCLOAK_DB_NAME=keycloak' 'KEYCLOAK_DB_USER=keycloak' 'KEYCLOAK_DB_PASSWORD=test' 'KEYCLOAK_BOOTSTRAP_ADMIN_USERNAME=admin' 'KEYCLOAK_BOOTSTRAP_ADMIN_PASSWORD=test') config --quiet
+env CLICKHOUSE_DB=test CLICKHOUSE_USER=test CLICKHOUSE_PASSWORD=test KEYCLOAK_HOSTNAME=auth.test.example KEYCLOAK_DB_NAME=keycloak KEYCLOAK_DB_USER=keycloak KEYCLOAK_DB_PASSWORD=test KEYCLOAK_BOOTSTRAP_ADMIN_USERNAME=admin KEYCLOAK_BOOTSTRAP_ADMIN_PASSWORD=test docker compose config --quiet
 ```
 
 Expected: both commands exit successfully; the rendered configuration has no public database or management port.
@@ -311,7 +311,7 @@ Run:
 
 ```bash
 pytest tests/test_keycloak_compose_configuration.py tests/test_clickhouse_compose_configuration.py tests/test_frontend_container_build.py -q
-docker compose --env-file <(printf '%s\\n' 'CLICKHOUSE_DB=test' 'CLICKHOUSE_USER=test' 'CLICKHOUSE_PASSWORD=test' 'KEYCLOAK_HOSTNAME=auth.test.example' 'KEYCLOAK_DB_NAME=keycloak' 'KEYCLOAK_DB_USER=keycloak' 'KEYCLOAK_DB_PASSWORD=test' 'KEYCLOAK_BOOTSTRAP_ADMIN_USERNAME=admin' 'KEYCLOAK_BOOTSTRAP_ADMIN_PASSWORD=test') config --quiet
+env CLICKHOUSE_DB=test CLICKHOUSE_USER=test CLICKHOUSE_PASSWORD=test KEYCLOAK_HOSTNAME=auth.test.example KEYCLOAK_DB_NAME=keycloak KEYCLOAK_DB_USER=keycloak KEYCLOAK_DB_PASSWORD=test KEYCLOAK_BOOTSTRAP_ADMIN_USERNAME=admin KEYCLOAK_BOOTSTRAP_ADMIN_PASSWORD=test docker compose config --quiet
 git diff origin/main...HEAD --check
 git status --short
 ```

--- a/docs/superpowers/plans/2026-09-01-keycloak-infrastructure-foundation.md
+++ b/docs/superpowers/plans/2026-09-01-keycloak-infrastructure-foundation.md
@@ -1,0 +1,359 @@
+# Keycloak Infrastructure Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make a pinned Keycloak instance operational behind Traefik with a private, persistent PostgreSQL database, without enabling SSF authentication or Studio provisioning.
+
+**Architecture:** Docker Compose runs an optimized Keycloak 26.7.2 image and a dedicated PostgreSQL 17.7-alpine database on the existing private Compose network. Traefik is the only public entry point; the deployment-specific `KEYCLOAK_HOSTNAME` configures both Keycloak's canonical URL and its TLS router. Python contract tests render Compose with throwaway values and protect this boundary.
+
+**Tech Stack:** Docker Compose, Traefik, Keycloak 26.7.2, PostgreSQL 17.7-alpine, pytest, PyYAML.
+
+**Spec:** `docs/superpowers/specs/2026-09-01-keycloak-infrastructure-design.md`
+
+## Global Constraints
+
+- Pin the Keycloak image and custom build to `26.7.2` and PostgreSQL to `17.7-alpine`.
+- Require `KEYCLOAK_HOSTNAME`; production sets it to `auth.kassel.smartspeechflow.de`.
+- Require `KEYCLOAK_DB_NAME`, `KEYCLOAK_DB_USER`, `KEYCLOAK_DB_PASSWORD`, `KEYCLOAK_BOOTSTRAP_ADMIN_USERNAME`, and `KEYCLOAK_BOOTSTRAP_ADMIN_PASSWORD` from the ignored deployment `.env` only.
+- Do not publish a host port or Traefik route for Keycloak PostgreSQL or Keycloak management port `9000`.
+- Do not add realm imports, clients, roles, claims, service accounts, Studio provisioning, gateway authorization, frontend login behaviour, or a Node toolchain migration.
+- Keep all newly created or modified project documentation, commit messages, and PR material in English.
+
+---
+
+## File Structure
+
+- `services/keycloak/Dockerfile` creates the optimized, pinned Keycloak runtime image.
+- `docker-compose.yml` declares the private Keycloak database, the Keycloak service, health checks, persistent storage, and its parameterized Traefik route.
+- `.env.example` documents all required, non-production Keycloak configuration keys.
+- `tests/test_keycloak_compose_configuration.py` renders Compose and asserts the Keycloak security and configuration contract.
+- `tests/test_clickhouse_compose_configuration.py` and `tests/test_frontend_container_build.py` provide every required Compose variable to their isolated Compose invocations.
+- `docs/operations/runbooks/keycloak-operations.md`, `docs/deployment/BACKUP_STRATEGY.md`, `docs/deployment/SECURITY.md`, and `docs/README.md` provide deployment, recovery, security, and navigation guidance.
+
+### Task 1: Rebase the isolated feature branch onto current main
+
+**Files:**
+- Modify: all files listed in the File Structure section only when a rebase conflict requires carrying the intended Keycloak change forward
+- Test: `git diff --check`
+
+**Interfaces:**
+- Consumes: the existing `feat/keycloak-infrastructure` commits and uncommitted Keycloak infrastructure changes.
+- Produces: a clean feature branch based on `origin/main` that retains the agreed Keycloak foundation scope.
+
+- [ ] **Step 1: Capture the current worktree state in a local checkpoint commit**
+
+Run:
+
+```bash
+git status --short
+git add .env.example docker-compose.yml docs tests services/keycloak
+git commit -m "feat: add Keycloak infrastructure foundation"
+```
+
+Expected: the Keycloak infrastructure files are represented by a local commit; unrelated files are not staged.
+
+- [ ] **Step 2: Rebase the branch on the current remote main**
+
+Run:
+
+```bash
+git fetch origin main
+git rebase origin/main
+```
+
+Expected: `git merge-base HEAD origin/main` equals `git rev-parse origin/main` after any conflicts are resolved with the intended Keycloak-only diff.
+
+- [ ] **Step 3: Verify the rebased diff contains no whitespace errors**
+
+Run:
+
+```bash
+git diff origin/main...HEAD --check
+git status --short
+```
+
+Expected: `git diff --check` is silent and the worktree is clean.
+
+- [ ] **Step 4: Commit conflict resolutions if rebase required a follow-up change**
+
+Run:
+
+```bash
+git add .
+git commit -m "chore: rebase Keycloak infrastructure on main"
+```
+
+Expected: create this commit only when a post-rebase correction is necessary; otherwise do not create an empty commit.
+
+### Task 2: Parameterize and secure the Compose topology
+
+**Files:**
+- Create: `services/keycloak/Dockerfile`
+- Modify: `.env.example: Keycloak configuration section`
+- Modify: `docker-compose.yml: services.keycloak-postgres, services.keycloak, volumes`
+- Test: `tests/test_keycloak_compose_configuration.py`
+
+**Interfaces:**
+- Consumes: the six `KEYCLOAK_*` Compose environment variables from `.env`.
+- Produces: `keycloak-postgres` and `keycloak` services; Keycloak exposes internal port `8080`, uses `KEYCLOAK_HOSTNAME`, and the database persists in `keycloak-postgres-data`.
+
+- [ ] **Step 1: Write the failing hostname configuration test**
+
+In `tests/test_keycloak_compose_configuration.py`, write the variable to the temporary env file and assert the rendered values:
+
+```python
+env_file.write("KEYCLOAK_HOSTNAME=auth.test.example\\n")
+
+assert keycloak["labels"]["traefik.http.routers.keycloak.rule"] == "Host(\`auth.test.example\`)"
+assert keycloak["environment"]["KC_HOSTNAME"] == "https://auth.test.example"
+```
+
+- [ ] **Step 2: Run the focused contract test to verify it fails**
+
+Run:
+
+```bash
+pytest tests/test_keycloak_compose_configuration.py -q
+```
+
+Expected: FAIL because the Compose service still hard-codes the Kassel hostname or lacks `KEYCLOAK_HOSTNAME` in the test environment.
+
+- [ ] **Step 3: Implement the minimal parameterized Compose configuration**
+
+In `.env.example`, add the non-secret deployment key:
+
+```dotenv
+KEYCLOAK_HOSTNAME=auth.example.com
+```
+
+In `docker-compose.yml`, make both canonical hostname consumers use the same required value:
+
+```yaml
+KC_HOSTNAME: https://${KEYCLOAK_HOSTNAME:?required}
+labels:
+  - "traefik.http.routers.keycloak.rule=Host(\`${KEYCLOAK_HOSTNAME:?required}\`)"
+```
+
+Retain the existing private PostgreSQL configuration, `expose: ["8080"]`, container-local port-9000 readiness probe, persistent volume, and Traefik TLS labels. Do not add `ports` to either service.
+
+- [ ] **Step 4: Run the focused test and Compose rendering check**
+
+Run:
+
+```bash
+pytest tests/test_keycloak_compose_configuration.py -q
+docker compose --env-file <(printf '%s\\n' 'CLICKHOUSE_DB=test' 'CLICKHOUSE_USER=test' 'CLICKHOUSE_PASSWORD=test' 'KEYCLOAK_HOSTNAME=auth.test.example' 'KEYCLOAK_DB_NAME=keycloak' 'KEYCLOAK_DB_USER=keycloak' 'KEYCLOAK_DB_PASSWORD=test' 'KEYCLOAK_BOOTSTRAP_ADMIN_USERNAME=admin' 'KEYCLOAK_BOOTSTRAP_ADMIN_PASSWORD=test') config --quiet
+```
+
+Expected: both commands exit successfully; the rendered configuration has no public database or management port.
+
+- [ ] **Step 5: Commit the topology and contract-test change**
+
+Run:
+
+```bash
+git add services/keycloak/Dockerfile docker-compose.yml .env.example tests/test_keycloak_compose_configuration.py
+git commit -m "feat: deploy Keycloak behind Traefik"
+```
+
+Expected: one focused commit contains the Keycloak image, Compose topology, configuration key, and security-contract test.
+
+### Task 3: Keep all existing Compose test entry points renderable
+
+**Files:**
+- Modify: `tests/test_clickhouse_compose_configuration.py: _clickhouse_service`
+- Modify: `tests/test_frontend_container_build.py: _compose_build`
+- Test: `tests/test_clickhouse_compose_configuration.py`, `tests/test_frontend_container_build.py`
+
+**Interfaces:**
+- Consumes: Compose's required `KEYCLOAK_HOSTNAME` and credential environment variables.
+- Produces: existing test helpers that render/build the full Compose project without reading a real `.env` file.
+
+- [ ] **Step 1: Add the required hostname variable to both helpers**
+
+Add the same test-only hostname environment value to each helper:
+
+```python
+env_file.write("KEYCLOAK_HOSTNAME=auth.test.example\\n")
+```
+
+and:
+
+```python
+environment["KEYCLOAK_HOSTNAME"] = "auth.test.example"
+```
+
+- [ ] **Step 2: Run the affected tests before adapting the helpers**
+
+Run:
+
+```bash
+pytest tests/test_clickhouse_compose_configuration.py tests/test_frontend_container_build.py -q
+```
+
+Expected: the Compose rendering path fails until every required Keycloak variable, including the hostname, is supplied.
+
+- [ ] **Step 3: Provide all isolated Keycloak test values in both helpers**
+
+Ensure both helpers set exactly these non-production values in addition to their existing ClickHouse values:
+
+```text
+KEYCLOAK_DB_NAME=keycloak_test
+KEYCLOAK_DB_USER=keycloak_test_user
+KEYCLOAK_DB_PASSWORD=test-only-db-password
+KEYCLOAK_BOOTSTRAP_ADMIN_USERNAME=bootstrap_admin
+KEYCLOAK_BOOTSTRAP_ADMIN_PASSWORD=test-only-admin-password
+KEYCLOAK_HOSTNAME=auth.test.example
+```
+
+- [ ] **Step 4: Run the affected tests after adapting the helpers**
+
+Run:
+
+```bash
+pytest tests/test_clickhouse_compose_configuration.py tests/test_frontend_container_build.py -q
+```
+
+Expected: PASS without depending on developer secrets or a local `.env` file.
+
+- [ ] **Step 5: Commit the test-helper compatibility change**
+
+Run:
+
+```bash
+git add tests/test_clickhouse_compose_configuration.py tests/test_frontend_container_build.py
+git commit -m "test: supply Keycloak Compose variables"
+```
+
+Expected: one focused commit restores isolated rendering/build tests.
+
+### Task 4: Document safe operations and verify the PR candidate
+
+**Files:**
+- Create: `docs/operations/runbooks/keycloak-operations.md`
+- Modify: `docs/README.md: Operations runbooks list`
+- Modify: `docs/deployment/BACKUP_STRATEGY.md: Keycloak identity data section`
+- Modify: `docs/deployment/SECURITY.md: private-service table and credential checklist`
+- Test: `tests/test_keycloak_compose_configuration.py`, `tests/test_clickhouse_compose_configuration.py`, `tests/test_frontend_container_build.py`
+
+**Interfaces:**
+- Consumes: the Compose service names `keycloak` and `keycloak-postgres`, plus `KEYCLOAK_HOSTNAME`.
+- Produces: an operator runbook for DNS/TLS validation, startup, readiness verification, encrypted logical backups, restore verification, upgrade, rollback, and incident boundaries.
+
+- [ ] **Step 1: Add documentation checks to the focused Keycloak contract test**
+
+Add assertions that the runbook contains the parameterized hostname and private-port policy:
+
+```python
+runbook = (ROOT / "docs/operations/runbooks/keycloak-operations.md").read_text()
+assert "KEYCLOAK_HOSTNAME" in runbook
+assert "management port 9000" in runbook
+```
+
+- [ ] **Step 2: Run the focused Keycloak test to verify it fails before documentation exists**
+
+Run:
+
+```bash
+pytest tests/test_keycloak_compose_configuration.py -q
+```
+
+Expected: FAIL until the referenced runbook uses the configured hostname and records the management-port boundary.
+
+- [ ] **Step 3: Write the runbook and deployment documentation**
+
+Document these executable, non-secret operations:
+
+```bash
+docker compose build keycloak
+docker compose up -d keycloak-postgres keycloak
+docker compose exec -T keycloak bash -ec 'exec 3<>/dev/tcp/127.0.0.1/9000; printf "GET /health/ready HTTP/1.1\\r\\nHost: localhost\\r\\nConnection: close\\r\\n\\r\\n" >&3; grep -q "200 OK" <&3'
+curl --fail --silent --show-error "https://${KEYCLOAK_HOSTNAME}/realms/master" >/dev/null
+```
+
+Require an encrypted, checksummed PostgreSQL logical dump and a temporary restore verification before upgrades. State that the hostname is deployment-specific, PostgreSQL and port 9000 are never exposed, bootstrap secrets stay out of the repository, and this PR does not enable SSF user authentication.
+
+- [ ] **Step 4: Run focused tests and the relevant quality checks**
+
+Run:
+
+```bash
+pytest tests/test_keycloak_compose_configuration.py tests/test_clickhouse_compose_configuration.py tests/test_frontend_container_build.py -q
+git diff origin/main...HEAD --check
+```
+
+Expected: all selected tests pass and the diff check is silent.
+
+- [ ] **Step 5: Commit the operational documentation**
+
+Run:
+
+```bash
+git add docs/README.md docs/deployment/BACKUP_STRATEGY.md docs/deployment/SECURITY.md docs/operations/runbooks/keycloak-operations.md tests/test_keycloak_compose_configuration.py
+git commit -m "docs: add Keycloak operations runbook"
+```
+
+Expected: one focused commit makes the deployment supportable without introducing authentication configuration.
+
+### Task 5: Create and validate the pull request
+
+**Files:**
+- Modify: no project files
+- Test: full relevant test suite and PR diff inspection
+
+**Interfaces:**
+- Consumes: the rebased, passing feature branch.
+- Produces: a GitHub pull request targeting `main`, linked to SSF issue #266 as explicitly out-of-scope follow-up work.
+
+- [ ] **Step 1: Run final verification**
+
+Run:
+
+```bash
+pytest tests/test_keycloak_compose_configuration.py tests/test_clickhouse_compose_configuration.py tests/test_frontend_container_build.py -q
+docker compose --env-file <(printf '%s\\n' 'CLICKHOUSE_DB=test' 'CLICKHOUSE_USER=test' 'CLICKHOUSE_PASSWORD=test' 'KEYCLOAK_HOSTNAME=auth.test.example' 'KEYCLOAK_DB_NAME=keycloak' 'KEYCLOAK_DB_USER=keycloak' 'KEYCLOAK_DB_PASSWORD=test' 'KEYCLOAK_BOOTSTRAP_ADMIN_USERNAME=admin' 'KEYCLOAK_BOOTSTRAP_ADMIN_PASSWORD=test') config --quiet
+git diff origin/main...HEAD --check
+git status --short
+```
+
+Expected: all commands succeed and `git status --short` is empty.
+
+- [ ] **Step 2: Inspect the exact PR diff**
+
+Run:
+
+```bash
+git log --oneline origin/main..HEAD
+git diff --stat origin/main...HEAD
+git diff --check origin/main...HEAD
+```
+
+Expected: only Keycloak infrastructure, its contract tests, and its operations documentation are included.
+
+- [ ] **Step 3: Push the branch and create the pull request**
+
+Run:
+
+```bash
+git push --set-upstream origin feat/keycloak-infrastructure
+gh pr create --base main --head feat/keycloak-infrastructure --title "feat: add Keycloak infrastructure foundation" --body "## Summary
+- deploy a pinned Keycloak instance behind Traefik with private PostgreSQL
+- configure the public hostname through \`KEYCLOAK_HOSTNAME\`
+- add Compose security-contract tests and an operations runbook
+
+## Out of scope
+This PR does not configure realms, clients, roles, claims, Studio provisioning, or SSF login. Those runtime-configuration and authorization changes follow [#266](https://github.com/smart-village-solutions/smart-speech-flow/issues/266).
+
+## Verification
+- \`pytest tests/test_keycloak_compose_configuration.py tests/test_clickhouse_compose_configuration.py tests/test_frontend_container_build.py -q\`
+- \`docker compose ... config --quiet\`"
+```
+
+Expected: the PR targets `main`, describes the infrastructure-only scope, and records the executed verification.
+
+## Self-Review
+
+- Spec coverage: Task 2 delivers the pinned image, private database, health checks, persistent volume, required hostname, credentials, and Traefik-only route. Task 3 preserves existing isolated Compose callers. Task 4 delivers the runbook, backup, security, and navigation documentation. Task 5 verifies and opens the scope-limited PR.
+- Exclusions: The global constraints and Tasks 2, 4, and 5 explicitly exclude realm/client/role/claim provisioning, SSF login, Studio integration, and Node migration.
+- Placeholder scan: no deferred implementation markers are used; every task names exact files, commands, configuration names, and expected outcomes.
+- Interface consistency: `KEYCLOAK_HOSTNAME`, `keycloak`, `keycloak-postgres`, and `keycloak-postgres-data` use the same names in every task.

--- a/docs/superpowers/specs/2026-09-01-keycloak-infrastructure-design.md
+++ b/docs/superpowers/specs/2026-09-01-keycloak-infrastructure-design.md
@@ -1,0 +1,88 @@
+# Keycloak Infrastructure Foundation Design
+
+## Status and purpose
+
+This design defines a standalone infrastructure pull request that makes
+Keycloak reproducibly deployable with Smart Speech Flow (SSF). It deliberately
+does not implement the Studio--SSF tenant and runtime-configuration contract.
+
+Keycloak is a technical component of an SSF installation. Studio will later
+provision tenant, identity, role, claim, and permission data through the
+approved control-plane contract.
+
+## Scope
+
+The infrastructure pull request SHALL provide:
+
+- a pinned, optimized Keycloak container image;
+- a private, persistent PostgreSQL database dedicated to Keycloak;
+- an internal Compose network boundary with no host ports for Keycloak,
+  PostgreSQL, or the Keycloak management interface;
+- public HTTPS access only through Traefik;
+- a required non-secret `KEYCLOAK_HOSTNAME` configuration value;
+- required bootstrap-administrator and database credentials sourced only from
+  the ignored deployment environment file;
+- readiness health checks, Compose contract tests, and an operator runbook;
+- documented backup, verification, upgrade, and rollback procedures.
+
+Production sets `KEYCLOAK_HOSTNAME=auth.kassel.smartspeechflow.de`. Local and
+other deployments may set a different hostname without altering Compose files.
+
+## Architecture
+
+```text
+Internet
+  -> Traefik (TLS, public route for KEYCLOAK_HOSTNAME)
+  -> Keycloak (internal port 8080)
+  -> Keycloak PostgreSQL (private Compose network and persistent volume)
+```
+
+Keycloak starts only after PostgreSQL is healthy. The Keycloak management port
+is used only by the container-local readiness probe and MUST NOT be published.
+The PostgreSQL service has neither published ports nor Traefik labels.
+
+The build image is pinned to Keycloak 26.7.2. Runtime configuration uses
+Keycloak's PostgreSQL settings, forwarded proxy headers, HTTP internally behind
+Traefik TLS termination, and enabled health endpoints.
+
+## Configuration and secrets
+
+The deployment environment supplies these required secret values:
+
+- `KEYCLOAK_DB_NAME`
+- `KEYCLOAK_DB_USER`
+- `KEYCLOAK_DB_PASSWORD`
+- `KEYCLOAK_BOOTSTRAP_ADMIN_USERNAME`
+- `KEYCLOAK_BOOTSTRAP_ADMIN_PASSWORD`
+
+The PR documents their generation and restrictive environment-file permissions.
+It MUST NOT add real credentials, users, client secrets, or application tokens
+to the repository.
+
+## Explicit exclusions
+
+This PR MUST NOT introduce:
+
+- a Keycloak realm import or application client configuration;
+- SSF user roles, tenant claims, `ssf_permissions`, or a service account;
+- Studio-driven provisioning or tenant lifecycle integration;
+- gateway authorization or frontend login behaviour;
+- a Node toolchain migration.
+
+Those changes require a separate, approved OpenSpec aligned with the
+Studio--SSF Runtime Configuration Contract V1 and SSF issue #266.
+
+## Tests and rollout
+
+Compose contract tests render the topology with throwaway credentials and verify
+that Keycloak is publicly reachable only through Traefik, that the hostname is
+configured through `KEYCLOAK_HOSTNAME`, that PostgreSQL is private and
+persistent, and that required health checks and credentials are present.
+
+The runbook requires DNS and TLS readiness, local generation of the required
+secrets, build and startup commands, a private-database verification, a public
+readiness check, and a tested encrypted logical-backup/restore procedure.
+
+Rolling out this PR makes Keycloak operationally available only. It does not
+enable SSF user authentication and does not modify the existing conversation
+flow.

--- a/services/keycloak/Dockerfile
+++ b/services/keycloak/Dockerfile
@@ -1,0 +1,7 @@
+FROM quay.io/keycloak/keycloak:26.7.2 AS builder
+
+RUN /opt/keycloak/bin/kc.sh build --db=postgres --health-enabled=true
+
+FROM quay.io/keycloak/keycloak:26.7.2
+
+COPY --from=builder /opt/keycloak/ /opt/keycloak/

--- a/services/keycloak/Dockerfile
+++ b/services/keycloak/Dockerfile
@@ -5,3 +5,5 @@ RUN /opt/keycloak/bin/kc.sh build --db=postgres --health-enabled=true
 FROM quay.io/keycloak/keycloak:26.7.2
 
 COPY --from=builder /opt/keycloak/ /opt/keycloak/
+
+USER 1000

--- a/tests/test_clickhouse_compose_configuration.py
+++ b/tests/test_clickhouse_compose_configuration.py
@@ -17,6 +17,11 @@ def _clickhouse_service() -> dict:
         env_file.write("CLICKHOUSE_DB=ssf_analytics_test\n")
         env_file.write("CLICKHOUSE_USER=ssf_telemetry_test\n")
         env_file.write("CLICKHOUSE_PASSWORD=test-only-password\n")
+        env_file.write("KEYCLOAK_DB_NAME=keycloak_test\n")
+        env_file.write("KEYCLOAK_DB_USER=keycloak_test_user\n")
+        env_file.write("KEYCLOAK_DB_PASSWORD=test-only-db-password\n")
+        env_file.write("KEYCLOAK_BOOTSTRAP_ADMIN_USERNAME=bootstrap_admin\n")
+        env_file.write("KEYCLOAK_BOOTSTRAP_ADMIN_PASSWORD=test-only-admin-password\n")
 
     try:
         result = subprocess.run(

--- a/tests/test_clickhouse_compose_configuration.py
+++ b/tests/test_clickhouse_compose_configuration.py
@@ -22,6 +22,7 @@ def _clickhouse_service() -> dict:
         env_file.write("KEYCLOAK_DB_PASSWORD=test-only-db-password\n")
         env_file.write("KEYCLOAK_BOOTSTRAP_ADMIN_USERNAME=bootstrap_admin\n")
         env_file.write("KEYCLOAK_BOOTSTRAP_ADMIN_PASSWORD=test-only-admin-password\n")
+        env_file.write("KEYCLOAK_HOSTNAME=auth.test.example\n")
 
     try:
         result = subprocess.run(

--- a/tests/test_frontend_container_build.py
+++ b/tests/test_frontend_container_build.py
@@ -33,6 +33,7 @@ def _compose_build(project_name: str) -> subprocess.CompletedProcess[str]:
     environment["KEYCLOAK_DB_PASSWORD"] = "test-only-db-password"
     environment["KEYCLOAK_BOOTSTRAP_ADMIN_USERNAME"] = "bootstrap_admin"
     environment["KEYCLOAK_BOOTSTRAP_ADMIN_PASSWORD"] = "test-only-admin-password"
+    environment["KEYCLOAK_HOSTNAME"] = "auth.test.example"
     return subprocess.run(
         [
             "docker",

--- a/tests/test_frontend_container_build.py
+++ b/tests/test_frontend_container_build.py
@@ -28,6 +28,11 @@ def _compose_build(project_name: str) -> subprocess.CompletedProcess[str]:
     environment["CLICKHOUSE_DB"] = "ssf_analytics_test"
     environment["CLICKHOUSE_USER"] = "ssf_telemetry_test"
     environment["CLICKHOUSE_PASSWORD"] = "test-only-password"
+    environment["KEYCLOAK_DB_NAME"] = "keycloak_test"
+    environment["KEYCLOAK_DB_USER"] = "keycloak_test_user"
+    environment["KEYCLOAK_DB_PASSWORD"] = "test-only-db-password"
+    environment["KEYCLOAK_BOOTSTRAP_ADMIN_USERNAME"] = "bootstrap_admin"
+    environment["KEYCLOAK_BOOTSTRAP_ADMIN_PASSWORD"] = "test-only-admin-password"
     return subprocess.run(
         [
             "docker",

--- a/tests/test_keycloak_compose_configuration.py
+++ b/tests/test_keycloak_compose_configuration.py
@@ -1,0 +1,88 @@
+"""Regression tests for the Keycloak Compose security contract."""
+
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).parents[1]
+
+
+def _keycloak_services() -> tuple[dict, dict]:
+    """Render Compose with isolated credentials and return Keycloak services."""
+    with tempfile.NamedTemporaryFile(mode="w", delete=False) as env_file:
+        env_file.write("CLICKHOUSE_DB=ssf_analytics_test\n")
+        env_file.write("CLICKHOUSE_USER=ssf_telemetry_test\n")
+        env_file.write("CLICKHOUSE_PASSWORD=test-only-password\n")
+        env_file.write("KEYCLOAK_DB_NAME=keycloak_test\n")
+        env_file.write("KEYCLOAK_DB_USER=keycloak_test_user\n")
+        env_file.write("KEYCLOAK_DB_PASSWORD=test-only-db-password\n")
+        env_file.write("KEYCLOAK_BOOTSTRAP_ADMIN_USERNAME=bootstrap_admin\n")
+        env_file.write("KEYCLOAK_BOOTSTRAP_ADMIN_PASSWORD=test-only-admin-password\n")
+
+    try:
+        result = subprocess.run(
+            ["docker", "compose", "--env-file", env_file.name, "config"],
+            cwd=ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    finally:
+        os.unlink(env_file.name)
+
+    services = yaml.safe_load(result.stdout)["services"]
+    return services["keycloak"], services["keycloak-postgres"]
+
+
+def test_keycloak_is_public_only_through_traefik() -> None:
+    """Fail if Keycloak loses its canonical TLS route or gets a host port."""
+    keycloak, _ = _keycloak_services()
+
+    assert keycloak["image"] == "ssf-keycloak:26.7.2"
+    assert keycloak["restart"] == "always"
+    assert keycloak.get("ports") is None
+    assert keycloak["expose"] == ["8080"]
+    assert (
+        keycloak["labels"]["traefik.http.routers.keycloak.rule"]
+        == "Host(`auth.kassel.smartspeechflow.de`)"
+    )
+    assert (
+        keycloak["environment"]["KC_HOSTNAME"]
+        == "https://auth.kassel.smartspeechflow.de"
+    )
+    assert keycloak["environment"]["KC_PROXY_HEADERS"] == "xforwarded"
+    assert keycloak["healthcheck"]
+
+
+def test_keycloak_postgres_is_private_persistent_and_credentialed() -> None:
+    """Fail if the identity database becomes public or loses durable state."""
+    keycloak, postgres = _keycloak_services()
+
+    assert postgres["image"] == "postgres:17.7-alpine"
+    assert postgres["restart"] == "always"
+    assert postgres.get("ports") is None
+    assert postgres.get("expose") is None
+    assert postgres.get("labels") is None
+    assert postgres["healthcheck"]
+    assert {
+        "type": "volume",
+        "source": "keycloak-postgres-data",
+        "target": "/var/lib/postgresql/data",
+        "volume": {},
+    } in postgres["volumes"]
+    assert postgres["environment"] == {
+        "POSTGRES_DB": "keycloak_test",
+        "POSTGRES_USER": "keycloak_test_user",
+        "POSTGRES_PASSWORD": "test-only-db-password",
+    }
+    assert keycloak["environment"]["KC_DB"] == "postgres"
+    assert keycloak["environment"]["KC_DB_URL_HOST"] == "keycloak-postgres"
+    assert keycloak["environment"]["KC_DB_URL_DATABASE"] == "keycloak_test"
+    assert keycloak["environment"]["KC_DB_USERNAME"] == "keycloak_test_user"
+    assert keycloak["environment"]["KC_DB_PASSWORD"] == "test-only-db-password"
+    assert keycloak["environment"]["KC_BOOTSTRAP_ADMIN_USERNAME"] == "bootstrap_admin"
+    assert keycloak["environment"]["KC_BOOTSTRAP_ADMIN_PASSWORD"] == "test-only-admin-password"

--- a/tests/test_keycloak_compose_configuration.py
+++ b/tests/test_keycloak_compose_configuration.py
@@ -9,6 +9,7 @@ import yaml
 
 
 ROOT = Path(__file__).parents[1]
+KEYCLOAK_DOCKERFILE = ROOT / "services/keycloak/Dockerfile"
 
 
 def _keycloak_services() -> tuple[dict, dict]:
@@ -95,3 +96,10 @@ def test_keycloak_runbook_uses_the_configured_hostname_and_preserves_private_por
 
     assert "KEYCLOAK_HOSTNAME" in runbook
     assert "management port 9000" in runbook
+
+
+def test_keycloak_runtime_image_explicitly_uses_the_unprivileged_image_user() -> None:
+    """Make the final Keycloak image's runtime identity unambiguous to scanners."""
+    final_stage = KEYCLOAK_DOCKERFILE.read_text().split("FROM quay.io/keycloak/keycloak:26.7.2\n", 1)[1]
+
+    assert "USER 1000" in final_stage

--- a/tests/test_keycloak_compose_configuration.py
+++ b/tests/test_keycloak_compose_configuration.py
@@ -22,6 +22,7 @@ def _keycloak_services() -> tuple[dict, dict]:
         env_file.write("KEYCLOAK_DB_PASSWORD=test-only-db-password\n")
         env_file.write("KEYCLOAK_BOOTSTRAP_ADMIN_USERNAME=bootstrap_admin\n")
         env_file.write("KEYCLOAK_BOOTSTRAP_ADMIN_PASSWORD=test-only-admin-password\n")
+        env_file.write("KEYCLOAK_HOSTNAME=auth.test.example\n")
 
     try:
         result = subprocess.run(
@@ -48,11 +49,11 @@ def test_keycloak_is_public_only_through_traefik() -> None:
     assert keycloak["expose"] == ["8080"]
     assert (
         keycloak["labels"]["traefik.http.routers.keycloak.rule"]
-        == "Host(`auth.kassel.smartspeechflow.de`)"
+        == "Host(`auth.test.example`)"
     )
     assert (
         keycloak["environment"]["KC_HOSTNAME"]
-        == "https://auth.kassel.smartspeechflow.de"
+        == "https://auth.test.example"
     )
     assert keycloak["environment"]["KC_PROXY_HEADERS"] == "xforwarded"
     assert keycloak["healthcheck"]
@@ -86,3 +87,11 @@ def test_keycloak_postgres_is_private_persistent_and_credentialed() -> None:
     assert keycloak["environment"]["KC_DB_PASSWORD"] == "test-only-db-password"
     assert keycloak["environment"]["KC_BOOTSTRAP_ADMIN_USERNAME"] == "bootstrap_admin"
     assert keycloak["environment"]["KC_BOOTSTRAP_ADMIN_PASSWORD"] == "test-only-admin-password"
+
+
+def test_keycloak_runbook_uses_the_configured_hostname_and_preserves_private_ports() -> None:
+    """Keep operational instructions aligned with the Compose security boundary."""
+    runbook = (ROOT / "docs/operations/runbooks/keycloak-operations.md").read_text()
+
+    assert "KEYCLOAK_HOSTNAME" in runbook
+    assert "management port 9000" in runbook


### PR DESCRIPTION
## Summary
- deploy a pinned Keycloak instance behind Traefik with private PostgreSQL
- configure the public hostname through `KEYCLOAK_HOSTNAME`
- add Compose security-contract tests and an operations runbook

## Out of scope
This PR does not configure realms, clients, roles, claims, Studio provisioning, or SSF login. Those runtime-configuration and authorization changes follow [#266](https://github.com/smart-village-solutions/smart-speech-flow/issues/266).

## Verification
- `pytest -qq --disable-warnings --log-cli-level=CRITICAL tests/test_[a-m]*.py` — 173 passed, 13 skipped
- `pytest -qq --disable-warnings --log-cli-level=CRITICAL tests/test_[n-z]*.py` — 294 passed, 12 skipped
- `pytest -qq --disable-warnings --log-cli-level=CRITICAL tests/integration tests/load tests/operations` — 14 passed, 8 skipped
- `docker compose config --quiet` with isolated Keycloak and ClickHouse variables
- `git diff origin/main...HEAD --check`