### PR TITLE
docs: refresh delivery roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,272 +1,73 @@
-# Smart Speech Flow Backend - Roadmap
+# Smart Speech Flow Delivery Roadmap
 
-This roadmap outlines completed v1.0 features, ongoing work, and planned improvements for the Smart Speech Flow Backend project.
+This roadmap provides strategic context for the 2026 delivery programme. The
+operational source of truth for work-package status is the GitHub Project and
+its repository snapshot in
+[`apps/project-report/src/data/project-status.json`](apps/project-report/src/data/project-status.json).
 
-## 🎉 v1.0 - Public Launch (November 2025)
+**Last reconciled:** 3 September 2026
 
-### ✅ Completed Features
+**Status source:** GitHub Project #7 (Smart Speech Flow Delivery)
 
-#### Core Services
-- ✅ **ASR Service** – Speech recognition with OpenAI Whisper
-- ✅ **Translation Service** – 100+ languages with Facebook M2M100
-- ✅ **TTS Service** – Text-to-speech with Coqui-TTS & HuggingFace MMS
-- ✅ **API Gateway** – Unified REST API and pipeline orchestration
-- ✅ **Multi-format Audio** – Support for WAV, MP3, OGG, FLAC
+**Scope:** Reliable, accessible multilingual communication for public-administration staff and citizens.
 
-#### Real-Time Communication
-- ✅ **WebSocket Architecture** – Singleton pattern with differentiated messaging
-- ✅ **Session Management** – Redis-backed persistent sessions
-- ✅ **Admin/Customer Roles** – Separate WebSocket channels
-- ✅ **Heartbeat System** – 30s keepalive with automatic reconnection
+## Current delivery position
 
-#### Infrastructure
-- ✅ **Docker Compose** – Full containerization with 14 services
-- ✅ **GPU Acceleration** – NVIDIA CUDA support for optimal performance
-- ✅ **LLM Refinement** – Optional Ollama integration (gpt-oss:20b)
-- ✅ **Load Balancer** – Traefik for production routing
-- ✅ **Service Discovery** – Docker networking with health checks
+Milestones M1 to M3 are past their committed dates. M4 is due today. The
+delivery plan therefore prioritises work that removes blockers from the
+conversation flow, legal review, core-module maintainability, and required
+language coverage.
 
-#### Monitoring & Operations
-- ✅ **Prometheus Integration** – Metrics collection from all services
-- ✅ **Grafana Dashboards** – Pre-built dashboards for health, performance, GPU
-- ✅ **GPU Monitoring** – DCGM Exporter for NVIDIA GPU metrics
-- ✅ **Alert Rules** – Service down, latency, GPU pressure alerts
-- ✅ **Health Endpoints** – `/health` and `/metrics` on all services
+| Milestone | Committed date | Current position |
+| --- | --- | --- |
+| M1 — Foundations and UI prototype | 13 August 2026 | Four packages complete; legal review (WP-013) remains in implementation. |
+| M2 — Conversation and audio flow | 20 August 2026 | Conversation flow (WP-004) and accessible conversation surfaces (WP-019) are complete; WP-005 status is disputed (`Done` / `Planned`) pending #273, while required language profiles remain planned. |
+| M3 — Complete most refactoring | 27 August 2026 | Four packages remain planned; WP-022 status is disputed (`Done` / `Planned`) pending #273. |
+| M4 — Internal optimisation round | 3 September 2026 | Four packages remain planned. |
+| M5 — Complete internal optimisation | 10 September 2026 | Training, usage, and handover materials (WP-025) are in implementation; four packages remain planned. |
+| M6 — Public optimisation and rollout preparation | Mid-September 2026 | Planned; public optimisation (WP-011) needs attention. |
+| M7 — Regular operation | October 2026 | Planned. |
 
-#### Testing & Quality
-- ✅ **Test Suite** – 242 tests (96.7% passing)
-- ✅ **Integration Tests** – API contract, pipeline, WebSocket tests
-- ✅ **Load Tests** – Performance benchmarks
-- ✅ **Code Quality** – black, isort, flake8, bandit integration
-- ✅ **Pre-commit Hooks** – Automated quality checks
+## Immediate work order
 
-#### Documentation
-- ✅ **Comprehensive README** – Quick Start, architecture, monitoring
-- ✅ **Contributing Guide** – 3-step onboarding, code style, PR process
-- ✅ **Code of Conduct** – Contributor Covenant v2.1
-- ✅ **Testing Guide** – Test categories, fixtures, CI/CD
-- ✅ **Architecture Docs** – System design, WebSocket patterns
-- ✅ **Operations Runbooks** – Deployment, troubleshooting
-- ✅ **GitHub Templates** – Issue templates, PR template
+1. **WP-013 — Legal review:** obtain the commissioned review's concrete remit
+   and results, document obligations, and unblock WP-014 and WP-015.
+2. **WP-007 — Maintainable core modules:** prioritise the linked gateway
+   boundary work and resolve the related issues #225, #228, #229, and #230.
+3. **WP-020 — Required language and use profiles:** complete after WP-005
+   provides robust audio processing.
+4. **WP-006 — Status, error handling, and transparency:** resume after WP-005
+   and complete the resilience paths represented by issues #219 and #220.
+5. **WP-015 — Tenant model and data isolation:** prepare the design once
+   WP-013 provides the legal constraints; issue #232 tracks the work.
 
----
+## Delivery risks and dependencies
 
-## 🚧 In Progress (Q4 2025)
+- WP-005 blocks WP-006 and WP-020; its GitHub evidence currently contains
+  conflicting `Done` and `Planned` statuses.
+- WP-022 depends on the completed conversation flow plus WP-005, WP-007, and
+  WP-016; its GitHub evidence also contains conflicting `Done` and `Planned`
+  statuses.
+- The plan preserves the current statuses of WP-005 and WP-022 until the
+  conflicts are decided in [decision issue #273](https://github.com/smart-village-solutions/smart-speech-flow/issues/273).
+  No strategic-priority class has changed.
+- The M1–M4 date slippage requires explicit delivery decisions before treating
+  later milestones as forecast commitments.
 
-### Code Quality Improvements
-**Status:** 75% complete ([OpenSpec: fix-remaining-code-quality](openspec/changes/fix-remaining-code-quality/))
-- 🚧 Fix pylint warnings (currently 72 warnings)
-- 🚧 Resolve complexity issues in services
-- 🚧 Add type hints to all public functions
-- 🚧 Improve docstring coverage
+## Recently completed delivery evidence
 
-**Why:** Ensure maintainability and code consistency before community contributions.
+- Pipeline admission control was deployed on 1 September 2026.
+- Keycloak infrastructure foundation was merged on 1 September 2026.
+- ClickHouse quality telemetry probe via OpenTelemetry was merged on
+  3 September 2026.
 
-### Frontend SPA Application
-**Status:** 50% complete ([OpenSpec: add-frontend-spa-application](openspec/changes/add-frontend-spa-application/))
-- ✅ React + Vite setup
-- ✅ WebSocket integration
-- 🚧 Audio recording UI
-- 🚧 Session management UI
-- 🚧 Admin dashboard
-- ⏳ Customer interface
+These changes improve operational readiness, but they do not by themselves
+prove all acceptance criteria of the affected work packages.
 
-**Why:** Provide a complete user interface for demonstration and testing.
+## Governance
 
-### WebSocket Integration Refinement
-**Status:** 80% complete ([OpenSpec: frontend-websocket-integration](openspec/changes/frontend-websocket-integration/))
-- ✅ Singleton WebSocket manager
-- ✅ Differentiated messaging (admin/customer)
-- ✅ Prometheus metrics
-- 🚧 Reconnection handling improvements
-- 🚧 Message queue for offline scenarios
-
-**Why:** Ensure rock-solid real-time communication.
-
----
-
-## 🎯 Planned Features
-
-### Performance & Scalability
-**Priority:** High
-
-- **Model Optimization**
-  - Quantized model support (INT8, FP16)
-  - Model caching improvements
-  - Lazy loading for unused languages
-  - Batch processing for translations
-
-- **Horizontal Scaling**
-  - Kubernetes deployment manifests
-  - Service autoscaling based on load
-  - Load balancer optimization
-  - Connection pooling for Redis
-
-- **Database Integration**
-  - PostgreSQL for persistent storage
-  - Session history and analytics
-  - User management system
-  - API usage tracking
-
-### Enhanced Features
-**Priority:** Medium
-
-- **Audio Processing**
-  - Noise reduction and preprocessing
-  - Voice activity detection (VAD)
-  - Speaker diarization
-  - Audio quality analysis
-
-- **Translation Improvements**
-  - Custom translation models
-  - Domain-specific vocabulary
-  - Translation memory
-  - Context-aware translation
-
-- **Multi-Modal Support**
-  - Video input support
-  - Subtitle generation (SRT, VTT)
-  - Image-to-text (OCR)
-  - Document translation (PDF, DOCX)
-
-### Developer Experience
-**Priority:** Medium
-
-- **API Enhancements**
-  - GraphQL API option
-  - Streaming responses
-  - Webhook notifications
-  - Rate limiting per API key
-
-- **SDKs & Clients**
-  - Python SDK
-  - JavaScript/TypeScript SDK
-  - CLI tool for testing
-  - Postman collection
-
-- **Documentation**
-  - API reference (OpenAPI/Swagger UI)
-  - Interactive examples
-  - Video tutorials
-  - Architecture decision records (ADRs)
-
-### Security & Compliance
-**Priority:** High
-
-- **Authentication & Authorization**
-  - JWT-based authentication
-  - Role-based access control (RBAC)
-  - API key management
-  - OAuth2 integration
-
-- **Security Hardening**
-  - Input sanitization audit
-  - Security scanning in CI/CD
-  - Vulnerability monitoring
-  - HTTPS enforcement
-
-- **Compliance**
-  - GDPR compliance toolkit
-  - Audit logging
-  - Data retention policies
-  - Privacy controls
-
----
-
-## 🔮 Future Vision
-
-### AI/ML Enhancements
-- **Emotion Detection** – Analyze sentiment and emotion in speech
-- **Custom Models** – Fine-tuning support for specific domains
-- **Multi-Speaker Support** – Handle multiple speakers in one audio
-- **Real-Time Translation** – Live streaming translation
-
-### Platform Expansion
-- **Mobile SDKs** – Native iOS and Android SDKs
-- **Edge Deployment** – Optimized models for edge devices
-- **Cloud Marketplace** – AWS/Azure/GCP marketplace listings
-- **SaaS Offering** – Managed cloud service option
-
-### Community Features
-- **Model Zoo** – Community-contributed models
-- **Plugin System** – Extensible architecture for custom processors
-- **Marketplace** – Premium models and features
-- **Community Forum** – Dedicated discussion platform
-
----
-
-## 📊 Known Limitations & Technical Debt
-
-### Test Suite
-- **7 Flaky Tests** – Pass individually, fail in parallel ([TEST_STATUS.md](TEST_STATUS.md))
-  - Affected: Audio upload, validation, cleanup, metadata
-  - Cause: Docker network, parallel execution, state pollution
-  - Impact: 96.7% pass rate (acceptable for v1.0)
-  - Plan: Fix post-launch with dedicated test isolation work
-
-### Code Quality
-- **72 Pylint Warnings** – Non-blocking style issues
-  - Categories: Line length, import order, complexity
-  - Plan: Addressed in [fix-remaining-code-quality](openspec/changes/fix-remaining-code-quality/)
-
-### Documentation
-- **Missing API Examples** – Some endpoints lack code examples
-- **No Video Tutorials** – Only text documentation available
-- **Limited Troubleshooting** – Common issues need more coverage
-
-### Performance
-- **Model Loading** – First request has high latency (cold start)
-- **Memory Usage** – Large models require 16GB+ RAM
-- **GPU Sharing** – Services don't share GPU efficiently
-
----
-
-## 🗓️ Release Timeline
-
-### Step 1
-- ✅ **v1.0.0** – Public launch (November 2025)
-- 🚧 **v1.1.0** – Code quality improvements, flaky test fixes
-- 🚧 **v1.2.0** – Frontend SPA completion, WebSocket refinements
-
-### Step 2
-- ⏳ **v1.3.0** – Performance optimizations, model caching
-- ⏳ **v1.4.0** – Database integration, user management
-- ⏳ **v1.5.0** – Authentication & authorization
-
-### Step 3
-- ⏳ **v2.0.0** – Major release with breaking changes
-  - Kubernetes support
-  - New API version (v2)
-  - Enhanced monitoring
-  - Premium features
-
----
-
-## 🤝 Contributing to the Roadmap
-
-We welcome community input on our roadmap!
-
-### How to Suggest Features
-1. Check [existing feature requests](https://github.com/smart-village-solutions/smart-speech-flow/labels/enhancement)
-2. Open a [new feature request](https://github.com/smart-village-solutions/smart-speech-flow/issues/new?template=feature_request.md)
-3. Participate in [GitHub Discussions](https://github.com/smart-village-solutions/smart-speech-flow/discussions)
-
-### How to Contribute
-- See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines
-- Look for [`good-first-issue`](https://github.com/smart-village-solutions/smart-speech-flow/labels/good-first-issue) labels
-- Join discussions on prioritization
-- Implement features from the roadmap
-
----
-
-## 📞 Questions?
-
-Have questions about the roadmap?
-- 💬 [GitHub Discussions](https://github.com/smart-village-solutions/smart-speech-flow/discussions)
-- 🐛 [GitHub Issues](https://github.com/smart-village-solutions/smart-speech-flow/issues)
-
----
-
-**Last Updated:** November 2025 | **Version:** 1.0.0
-
-*This roadmap is subject to change based on community feedback and project priorities.*
+- GitHub Project #7 is the current delivery-status source.
+- OpenSpec changes record approved intended work and task progress.
+- The repository status snapshot supports the project report.
+- This roadmap provides prioritisation and context; it does not override
+  current GitHub evidence or approved project decisions.

--- a/apps/project-report/src/data/project-status.json
+++ b/apps/project-report/src/data/project-status.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "version": "1.6.0",
-    "updatedAt": "2026-08-30",
+    "updatedAt": "2026-09-03",
     "source": "Generated snapshot of GitHub Project #7 (Smart Speech Flow Delivery). Roadmap structure and acceptance criteria originate from docs/local-notes/konzept.md and the architecture reviews of 20.08.2026."
   },
   "statusModel": {
@@ -146,7 +146,7 @@
           "area": "Session und WebSocket",
           "priority": "must",
           "effortPt": 16,
-          "status": "planned",
+          "status": "done",
           "health": "on_track",
           "dependsOn": [
             "WP-003"
@@ -213,7 +213,7 @@
           "area": "Produktdesign und Barrierefreiheit",
           "priority": "must",
           "effortPt": 10,
-          "status": "planned",
+          "status": "done",
           "health": "on_track",
           "dependsOn": [
             "WP-003",


### PR DESCRIPTION
## Description

Refreshes the delivery roadmap and project-report snapshot from the live GitHub Project #7 evidence collected on 3 September 2026.

## Type of Change

- [x] 📝 Documentation update

## Related Issues

Tracks the resulting delivery-status decision in #273.

## Changes Made

- Replaced the November 2025 roadmap with the current 2026 delivery position, work order, risks, and governance sources.
- Synced the project-report snapshot: WP-004 and WP-019 are now `done`; the snapshot refresh date is 2026-09-03.
- Preserved WP-005 and WP-022 without a status change because their GitHub evidence conflicts; linked decision issue #273.

## Testing

- `npm run sync:github-project`
- `npm test` — 3 files, 11 tests passed
- `npm run build`
- `jq -e . apps/project-report/src/data/project-status.json`
- `git diff --check`

## Checklist

### Code Quality

- [x] Self-review of code completed
- [x] Pre-commit hooks pass

### Testing

- [x] All tests pass locally

### Documentation

- [x] Documentation updated

### Dependencies

- [x] No new dependencies added

### Security

- [x] No sensitive data exposed

## Performance Impact

- [x] No performance impact

## Breaking Changes

None.

## Deployment Notes

- [x] No special deployment steps needed