### PR TITLE
feat(telemetry): quality event taxonomy, gold tier, first real event and dashboards

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,8 +39,13 @@ CLICKHOUSE_USER=ssf_telemetry
 CLICKHOUSE_PASSWORD=replace_with_a_unique_strong_password
 
 # Quality telemetry (OTLP -> collector -> ClickHouse)
-# SSF_QUALITY_TELEMETRY_MODE accepts exactly `disabled` or `probe`. Any other
-# value logs a warning and falls back to `disabled`; it never stops the gateway.
+# SSF_QUALITY_TELEMETRY_MODE is one of `disabled`, `probe` or `enabled`. Any
+# other value logs a warning and falls back to `disabled`; it never stops the
+# gateway.
+#   disabled  no exporter is built at all.
+#   probe     transport check only, via the admin probe endpoint. No pipeline
+#             events, so turning it on adds no event volume.
+#   enabled   additionally emits real pipeline events (refinement_attempt).
 # `probe` for local and dev, so the pipeline produces rows without extra setup.
 # Production overrides this to `disabled` in deploy/production/.
 SSF_QUALITY_TELEMETRY_MODE=probe

--- a/.gitignore
+++ b/.gitignore
@@ -73,7 +73,14 @@ docs/local-notes
 *.pid
 monitoring/loki-data/
 monitoring/promtail-data/
+# monitoring/grafana is the container's /var/lib/grafana; it writes these
+# back into the working tree as root, and git cannot even read csv/pdf/png.
 monitoring/grafana/grafana.db
+monitoring/grafana/plugins/
+monitoring/grafana/csv/
+monitoring/grafana/pdf/
+monitoring/grafana/png/
+monitoring/grafana/dashboards/
 
 # OS
 .DS_Store

--- a/deploy/clickhouse/migrations/002_quality_events_fields_and_gold.sql
+++ b/deploy/clickhouse/migrations/002_quality_events_fields_and_gold.sql
@@ -1,0 +1,118 @@
+-- Typed quality fields on silver, plus the gold daily-aggregate tier.
+--
+-- Tasks 1.2 and 1.3 of openspec/changes/add-clickhouse-quality-telemetry.
+-- 001 shipped the seven envelope columns and fixed the 30-day raw TTL; this
+-- migration adds the first real event's fields and the 13-month aggregate tier
+-- alongside it. Both retention numbers are confirmed and deliberate: ClickHouse
+-- fixes TTL at table-creation time, so the 13 MONTH below cannot be changed
+-- later without an ALTER or a recreate.
+--
+-- ALTER, never CREATE, for the silver table: production's volume already holds
+-- `quality_events`, and a CREATE TABLE IF NOT EXISTS with new columns would
+-- silently do nothing there while succeeding on a fresh stack -- the two
+-- environments would then disagree about the schema with no error anywhere.
+
+ALTER TABLE quality_events
+    ADD COLUMN IF NOT EXISTS refiner_role          LowCardinality(String) DEFAULT '',
+    ADD COLUMN IF NOT EXISTS model_ref             LowCardinality(String) DEFAULT '',
+    ADD COLUMN IF NOT EXISTS refinement_outcome    LowCardinality(String) DEFAULT '',
+    ADD COLUMN IF NOT EXISTS refinement_latency_ms UInt32                 DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS refinement_changed    UInt8                  DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS source_lang           LowCardinality(String) DEFAULT '',
+    ADD COLUMN IF NOT EXISTS target_lang           LowCardinality(String) DEFAULT '',
+    ADD COLUMN IF NOT EXISTS error_code            LowCardinality(String) DEFAULT '';
+
+-- MODIFY QUERY rather than DROP + CREATE: dropping the view leaves a window in
+-- which inserts into otel_logs are not projected into quality_events at all,
+-- and those events are simply lost -- there is no replay.
+--
+-- The defensive casts are load-bearing for the same reason as in 001: a
+-- materialized view that throws fails the originating INSERT into otel_logs,
+-- which the collector then retries forever. Map access on an absent key yields
+-- the type default rather than raising, so an event that does not carry the
+-- refinement fields projects zeros and empty strings, not an error.
+ALTER TABLE quality_events_mv MODIFY QUERY
+SELECT
+    toUUIDOrZero(LogAttributes['ssf.quality.event_id'])         AS event_id,
+    toUInt16OrZero(LogAttributes['ssf.quality.schema_version']) AS schema_version,
+    toDateTime64(Timestamp, 3)                                  AS emitted_at_utc,
+    EventName                                                   AS event_type,
+    ServiceName                                                 AS service_name,
+    ResourceAttributes['service.version']                       AS service_version,
+    ResourceAttributes['deployment.environment.name']           AS deployment_env,
+    LogAttributes['ssf.quality.refiner_role']                   AS refiner_role,
+    LogAttributes['ssf.quality.model_ref']                      AS model_ref,
+    LogAttributes['ssf.quality.refinement_outcome']             AS refinement_outcome,
+    toUInt32OrZero(LogAttributes['ssf.quality.refinement_latency_ms'])
+                                                                AS refinement_latency_ms,
+    toUInt8(LogAttributes['ssf.quality.refinement_changed'] = 'true')
+                                                                AS refinement_changed,
+    LogAttributes['ssf.quality.source_lang']                    AS source_lang,
+    LogAttributes['ssf.quality.target_lang']                    AS target_lang,
+    LogAttributes['ssf.quality.error_code']                     AS error_code
+FROM otel_logs
+WHERE toUUIDOrNull(LogAttributes['ssf.quality.event_id']) IS NOT NULL;
+
+-- Gold tier: one row per day per attribute combination, kept for 13 months so a
+-- release or model change can be compared against the same month a year back.
+--
+-- Every count here is uniqExact over event_id, never count() or sum(). A retried
+-- export inserts the bronze row a second time, and silver's ReplacingMergeTree
+-- only collapses that at merge time -- so an unmerged duplicate inflates a
+-- plain counter permanently, because an aggregate cannot be un-counted. This
+-- was observed: a sumState-based `changed_events` reported 2 for a single
+-- duplicated event while `events` correctly reported 1.
+--
+-- The latency states are the one place this fix does not reach: avg and the
+-- quantile digest have no distinct-by form, so a duplicated delivery
+-- contributes its value twice. The skew is bounded by the retry rate, which the
+-- writer-health alerts make visible; it is accepted rather than hidden.
+CREATE TABLE IF NOT EXISTS quality_events_daily
+(
+    event_date           Date,
+    event_type           LowCardinality(String),
+    deployment_env       LowCardinality(String),
+    service_version      LowCardinality(String),
+    refiner_role         LowCardinality(String),
+    model_ref            LowCardinality(String),
+    refinement_outcome   LowCardinality(String),
+    error_code           LowCardinality(String),
+    source_lang          LowCardinality(String),
+    target_lang          LowCardinality(String),
+    events               AggregateFunction(uniqExact, UUID),
+    changed_events       AggregateFunction(uniqExact, UUID),
+    latency_ms_avg       AggregateFunction(avg, UInt32),
+    latency_ms_quantiles AggregateFunction(quantilesTDigest(0.5, 0.95, 0.99), UInt32)
+)
+ENGINE = AggregatingMergeTree
+PARTITION BY toYYYYMM(event_date)
+ORDER BY (
+    event_date, event_type, deployment_env, service_version,
+    refiner_role, model_ref, refinement_outcome, error_code,
+    source_lang, target_lang
+)
+TTL event_date + INTERVAL 13 MONTH;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS quality_events_daily_mv
+TO quality_events_daily AS
+SELECT
+    toDate(emitted_at_utc) AS event_date,
+    event_type,
+    deployment_env,
+    service_version,
+    refiner_role,
+    model_ref,
+    refinement_outcome,
+    error_code,
+    source_lang,
+    target_lang,
+    uniqExactState(event_id)                    AS events,
+    uniqExactStateIf(event_id, refinement_changed = 1) AS changed_events,
+    avgState(refinement_latency_ms)             AS latency_ms_avg,
+    quantilesTDigestState(0.5, 0.95, 0.99)(refinement_latency_ms)
+                                                AS latency_ms_quantiles
+FROM quality_events
+GROUP BY
+    event_date, event_type, deployment_env, service_version,
+    refiner_role, model_ref, refinement_outcome, error_code,
+    source_lang, target_lang;

--- a/deploy/production/docker-compose.production.yml
+++ b/deploy/production/docker-compose.production.yml
@@ -217,6 +217,7 @@ services:
     expose:
     - '4318'
     - '13133'
+    - '8888'
     environment:
     - CLICKHOUSE_DB=${CLICKHOUSE_DB:?set CLICKHOUSE_DB in .env}
     - CLICKHOUSE_USER=${CLICKHOUSE_USER:?set CLICKHOUSE_USER in .env}
@@ -345,6 +346,10 @@ services:
     - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}
     - GF_SECURITY_DISABLE_INITIAL_ADMIN_CREATION=false
     - GF_USERS_ALLOW_SIGN_UP=false
+    - GF_INSTALL_PLUGINS=grafana-clickhouse-datasource 4.21.2
+    - CLICKHOUSE_DB=${CLICKHOUSE_DB:?set CLICKHOUSE_DB in .env}
+    - CLICKHOUSE_USER=${CLICKHOUSE_USER:?set CLICKHOUSE_USER in .env}
+    - CLICKHOUSE_PASSWORD=${CLICKHOUSE_PASSWORD:?required}
     volumes:
     - ../../monitoring/grafana:/var/lib/grafana
     - ../../monitoring/grafana-provisioning:/etc/grafana/provisioning:ro

--- a/deploy/production/production.env.example
+++ b/deploy/production/production.env.example
@@ -20,11 +20,17 @@ CLICKHOUSE_USER=ssf_telemetry
 CLICKHOUSE_PASSWORD=replace_with_a_unique_strong_password
 
 # Quality telemetry (OTLP -> otel-collector -> ClickHouse).
-# `disabled` or `probe` only; any other value logs a warning and falls back to
-# `disabled` without affecting gateway startup. Leave this `disabled` until the
-# production enablement steps in
+# One of `disabled`, `probe` or `enabled`; any other value logs a warning and
+# falls back to `disabled` without affecting gateway startup.
+#   disabled  no exporter is built at all. The production default.
+#   probe     transport check only, reachable from the admin probe endpoint.
+#             Emits no pipeline events, so turning it on adds no event volume.
+#   enabled   additionally emits real pipeline events (refinement_attempt).
+# Leave this `disabled` until the production enablement steps in
 # docs/operations/runbooks/clickhouse-operations.md have been completed --
-# the schema must be applied before the collector starts exporting.
+# the schema must be applied before the collector starts exporting, and
+# migration 002 must be applied before `enabled`, or refinement events land
+# with only their envelope columns populated.
 SSF_QUALITY_TELEMETRY_MODE=disabled
 SSF_OTLP_LOGS_ENDPOINT=http://otel-collector:4318/v1/logs
 # Set to the deployed git sha, matching the prod-<sha> image tags.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -240,6 +240,7 @@ services:
     expose:
       - "4318"
       - "13133"
+      - "8888"
     environment:
       - CLICKHOUSE_DB=${CLICKHOUSE_DB:?set CLICKHOUSE_DB in .env}
       - CLICKHOUSE_USER=${CLICKHOUSE_USER:?set CLICKHOUSE_USER in .env}
@@ -372,6 +373,10 @@ services:
       - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}
       - GF_SECURITY_DISABLE_INITIAL_ADMIN_CREATION=false
       - GF_USERS_ALLOW_SIGN_UP=false
+      - GF_INSTALL_PLUGINS=grafana-clickhouse-datasource 4.21.2
+      - CLICKHOUSE_DB=${CLICKHOUSE_DB:?set CLICKHOUSE_DB in .env}
+      - CLICKHOUSE_USER=${CLICKHOUSE_USER:?set CLICKHOUSE_USER in .env}
+      - CLICKHOUSE_PASSWORD=${CLICKHOUSE_PASSWORD:?required}
     volumes:
       - ./monitoring/grafana:/var/lib/grafana
       - ./monitoring/grafana-provisioning:/etc/grafana/provisioning:ro

--- a/docs/operations/runbooks/clickhouse-operations.md
+++ b/docs/operations/runbooks/clickhouse-operations.md
@@ -105,18 +105,39 @@ design.
 
 ### What leaves the gateway
 
-Six values are *declared* by the gateway. No source text, transcript,
-translation, audio, audio URL, IP address, session id, raw error, or debug
-payload is among them:
+No source text, transcript, translation, audio, audio URL, IP address, session
+id, raw error, or debug payload is among the declared values. The envelope, on
+every event:
 
 | Field | Carried as |
 | --- | --- |
-| Event type | top-level OTLP `event_name` (`telemetry_probe`) |
+| Event type | top-level OTLP `event_name` |
 | Event id | log attribute `ssf.quality.event_id` |
 | Schema version | log attribute `ssf.quality.schema_version` |
 | Service name | resource attribute `service.name` |
 | Service version | resource attribute `service.version` |
 | Deployment environment | resource attribute `deployment.environment.name` |
+
+And on `refinement_attempt` (mode `enabled` only), eight more — every one a
+number or a closed enum except `model_ref`, which is operator-set configuration
+constrained to a label charset with no whitespace:
+
+| Field | Carried as | Shape |
+| --- | --- | --- |
+| Refiner role | `ssf.quality.refiner_role` | enum: primary, candidate |
+| Model | `ssf.quality.model_ref` | label token, max 64 chars |
+| Outcome | `ssf.quality.refinement_outcome` | enum: success, error, skipped_overload, submission_failed |
+| Latency | `ssf.quality.refinement_latency_ms` | integer |
+| Changed | `ssf.quality.refinement_changed` | enum: true, false |
+| Source language | `ssf.quality.source_lang` | language code, else `und` |
+| Target language | `ssf.quality.target_lang` | language code, else `und` |
+| Error | `ssf.quality.error_code` | enum from the error taxonomy |
+
+`ALLOWED_ATTRIBUTES` in `services/api_gateway/quality_telemetry.py` is the
+single manifest. It declares a *value shape* per key, not just a key, and there
+is deliberately no free-text kind to declare — so an `error_code` carrying a
+raw upstream message is rejected as firmly as an unknown key would be. Widening
+it means opening six places that must agree; the tests fail until they do.
 
 OTLP also carries protocol fields the gateway does not choose: the record
 `Timestamp` (set from the event's own emission time), `ScopeName`
@@ -154,9 +175,20 @@ none of it is stored.
 
 ### Kill switch
 
-`SSF_QUALITY_TELEMETRY_MODE` accepts exactly `disabled` (the default) or
-`probe`. When disabled, no SDK provider is built, no event is constructed, and
-no export is attempted.
+`SSF_QUALITY_TELEMETRY_MODE` accepts exactly `disabled` (the default), `probe`
+or `enabled`. When disabled, no SDK provider is built, no event is constructed,
+and no export is attempted.
+
+| Mode | SDK provider | Admin probe | Pipeline events |
+| --- | --- | --- | --- |
+| `disabled` | not built | reports `disabled` | none |
+| `probe` | built | emits | **none** |
+| `enabled` | built | emits | `refinement_attempt` |
+
+`probe` deliberately emits no pipeline events. It is a pure transport check, so
+an operator can prove the path end to end without switching on production event
+volume — and so a deployment already running `probe` does not silently start
+emitting real events merely by being upgraded.
 
 Any other value logs a warning and falls back to `disabled`. It never stops the
 gateway from serving translations — telemetry is optional, the gateway is not.
@@ -304,6 +336,33 @@ row is the proof. If it never arrives, check
 captured from the running containers, so refresh it after the deploy and commit
 the result — it should now list `otel-collector`.
 
+**11. Turn real pipeline events on (optional, and separate).** Steps 1-10 leave
+the gateway on `probe`, which emits no pipeline events. Before switching to
+`enabled`, confirm migration `002` has been applied — it is the one that gives
+`quality_events` its typed columns, and `initdb` does **not** re-run on a volume
+that already has data:
+
+    $PC exec -T clickhouse sh -ec 'clickhouse-client --user "$CLICKHOUSE_USER" --password "$CLICKHOUSE_PASSWORD" --database "$CLICKHOUSE_DB" --query "SELECT name FROM system.tables WHERE database = currentDatabase() ORDER BY name"'
+
+Expect `otel_logs`, `quality_events`, `quality_events_daily`,
+`quality_events_daily_mv`, `quality_events_mv`. If the gold tier is missing,
+re-run `apply.sh` (step 5) — it is idempotent.
+
+**Order matters.** Emitting `refinement_attempt` while `002` is unapplied writes
+rows whose typed columns are all defaults, and those rows cannot be repaired:
+the attributes were dropped at projection time and bronze expires after 7 days.
+The dashboard's `Rows Missing Typed Fields` panel exists to catch exactly this
+and should read zero.
+
+Then:
+
+    SSF_QUALITY_TELEMETRY_MODE=enabled
+    $PC up -d --no-deps --force-recreate api_gateway
+    $PC logs --tail=20 api_gateway | grep "Quality telemetry ready"
+
+Expect `Quality telemetry ready (mode=enabled)`. Events appear only when the
+shadow refiner actually runs, which needs `LLM_REFINEMENT_MODE=shadow_compare`.
+
 #### Rolling back
 
 Set `SSF_QUALITY_TELEMETRY_MODE=disabled`, recreate `api_gateway`, and the
@@ -313,13 +372,61 @@ expires after 7 days and silver after 30, and neither is read by anything else.
 
 ### Retention
 
-Bronze `otel_logs` keeps 7 days, silver `quality_events` keeps 30 days. Both
-TTLs live in `deploy/clickhouse/`. ClickHouse fixes TTL at table-creation time,
-so a TTL added to the DDL later does not reach an existing table — check and
-retrofit:
+Bronze `otel_logs` keeps 7 days, silver `quality_events` keeps 30 days, and gold
+`quality_events_daily` keeps 13 months. All three TTLs live in
+`deploy/clickhouse/`. ClickHouse fixes TTL at table-creation time, so a TTL
+added to the DDL later does not reach an existing table — check and retrofit:
 
     docker compose exec -T clickhouse sh -ec 'clickhouse-client --user "$CLICKHOUSE_USER" --password "$CLICKHOUSE_PASSWORD" --database "$CLICKHOUSE_DB" --query "SHOW CREATE TABLE otel_logs"'
     docker compose exec -T clickhouse sh -ec 'clickhouse-client --user "$CLICKHOUSE_USER" --password "$CLICKHOUSE_PASSWORD" --database "$CLICKHOUSE_DB" --query "ALTER TABLE otel_logs MODIFY TTL toDateTime(Timestamp) + INTERVAL 7 DAY"'
+
+#### Verifying retention is actually running
+
+A TTL in the DDL is a claim; the oldest surviving row is the evidence. The
+`Retention Verification` panel on the SSF Telemetry dashboard shows this, and
+the same query by hand:
+
+    docker compose exec -T clickhouse sh -ec 'clickhouse-client --user "$CLICKHOUSE_USER" --password "$CLICKHOUSE_PASSWORD" --database "$CLICKHOUSE_DB" --query "
+      SELECT '\''quality_events'\'' AS tier, min(emitted_at_utc) AS oldest, dateDiff('\''day'\'', min(emitted_at_utc), now()) AS age_days FROM quality_events FINAL
+      UNION ALL
+      SELECT '\''quality_events_daily'\'', toDateTime(min(event_date)), dateDiff('\''day'\'', toDateTime(min(event_date)), now()) FROM quality_events_daily"'
+
+`age_days` materially above the tier's window means expiry is not running.
+Confirm the TTL is on the table at all before anything else — a tier created
+without one cannot be given one, only recreated:
+
+    docker compose exec -T clickhouse sh -ec 'clickhouse-client --user "$CLICKHOUSE_USER" --password "$CLICKHOUSE_PASSWORD" --database "$CLICKHOUSE_DB" --query "SHOW CREATE TABLE quality_events_daily"' | grep -i ttl
+
+Expect `toIntervalMonth(13)`. TTL removal happens during background merges, so
+a recently-expired partition can survive briefly; `OPTIMIZE TABLE ... FINAL`
+forces it if you need a definitive answer.
+
+### Writer-health alerts
+
+`monitoring/alert_rules.yml` group `ssf-quality-telemetry`. Every rule is a
+**warning** by design: telemetry is optional and a dead collector cannot affect
+translation, sessions or WebSocket delivery, so none of this should page anyone.
+
+The alerts read two sources, because neither alone can see the whole path:
+
+- `ssf_quality_telemetry_events_total` from the gateway — what was *queued*.
+- `otelcol_*` from the collector's own `:8888` endpoint — what *arrived*.
+
+`QualityTelemetryEventsLostBeforeCollector` is the difference between them, and
+it exists because the OTel SDK's `BatchLogRecordProcessor` drops on queue
+overflow and reports that **nowhere** — not in the gateway's counter, not as an
+`export_failed` outcome. The gap is the only measurement of it. Record the
+observed rate before deciding whether a bounded acknowledged writer (task 2.1)
+is real work: if it stays at zero at production volume, the SDK's 2048-event
+queue is adequate and that is a finding, not a gap.
+
+`QualityTelemetryAttributeRejected` is different in kind from the rest. It fires
+without a delay because it means the six places that must agree about a field
+have diverged, which loses data silently — a code defect, not a transient.
+
+The collector's internal metrics are bound to `0.0.0.0:8888` in
+`monitoring/otel-collector-config.yaml`; the default binds localhost, which no
+other container can reach. The port is `expose`d, never published.
 
 ### Verifying the pipeline
 
@@ -359,6 +466,107 @@ port 13133 is the health signal; query it from another container on the network:
 `docker compose logs otel-collector` is the other signal. A mis-configured
 collector fails at startup and `restart: always` will loop it, so a container
 that keeps restarting means the config, not the pipeline.
+
+### Grafana Dashboard
+
+Grafana reaches ClickHouse over the compose network only — `clickhouse:9000`,
+native protocol — never through a host port or Traefik route. The
+`grafana-clickhouse-datasource` plugin is installed at container start via
+`GF_INSTALL_PLUGINS`, so it is not baked into the pinned image and requires
+outbound internet access from the Grafana container the first time it starts
+(or after the plugin volume is cleared).
+
+The plugin version is pinned in both Compose files — `GF_INSTALL_PLUGINS=grafana-clickhouse-datasource 4.21.2`.
+Grafana's entrypoint word-splits the value into `grafana cli plugins install
+<id> <version>`, so the separator is a space, not a colon or an `@`. Pinning
+matters because every production image is pinned by digest; an unpinned plugin
+would let a restart install a version the dashboard was never verified against.
+To upgrade, change the version in both files, clear
+`monitoring/grafana/plugins/grafana-clickhouse-datasource`, recreate the
+container, and confirm the startup log reports the version you asked for.
+
+Open the dashboard at `http://localhost:3000` locally, or
+`https://grafana-ssf.smart-village.solutions` in production, folder **SSF**,
+dashboard **SSF Telemetry**. The datasource is provisioned as **ClickHouse**
+(`uid: clickhouse-ssf`); `Save & test` on it must return `Data source is
+working`.
+
+**What it shows today, and no more:** exactly one event type exists —
+`telemetry_probe`, the manually-triggered event from
+`POST /api/admin/telemetry/probe`. There are no pipeline hooks yet (openspec
+task 2.3 is what adds them), so the dashboard can chart only "probe calls over
+time" — it is proof that the transport works, not a quality dashboard. Every
+panel queries `quality_events FINAL` (required — see "Verifying the pipeline"
+above) filtered with the `$__timeFilter(emitted_at_utc)` macro, so the time
+picker controls what each panel shows.
+
+If a panel is empty, first check the time range: probe events are sparse and
+manually triggered, so the default range can easily miss them. If it is still
+empty, work backwards through "Verifying the pipeline" above rather than
+assuming the dashboard is broken.
+
+#### Enabling the dashboard in production
+
+Merging is not enough. No new `.env` variables are needed — `CLICKHOUSE_DB`,
+`CLICKHOUSE_USER` and `CLICKHOUSE_PASSWORD` are already required by the running
+`clickhouse` and `otel-collector` services, and Grafana's provisioning
+substitutes the same three. But the plugin and the datasource are read only at
+Grafana startup, so the container must be recreated.
+
+The dashboard JSON is the exception: the provider re-reads
+`/var/lib/grafana/dashboards` every 30s (`updateIntervalSeconds: 30`), so
+`ssf-telemetry.json` appears within half a minute of `git pull` on its own.
+
+Using the same `PC` invocation as "Enabling in production" above:
+
+**1. Pull, then recreate Grafana.**
+
+    git pull --ff-only
+    $PC up -d --no-deps --force-recreate grafana
+
+**2. Confirm the pinned plugin installed.** This step needs outbound access to
+grafana.com from the Grafana container — the plugin is not in the pinned image:
+
+    $PC logs grafana | grep -i clickhouse-datasource
+
+Expect `Downloaded and extracted grafana-clickhouse-datasource v4.21.2` on the
+first start, then `Plugin registered`. On later starts the download is skipped
+because the plugin is already on the bind mount.
+
+**If egress is blocked**, install it without the network. `monitoring/grafana`
+is a bind mount from the checkout, so the host filesystem *is* Grafana's plugin
+directory:
+
+    curl -L -o /tmp/ch.zip \
+      https://grafana.com/api/plugins/grafana-clickhouse-datasource/versions/4.21.2/download
+    unzip -q -d monitoring/grafana/plugins /tmp/ch.zip
+    chown -R 472:472 monitoring/grafana/plugins/grafana-clickhouse-datasource
+    $PC up -d --no-deps --force-recreate grafana
+
+The archive unpacks to a single `grafana-clickhouse-datasource/` directory and
+is about 75 MB (it ships binaries for every platform). Use `curl -L` with `GET`
+— that endpoint rejects `HEAD`, so a `curl -I` probe returns 405 and tells you
+nothing.
+
+Grafana runs as uid 472; a plugin directory it cannot read is silently ignored.
+
+**3. Confirm the datasource provisioned.**
+
+    $PC logs grafana | grep "inserting datasource"
+
+Expect `name=ClickHouse uid=clickhouse-ssf`. A `plugin not found` error here
+means step 2 did not actually succeed.
+
+**4. Confirm Grafana can reach ClickHouse** over the compose network:
+
+    $PC exec -T grafana wget -qO- http://clickhouse:8123/ping
+
+Expect `Ok.` This uses 8123 only as a reachability check; the datasource itself
+uses the native protocol on 9000.
+
+**5. Open the dashboard** and confirm a panel returns data. The schema must
+already exist — steps 5 and 6 of "Enabling in production" above. A panel error
+mentioning `UNKNOWN_TABLE` means the migrations were never applied.
 
 ## Incident Response
 

--- a/docs/operations/runbooks/clickhouse-operations.md
+++ b/docs/operations/runbooks/clickhouse-operations.md
@@ -7,11 +7,15 @@ the Docker Compose network at clickhouse:8123. It has no host port, Traefik
 route, or public SQL UI. Do not add ports, Traefik labels, or the insecure
 CLICKHOUSE_SKIP_USER_SETUP setting.
 
-This infrastructure installation creates no analytical tables and sends no SSF
-events to ClickHouse. A later approved change owns telemetry schemas and the
-event writer. ClickHouse must contain only pseudonymised quality metadata, never
-recordings, source text, transcripts, translations, IP addresses, or raw error
-messages.
+ClickHouse now holds the quality telemetry schema: three medallion tiers
+(`otel_logs`, `quality_events`, `quality_events_daily`), owned by
+`deploy/clickhouse/` and described under Quality Telemetry below. They are
+included in the backup procedure. Whether the gateway *sends* events depends on
+`SSF_QUALITY_TELEMETRY_MODE`, which is `disabled` in production until an
+operator completes the enablement steps.
+
+ClickHouse must contain only pseudonymised quality metadata, never recordings,
+source text, transcripts, translations, IP addresses, or raw error messages.
 
 ## Prerequisites
 
@@ -124,7 +128,7 @@ constrained to a label charset with no whitespace:
 
 | Field | Carried as | Shape |
 | --- | --- | --- |
-| Refiner role | `ssf.quality.refiner_role` | enum: primary, candidate |
+| Refiner role | `ssf.quality.refiner_role` | enum: primary (in-path), candidate (shadow) |
 | Model | `ssf.quality.model_ref` | label token, max 64 chars |
 | Outcome | `ssf.quality.refinement_outcome` | enum: success, error, skipped_overload, submission_failed |
 | Latency | `ssf.quality.refinement_latency_ms` | integer |
@@ -360,8 +364,15 @@ Then:
     $PC up -d --no-deps --force-recreate api_gateway
     $PC logs --tail=20 api_gateway | grep "Quality telemetry ready"
 
-Expect `Quality telemetry ready (mode=enabled)`. Events appear only when the
-shadow refiner actually runs, which needs `LLM_REFINEMENT_MODE=shadow_compare`.
+Expect `Quality telemetry ready (mode=enabled)`.
+
+`refinement_attempt` is emitted from the **in-path** refiner, so production's
+default `LLM_REFINEMENT_MODE=primary_only` produces rows with
+`refiner_role=primary`. Rows only stop entirely at
+`LLM_REFINEMENT_MODE=disabled`, where no refinement happens and there is no
+attempt to record. `shadow_compare` additionally produces
+`refiner_role=candidate` rows, which is what makes the `Latency p95 by Model`
+panel show two series instead of one.
 
 #### Rolling back
 

--- a/monitoring/alert_rules.yml
+++ b/monitoring/alert_rules.yml
@@ -290,3 +290,85 @@ groups:
         annotations:
           summary: High number of audio files stored
           description: "{{ $value }} audio files currently stored. This may indicate high traffic or cleanup issues."
+
+  # Quality telemetry is optional and must never page: a dead collector or a
+  # dead ClickHouse cannot affect translation, sessions or WebSocket delivery.
+  # Everything here is a warning by design. Metric names were read from a
+  # running collector's :8888 endpoint, not from documentation.
+  - name: ssf-quality-telemetry
+    rules:
+      - alert: QualityTelemetryExportFailing
+        expr: increase(ssf_quality_telemetry_events_total{outcome="export_failed"}[10m]) > 0
+        for: 5m
+        labels:
+          severity: warning
+          component: quality-telemetry
+        annotations:
+          summary: Quality telemetry emit calls are raising.
+          description: The emitter caught an exception on export. Note this fires only when the emit call itself raises; a collector or ClickHouse outage shows up as an SDK export warning in the gateway log instead. See the ClickHouse operations runbook.
+
+      - alert: QualityTelemetryAttributeRejected
+        expr: increase(ssf_quality_telemetry_events_total{outcome="dropped_disallowed"}[10m]) > 0
+        labels:
+          severity: warning
+          component: quality-telemetry
+        annotations:
+          summary: A quality telemetry attribute was rejected by the allowlist.
+          description: An event carried a key or value the manifest does not permit, so it was dropped before the wire. This is a code defect - the six places that must agree about a field have diverged - and it loses data silently. No delay before firing.
+
+      - alert: QualityTelemetryEventsLostBeforeCollector
+        expr: |
+          (
+            sum(increase(ssf_quality_telemetry_events_total{outcome="emitted"}[30m]))
+            - sum(increase(otelcol_receiver_accepted_log_records{receiver="otlp"}[30m]))
+          )
+          / clamp_min(sum(increase(ssf_quality_telemetry_events_total{outcome="emitted"}[30m])), 1)
+          > 0.01
+        for: 15m
+        labels:
+          severity: warning
+          component: quality-telemetry
+        annotations:
+          summary: More than 1% of queued quality events never reached the collector.
+          description: The gateway counted these as emitted, meaning accepted into the OTel SDK's in-process queue, but the collector never received them. That gap is the SDK's BatchLogRecordProcessor dropping on overflow, which it does not report anywhere else. This is the measurement that decides whether a bounded acknowledged writer is real work or theoretical - record the observed rate before acting on it.
+
+      - alert: QualityTelemetryClickHouseWritesFailing
+        expr: increase(otelcol_exporter_send_failed_log_records{exporter="clickhouse"}[10m]) > 0
+        for: 5m
+        labels:
+          severity: warning
+          component: quality-telemetry
+        annotations:
+          summary: The collector cannot write quality events to ClickHouse.
+          description: Exports are failing. The exporter retries with backoff for 300s and then drops the batch. Check that the migrations have been applied - an unapplied schema surfaces as UNKNOWN_TABLE - and that ClickHouse is reachable on the compose network.
+
+      - alert: QualityTelemetryExporterQueueFilling
+        expr: otelcol_exporter_queue_size{exporter="clickhouse"} / clamp_min(otelcol_exporter_queue_capacity{exporter="clickhouse"}, 1) > 0.8
+        for: 10m
+        labels:
+          severity: warning
+          component: quality-telemetry
+        annotations:
+          summary: The collector's ClickHouse send queue is over 80% full.
+          description: Events are arriving faster than they can be written. Once the queue is full the collector drops them. Check ClickHouse write latency and part counts before raising the queue size.
+
+      - alert: QualityTelemetryCollectorRefusingRecords
+        expr: increase(otelcol_receiver_refused_log_records[10m]) > 0
+        for: 5m
+        labels:
+          severity: warning
+          component: quality-telemetry
+        annotations:
+          summary: The collector is refusing quality telemetry records.
+          description: The memory_limiter is pushing back, so the receiver is rejecting records at the door. The collector is capped at 256 MiB; check for a volume increase or a stalled exporter holding batches in memory.
+
+      - alert: QualityTelemetryCollectorDown
+        expr: up{job="otel_collector"} == 0
+        for: 5m
+        labels:
+          severity: warning
+          component: quality-telemetry
+        annotations:
+          summary: The quality telemetry collector is unreachable.
+          description: Prometheus cannot scrape otel-collector:8888. Quality events are being queued in the gateway and dropped once its queue fills. Translation, sessions and WebSocket delivery are unaffected by design.
+

--- a/monitoring/grafana-dashboards/ssf-telemetry.json
+++ b/monitoring/grafana-dashboards/ssf-telemetry.json
@@ -196,7 +196,7 @@
           },
           "editorType": "sql",
           "format": 0,
-          "rawSql": "SELECT countIf(error_code != 'none') AS failures FROM quality_events FINAL WHERE event_type = 'refinement_attempt' AND $__timeFilter(emitted_at_utc)",
+          "rawSql": "SELECT countIf(error_code NOT IN ('none', '')) AS failures FROM quality_events FINAL WHERE event_type = 'refinement_attempt' AND $__timeFilter(emitted_at_utc)",
           "refId": "A"
         }
       ],
@@ -399,7 +399,7 @@
           },
           "editorType": "sql",
           "format": 1,
-          "rawSql": "SELECT error_code, count() AS attempts FROM quality_events FINAL WHERE event_type = 'refinement_attempt' AND $__timeFilter(emitted_at_utc) AND error_code != 'none' GROUP BY error_code ORDER BY attempts DESC",
+          "rawSql": "SELECT error_code, count() AS attempts FROM quality_events FINAL WHERE event_type = 'refinement_attempt' AND $__timeFilter(emitted_at_utc) AND error_code NOT IN ('none', '') GROUP BY error_code ORDER BY attempts DESC",
           "refId": "A"
         }
       ],
@@ -575,7 +575,7 @@
           },
           "editorType": "sql",
           "format": 0,
-          "rawSql": "SELECT event_date AS time, model_ref, uniqExactMerge(events) AS attempts FROM quality_events_daily WHERE event_type = 'refinement_attempt' AND model_ref != '' GROUP BY event_date, model_ref ORDER BY event_date",
+          "rawSql": "SELECT event_date AS time, model_ref, uniqExactMerge(events) AS attempts FROM quality_events_daily WHERE event_type = 'refinement_attempt' AND model_ref != '' AND $__dateFilter(event_date) GROUP BY event_date, model_ref ORDER BY event_date",
           "refId": "A"
         }
       ],

--- a/monitoring/grafana-dashboards/ssf-telemetry.json
+++ b/monitoring/grafana-dashboards/ssf-telemetry.json
@@ -1,0 +1,679 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Quality telemetry: refinement attempts from ClickHouse, writer health from Prometheus. Empty panels in production are expected until SSF_QUALITY_TELEMETRY_MODE is set to `enabled`.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "clickhouse-ssf"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "clickhouse-ssf"
+          },
+          "editorType": "sql",
+          "format": 0,
+          "rawSql": "SELECT count() AS attempts FROM quality_events FINAL WHERE event_type = 'refinement_attempt' AND $__timeFilter(emitted_at_utc)",
+          "refId": "A"
+        }
+      ],
+      "title": "Refinement Attempts",
+      "type": "stat",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNonNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "description": "Shadow candidate runs recorded in the selected range. Empty means the gateway is not in `enabled` mode, or the collector is not delivering."
+    },
+    {
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "clickhouse-ssf"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 0
+      },
+      "id": 2,
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "clickhouse-ssf"
+          },
+          "editorType": "sql",
+          "format": 0,
+          "rawSql": "SELECT quantile(0.95)(refinement_latency_ms) AS p95_ms FROM quality_events FINAL WHERE event_type = 'refinement_attempt' AND $__timeFilter(emitted_at_utc)",
+          "refId": "A"
+        }
+      ],
+      "title": "Candidate Latency p95",
+      "type": "stat",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNonNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "description": "The number the refinement benchmarking work needs and has never had: candidate latency was measured and thrown away into a log line."
+    },
+    {
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "clickhouse-ssf"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      },
+      "id": 3,
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "clickhouse-ssf"
+          },
+          "editorType": "sql",
+          "format": 0,
+          "rawSql": "SELECT round(100 * countIf(refinement_changed = 1) / greatest(count(), 1), 1) AS changed_pct FROM quality_events FINAL WHERE event_type = 'refinement_attempt' AND $__timeFilter(emitted_at_utc)",
+          "refId": "A"
+        }
+      ],
+      "title": "Text Changed",
+      "type": "stat",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNonNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "description": "Share of attempts where the candidate model actually altered the translation. A rate near zero means the model is earning nothing."
+    },
+    {
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "clickhouse-ssf"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
+      "id": 4,
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "clickhouse-ssf"
+          },
+          "editorType": "sql",
+          "format": 0,
+          "rawSql": "SELECT countIf(error_code != 'none') AS failures FROM quality_events FINAL WHERE event_type = 'refinement_attempt' AND $__timeFilter(emitted_at_utc)",
+          "refId": "A"
+        }
+      ],
+      "title": "Failed Attempts",
+      "type": "stat",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNonNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "description": "Attempts that ended in a classified failure. The classification is a closed enum; the original message never leaves the gateway."
+    },
+    {
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "clickhouse-ssf"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 4
+      },
+      "id": 5,
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "clickhouse-ssf"
+          },
+          "editorType": "sql",
+          "format": 0,
+          "rawSql": "SELECT toStartOfInterval(emitted_at_utc, INTERVAL 5 MINUTE) AS time, quantile(0.5)(refinement_latency_ms) AS p50, quantile(0.95)(refinement_latency_ms) AS p95, quantile(0.99)(refinement_latency_ms) AS p99 FROM quality_events FINAL WHERE event_type = 'refinement_attempt' AND $__timeFilter(emitted_at_utc) GROUP BY time ORDER BY time",
+          "refId": "A"
+        }
+      ],
+      "title": "Candidate Latency Percentiles",
+      "type": "timeseries",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
+    },
+    {
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "clickhouse-ssf"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 4
+      },
+      "id": 6,
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "clickhouse-ssf"
+          },
+          "editorType": "sql",
+          "format": 0,
+          "rawSql": "SELECT toStartOfInterval(emitted_at_utc, INTERVAL 5 MINUTE) AS time, model_ref, quantile(0.95)(refinement_latency_ms) AS p95_ms FROM quality_events FINAL WHERE event_type = 'refinement_attempt' AND $__timeFilter(emitted_at_utc) AND model_ref != '' GROUP BY time, model_ref ORDER BY time",
+          "refId": "A"
+        }
+      ],
+      "title": "Latency p95 by Model",
+      "type": "timeseries",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "description": "Model comparison. This is the question `add-phi-refinement-benchmarking` asks; a shadow deployment of a second model populates both series."
+    },
+    {
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "clickhouse-ssf"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 12
+      },
+      "id": 7,
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "clickhouse-ssf"
+          },
+          "editorType": "sql",
+          "format": 0,
+          "rawSql": "SELECT toStartOfInterval(emitted_at_utc, INTERVAL 5 MINUTE) AS time, refinement_outcome, count() AS attempts FROM quality_events FINAL WHERE event_type = 'refinement_attempt' AND $__timeFilter(emitted_at_utc) AND refinement_outcome != '' GROUP BY time, refinement_outcome ORDER BY time",
+          "refId": "A"
+        }
+      ],
+      "title": "Outcome Mix",
+      "type": "timeseries",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "none",
+          "custom": {
+            "drawStyle": "bars",
+            "fillOpacity": 60,
+            "stacking": {
+              "mode": "normal"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
+    },
+    {
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "clickhouse-ssf"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 12
+      },
+      "id": 8,
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "clickhouse-ssf"
+          },
+          "editorType": "sql",
+          "format": 1,
+          "rawSql": "SELECT error_code, count() AS attempts FROM quality_events FINAL WHERE event_type = 'refinement_attempt' AND $__timeFilter(emitted_at_utc) AND error_code != 'none' GROUP BY error_code ORDER BY attempts DESC",
+          "refId": "A"
+        }
+      ],
+      "title": "Failures by Error Code",
+      "type": "table",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "options": {
+        "showHeader": true
+      },
+      "description": "The stable error taxonomy. New values here mean the classifier gained a case, not that an upstream changed its wording."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus-ssf"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 20
+      },
+      "id": 9,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus-ssf"
+          },
+          "expr": "sum by (outcome) (increase(ssf_quality_telemetry_events_total[5m]))",
+          "legendFormat": "{{outcome}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Writer Health by Outcome",
+      "type": "timeseries",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "description": "`dropped_disallowed` here is a code defect: the six places that must agree about a field have diverged and data is being lost silently."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus-ssf"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 20
+      },
+      "id": 10,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus-ssf"
+          },
+          "expr": "sum(increase(ssf_quality_telemetry_events_total{outcome=\"emitted\"}[30m])) - sum(increase(otelcol_receiver_accepted_log_records{receiver=\"otlp\"}[30m]))",
+          "legendFormat": "sdk queue drops",
+          "refId": "A"
+        }
+      ],
+      "title": "Events Lost Before The Collector",
+      "type": "timeseries",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "description": "The gateway counted these as queued into the SDK; the collector never received them. The OTel SDK's BatchLogRecordProcessor reports its overflow drops nowhere else, so this gap is the only measurement of them - and the evidence that decides whether task 2.1 is real work."
+    },
+    {
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "clickhouse-ssf"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 28
+      },
+      "id": 11,
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "clickhouse-ssf"
+          },
+          "editorType": "sql",
+          "format": 1,
+          "rawSql": "SELECT 'quality_events (30 day TTL)' AS tier, toString(min(emitted_at_utc)) AS oldest_row, dateDiff('day', min(emitted_at_utc), now()) AS age_days FROM quality_events FINAL UNION ALL SELECT 'quality_events_daily (13 month TTL)' AS tier, toString(min(event_date)) AS oldest_row, dateDiff('day', toDateTime(min(event_date)), now()) AS age_days FROM quality_events_daily",
+          "refId": "A"
+        }
+      ],
+      "title": "Retention Verification",
+      "type": "table",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "options": {
+        "showHeader": true
+      },
+      "description": "age_days above the tier's TTL means expiry is not running. ClickHouse fixes TTL at table creation, so a tier created without one can never be given one - check SHOW CREATE TABLE, not this panel alone."
+    },
+    {
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "clickhouse-ssf"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 12,
+        "y": 28
+      },
+      "id": 12,
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "clickhouse-ssf"
+          },
+          "editorType": "sql",
+          "format": 0,
+          "rawSql": "SELECT event_date AS time, model_ref, uniqExactMerge(events) AS attempts FROM quality_events_daily WHERE event_type = 'refinement_attempt' AND model_ref != '' GROUP BY event_date, model_ref ORDER BY event_date",
+          "refId": "A"
+        }
+      ],
+      "title": "Daily Attempts (Gold Tier)",
+      "type": "timeseries",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "description": "Read from the 13-month aggregate tier, not the 30-day raw tier. Counts are uniqExact over event_id so a retried delivery is not double-counted."
+    },
+    {
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "clickhouse-ssf"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 18,
+        "y": 28
+      },
+      "id": 13,
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "clickhouse-ssf"
+          },
+          "editorType": "sql",
+          "format": 0,
+          "rawSql": "SELECT countIf(model_ref = '') AS untyped FROM quality_events FINAL WHERE event_type = 'refinement_attempt' AND $__timeFilter(emitted_at_utc)",
+          "refId": "A"
+        }
+      ],
+      "title": "Rows Missing Typed Fields",
+      "type": "stat",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNonNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "description": "Should be zero. Anything else means refinement events were written while migration 002 was not yet applied, so the view projected only the envelope. Apply the migrations before switching the mode to `enabled`."
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": [
+    "ssf",
+    "telemetry",
+    "clickhouse"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "utc",
+  "title": "SSF Telemetry",
+  "uid": "ssf-telemetry",
+  "version": 2,
+  "weekStart": ""
+}

--- a/monitoring/grafana-provisioning/datasources/datasources.yml
+++ b/monitoring/grafana-provisioning/datasources/datasources.yml
@@ -5,6 +5,8 @@ deleteDatasources:
     orgId: 1
   - name: Loki
     orgId: 1
+  - name: ClickHouse
+    orgId: 1
 
 datasources:
   - name: Prometheus
@@ -24,3 +26,17 @@ datasources:
     access: proxy
     url: http://loki:3100
     editable: false
+
+  - name: ClickHouse
+    uid: clickhouse-ssf
+    type: grafana-clickhouse-datasource
+    access: proxy
+    editable: false
+    jsonData:
+      host: clickhouse
+      port: 9000
+      protocol: native
+      defaultDatabase: $CLICKHOUSE_DB
+      username: $CLICKHOUSE_USER
+    secureJsonData:
+      password: $CLICKHOUSE_PASSWORD

--- a/monitoring/otel-collector-config.yaml
+++ b/monitoring/otel-collector-config.yaml
@@ -33,7 +33,7 @@ processors:
       - context: log
         statements:
           - set(log.body, "")
-          - keep_keys(log.attributes, ["ssf.quality.event_id", "ssf.quality.schema_version"])
+          - keep_keys(log.attributes, ["ssf.quality.event_id", "ssf.quality.schema_version", "ssf.quality.error_code", "ssf.quality.model_ref", "ssf.quality.refinement_changed", "ssf.quality.refinement_latency_ms", "ssf.quality.refinement_outcome", "ssf.quality.refiner_role", "ssf.quality.source_lang", "ssf.quality.target_lang"])
           - keep_keys(resource.attributes, ["service.name", "service.version", "deployment.environment.name"])
   batch:
     timeout: 5s
@@ -66,6 +66,17 @@ service:
   telemetry:
     metrics:
       level: basic
+      # Bound to 0.0.0.0 so Prometheus can scrape it from another container; the
+      # default binds localhost, which is unreachable across the compose network.
+      # These counters are the only place the gateway SDK's queue-overflow drops
+      # become visible: the gateway counts what it queued, this counts what
+      # actually arrived, and the gap between them is the loss.
+      readers:
+        - pull:
+            exporter:
+              prometheus:
+                host: 0.0.0.0
+                port: 8888
   pipelines:
     logs:
       receivers: [otlp]

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -16,6 +16,13 @@ scrape_configs:
     static_configs:
       - targets: ['api_gateway:8000']
 
+  # The collector's own counters. These are the only place the gateway SDK's
+  # queue-overflow drops become measurable: the gateway counts what it queued,
+  # this counts what actually arrived.
+  - job_name: 'otel_collector'
+    static_configs:
+      - targets: ['otel-collector:8888']
+
   - job_name: 'dcgm_exporter'
     static_configs:
       - targets: ['dcgm_exporter:9400']

--- a/openspec/changes/add-clickhouse-quality-telemetry/tasks.md
+++ b/openspec/changes/add-clickhouse-quality-telemetry/tasks.md
@@ -1,28 +1,34 @@
 ## 1. Schema and Contract
 
-- [ ] 1.1 Define versioned, typed allowlisted event models and stable error taxonomy.
+- [x] 1.1 Define versioned, typed allowlisted event models and stable error taxonomy.
 - [ ] 1.2 Create ClickHouse schema migrations for raw session and translation quality records.
-- [ ] 1.3 Add monthly partitioning, event_id deduplication, 30-day raw-data TTL, and 13-month daily aggregate TTL.
+      Partially delivered: `002_quality_events_fields_and_gold.sql` adds the typed
+      silver columns and the gold tier, but the records it types are refinement
+      attempts. Session and translation records land with their emitters.
+- [x] 1.3 Add monthly partitioning, event_id deduplication, 30-day raw-data TTL, and 13-month daily aggregate TTL.
 
 ## 2. Writer and Gateway Integration
 
 - [ ] 2.1 Implement a bounded asynchronous writer with batched, acknowledged inserts and operational metrics.
 - [ ] 2.2 Implement retry and idempotency behavior keyed by event_id.
 - [ ] 2.3 Emit allowed lifecycle, pipeline, delivery, and terminal-outcome metadata from API Gateway hooks.
+      Partially delivered: `refinement_attempt` is emitted from
+      `ShadowComparisonRefiner._run_candidate`. Lifecycle, delivery and
+      terminal-outcome metadata remain.
 - [ ] 2.4 Ensure unavailable ClickHouse never changes message, session, or WebSocket outcomes.
 
 ## 3. Privacy and Operations
 
-- [ ] 3.1 Redact content-bearing pipeline metadata through an explicit allowlist.
+- [x] 3.1 Redact content-bearing pipeline metadata through an explicit allowlist.
 - [ ] 3.2 Persist only opaque content references and consent snapshots; do not implement content storage here.
-- [ ] 3.3 Add dashboards, writer-health alerts, retention verification, and operational runbook updates.
+- [x] 3.3 Add dashboards, writer-health alerts, retention verification, and operational runbook updates.
 
 ## 4. Verification
 
-- [ ] 4.1 Add unit tests for allowlisting, redaction, and stable error classification.
+- [x] 4.1 Add unit tests for allowlisting, redaction, and stable error classification.
 - [ ] 4.2 Add tests for duplicate event delivery and retry idempotency.
 - [ ] 4.3 Add tests proving a ClickHouse outage does not affect successful or failed message processing.
-- [ ] 4.4 Add integration tests for schema, TTL configuration, and aggregate correctness.
+- [x] 4.4 Add integration tests for schema, TTL configuration, and aggregate correctness.
 
 ## 5. Probe (issue #199)
 
@@ -41,24 +47,35 @@ keep meaning what they say: none of them is satisfied by one probe event.
 - [x] 5.9 Observed insertion, querying, failure and operational behaviour written up in
       `docs/operations/clickhouse-telemetry-probe-findings.md`.
 
-### Explicitly not delivered by #199
+### Explicitly not delivered
 
-- No error taxonomy exists (1.1). The probe has no failure classification.
-- No session or translation quality records (1.2). One probe table only.
-- No gold tier and no 13-month aggregate TTL (1.3) — deferred by design.
+Updated as each bullet stops being true. What remains open:
+
+- No session or translation quality records (1.2). The typed-column mechanism
+  and the gold tier exist; the session and translation events do not.
 - No bounded acknowledged writer (2.1). Delivery is lossy by design: the OTel
   SDK's `BatchLogRecordProcessor` drops on overflow without surfacing it in
-  `ssf_quality_telemetry_events_total`.
-- No pipeline hooks (2.3). Telemetry is reachable only from the admin probe
-  endpoint, so 2.4 is untested against real message or WebSocket paths.
-- No consent snapshots or content references (3.2).
-- No dashboards or writer-health alerts (3.3). Runbook and findings write-up only.
-- Production is `disabled` explicitly in
+  `ssf_quality_telemetry_events_total`. This is now **measurable** rather than
+  invisible — `QualityTelemetryEventsLostBeforeCollector` compares what the
+  gateway queued against what the collector received, and the gap is the drop.
+  Decide 2.1 from that evidence at production volume, not on principle.
+- No writer-level retry idempotency (2.2). Deduplication is at the storage
+  layer: silver collapses duplicate `event_id`s and every gold counter is
+  `uniqExact` over `event_id`, so a retried delivery cannot inflate a count.
+  The latency aggregates have no distinct-by form and do skew; documented in
+  the migration.
+- Only one pipeline hook (2.3). `refinement_attempt` is emitted; session
+  lifecycle, delivery and terminal-outcome metadata are not.
+- 2.4 is proven at the refinement hook and at the emitter, not yet against the
+  live message or WebSocket paths — those have no emitter to fail.
+- No consent snapshots or content references (3.2). Nothing emitted so far
+  refers to content at all, so there is no reference to persist yet.
+- Production remains `disabled` in
   `deploy/production/docker-compose.production.yml`, so merging changes nothing
-  there. The `otel-collector` service is defined and digest-pinned, but starting
-  it, pre-pulling the image and applying the schema are host-side steps that
-  cannot be committed — the ordered procedure is in the runbook under Quality
-  Telemetry -> Enabling in production.
+  there. `probe` emits no pipeline events either; `enabled` is the new value
+  that does, and migration `002` must be applied before it is set. The ordered
+  procedure is in the runbook under Quality Telemetry -> Enabling in production,
+  step 11.
 - The OTLP instrumentation-scope namespace is not allowlisted in the collector.
-  No SSF code path can write content into it; a security review judged the residual
-  exposure non-actionable. Tracked in the findings write-up.
+  No SSF code path can write content into it; a security review judged the
+  residual exposure non-actionable. Tracked in the findings write-up.

--- a/services/api_gateway/app.py
+++ b/services/api_gateway/app.py
@@ -249,8 +249,9 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     telemetry_mode = TelemetryMode.parse(os.environ.get("SSF_QUALITY_TELEMETRY_MODE"))
     # Built only when it will be used: the SDK provider runs a worker thread.
     telemetry_exporter = None
-    if telemetry_mode is not TelemetryMode.DISABLED:
-        try:
+    quality_telemetry = None
+    try:
+        if telemetry_mode is not TelemetryMode.DISABLED:
             telemetry_exporter = build_otlp_exporter(
                 endpoint=os.environ.get(
                     "SSF_OTLP_LOGS_ENDPOINT", "http://otel-collector:4318/v1/logs"
@@ -259,23 +260,34 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
                 service_version=os.environ.get("SSF_RELEASE_VERSION", "unknown"),
                 deployment_environment=os.environ.get("SSF_DEPLOYMENT_ENV", "unknown"),
             )
-        except Exception as e:
-            # OTLPLogExporter parses OTEL_EXPORTER_OTLP_TIMEOUT and
-            # _COMPRESSION itself and raises on a malformed value. Same rule as
-            # TelemetryMode.parse: fall back to disabled rather than crashloop
-            # the gateway over an optional setting. Reported as disabled, not
-            # as a silent probe mode that exports nothing.
-            sys.stderr.write(
-                f"Quality telemetry disabled: exporter setup failed ({e})\n"
-            )
-            sys.stderr.flush()
-            telemetry_mode = TelemetryMode.DISABLED
+        quality_telemetry = QualityTelemetry(
+            mode=telemetry_mode,
+            exporter=telemetry_exporter or discard_event,
+            registry=app.state.prometheus_registry,
+        )
+    except Exception as e:
+        # OTLPLogExporter parses OTEL_EXPORTER_OTLP_TIMEOUT and _COMPRESSION
+        # itself and raises on a malformed value, and QualityTelemetry has to
+        # register a Prometheus counter. Same rule as TelemetryMode.parse: fall
+        # back to disabled rather than crashloop the gateway over an optional
+        # setting. Reported as disabled, not as a silent probe mode that
+        # exports nothing.
+        sys.stderr.write(f"Quality telemetry disabled: setup failed ({e})\n")
+        sys.stderr.flush()
+        telemetry_mode = TelemetryMode.DISABLED
+        telemetry_exporter = None
+
+    if quality_telemetry is None:
+        # Last resort: an unregistered registry cannot collide with anything,
+        # so this construction has nothing left to fail on.
+        quality_telemetry = QualityTelemetry(
+            mode=TelemetryMode.DISABLED,
+            exporter=discard_event,
+            registry=CollectorRegistry(),
+        )
+
     app.state.quality_telemetry_exporter = telemetry_exporter
-    app.state.quality_telemetry = QualityTelemetry(
-        mode=telemetry_mode,
-        exporter=telemetry_exporter or discard_event,
-        registry=app.state.prometheus_registry,
-    )
+    app.state.quality_telemetry = quality_telemetry
     # The refiner is a module-level singleton built at import time; telemetry is
     # built here, per lifespan. Nothing connects them unless this line does.
     from .translation_refiner import translation_refiner

--- a/services/api_gateway/app.py
+++ b/services/api_gateway/app.py
@@ -276,6 +276,11 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         exporter=telemetry_exporter or discard_event,
         registry=app.state.prometheus_registry,
     )
+    # The refiner is a module-level singleton built at import time; telemetry is
+    # built here, per lifespan. Nothing connects them unless this line does.
+    from .translation_refiner import translation_refiner
+
+    translation_refiner.attach_quality_telemetry(app.state.quality_telemetry)
     sys.stderr.write(f"Quality telemetry ready (mode={telemetry_mode.value})\n")
     sys.stderr.flush()
 
@@ -323,6 +328,9 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 
         app.state.pipeline_admission = None
 
+        # Released before the provider is shut down: a refiner still holding
+        # this would emit into a provider that no longer has an export thread.
+        translation_refiner.attach_quality_telemetry(None)
         telemetry_exporter_at_exit = app.state.quality_telemetry_exporter
         app.state.quality_telemetry_exporter = None
         if telemetry_exporter_at_exit is not None:

--- a/services/api_gateway/pipeline_logic.py
+++ b/services/api_gateway/pipeline_logic.py
@@ -14,6 +14,7 @@ import numpy as np
 import psutil
 import requests
 
+from .quality_telemetry import classify_exception
 from .translation_refiner import RefinementOutcome, translation_refiner
 
 # Import service URLs from app.py (respects DOCKER_COMPOSE env var)
@@ -387,6 +388,7 @@ def _pipeline_error_result(
     audio_bytes: Optional[bytes],
     validation_result: Optional[Any] = None,
     upstream_response: Optional[Any] = None,
+    error_code: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Flattens an upstream failure into the pipeline's result shape.
 
@@ -397,6 +399,8 @@ def _pipeline_error_result(
     of which a client reads as permanent.
     """
     _mark_pipeline_failure(debug_info, start_total, error_message)
+    if error_code is not None:
+        debug_info["error_code"] = error_code
     result = {
         "error": True,
         "error_msg": error_message,
@@ -1220,6 +1224,8 @@ def process_text_pipeline(
         "pipeline_started_at": pipeline_start_time.isoformat() + "Z",
     }
     start_total = time.perf_counter()
+    processed_text: Optional[str] = None
+    translation_text: Optional[str] = None
 
     try:
         # Step 1: Text validation (if enabled)
@@ -1343,13 +1349,20 @@ def process_text_pipeline(
         }
 
     except Exception as e:
+        # routes/pipeline.py serialises error_msg and debug straight to the
+        # browser, and a requests exception carries the internal service
+        # hostname and port. The detail goes to the server log; the client gets
+        # the stable taxonomy code.
+        code = classify_exception(e)
+        logging.warning("Pipeline failed (%s)", code.value, exc_info=True)
         return _pipeline_error_result(
             debug_info=debug_info,
             start_total=start_total,
-            error_message=f"Pipeline-Fehler: {str(e)}",
-            asr_text=None,
-            translation_text=None,
+            error_message=f"Pipeline-Fehler: {code.value}",
+            asr_text=processed_text,
+            translation_text=translation_text,
             audio_bytes=None,
+            error_code=code.value,
         )
 
 
@@ -1379,6 +1392,8 @@ def process_wav(file_bytes, source_lang, target_lang, debug=False, validate_audi
         "pipeline_started_at": pipeline_start_time.isoformat() + "Z",
     }
     start_total = time.perf_counter()
+    asr_text: Optional[str] = None
+    translation_text: Optional[str] = None
 
     try:
         # Audio Validation Step (if enabled)
@@ -1597,11 +1612,18 @@ def process_wav(file_bytes, source_lang, target_lang, debug=False, validate_audi
         }
 
     except Exception as e:
+        # routes/pipeline.py serialises error_msg and debug straight to the
+        # browser, and a requests exception carries the internal service
+        # hostname and port. The detail goes to the server log; the client gets
+        # the stable taxonomy code.
+        code = classify_exception(e)
+        logging.warning("Pipeline failed (%s)", code.value, exc_info=True)
         return _pipeline_error_result(
             debug_info=debug_info,
             start_total=start_total,
-            error_message=f"Pipeline-Fehler: {str(e)}",
-            asr_text=None,
-            translation_text=None,
+            error_message=f"Pipeline-Fehler: {code.value}",
+            asr_text=asr_text,
+            translation_text=translation_text,
             audio_bytes=None,
+            error_code=code.value,
         )

--- a/services/api_gateway/pipeline_logic.py
+++ b/services/api_gateway/pipeline_logic.py
@@ -337,12 +337,35 @@ def _collect_system_metrics() -> Dict[str, float]:
     }
 
 
+def _record_pipeline_duration(debug_info: Dict[str, Any], start_total: float) -> None:
+    """Record how long the pipeline ran, from a single clock sample.
+
+    Both duration fields used to be read from two separate ``perf_counter()``
+    calls, so they disagreed; and the failure path recorded only the seconds
+    field, leaving failure rows with no millisecond duration and no completion
+    timestamp to compare against a success row.
+    """
+    elapsed_seconds = time.perf_counter() - start_total
+    debug_info["pipeline_completed_at"] = utc_now().isoformat() + "Z"
+    debug_info["total_duration_ms"] = int(elapsed_seconds * 1000)
+    debug_info["total_duration"] = round(elapsed_seconds, 3)
+
+
+def _upstream_error_message(response: Any) -> str:
+    """Best-effort reason from a failed upstream reply, never raising."""
+    try:
+        payload = response.json()
+        return payload.get("detail") or payload.get("error") or str(payload)
+    except Exception:
+        return str(getattr(response, "text", ""))
+
+
 def _mark_pipeline_failure(
     debug_info: Dict[str, Any], start_total: float, error_message: str
 ) -> None:
     debug_info["error"] = error_message
+    _record_pipeline_duration(debug_info, start_total)
     debug_info["system"] = _collect_system_metrics()
-    debug_info["total_duration"] = round(time.perf_counter() - start_total, 3)
 
 
 def _upstream_retry_after(response: Any) -> int:
@@ -664,11 +687,8 @@ def _apply_audio_validation(
 
 
 def _finalize_pipeline_success(debug_info: Dict[str, Any], start_total: float) -> None:
-    pipeline_completed_at = utc_now()
-    debug_info["pipeline_completed_at"] = pipeline_completed_at.isoformat() + "Z"
-    debug_info["total_duration_ms"] = int((time.perf_counter() - start_total) * 1000)
+    _record_pipeline_duration(debug_info, start_total)
     debug_info["system"] = _collect_system_metrics()
-    debug_info["total_duration"] = round(time.perf_counter() - start_total, 3)
 
 
 # === Audio Validation Functions ===
@@ -1360,187 +1380,228 @@ def process_wav(file_bytes, source_lang, target_lang, debug=False, validate_audi
     }
     start_total = time.perf_counter()
 
-    # Audio Validation Step (if enabled)
-    if validate_audio:
-        validated_bytes, validation_failure = _apply_audio_validation(
-            file_bytes,
-            debug_info=debug_info,
-            start_total=start_total,
-        )
-        if validation_failure is not None:
-            return validation_failure
-        file_bytes = validated_bytes
+    try:
+        # Audio Validation Step (if enabled)
+        if validate_audio:
+            validated_bytes, validation_failure = _apply_audio_validation(
+                file_bytes,
+                debug_info=debug_info,
+                start_total=start_total,
+            )
+            if validation_failure is not None:
+                return validation_failure
+            file_bytes = validated_bytes
 
-    # ASR
-    start_asr = time.perf_counter()
-    asr_started_at = utc_now()
-    asr_resp = requests.post(
-        ASR_URL,
-        files={"file": ("input.wav", file_bytes, AUDIO_WAV_MIME)},
-        data={"lang": source_lang, "debug": str(debug).lower()},
-        timeout=60,  # ASR kann länger dauern
-    )
-    asr_completed_at = utc_now()
-    asr_json = asr_resp.json()
-    asr_text = asr_json.get("text", "")
-    asr_duration_ms = int((time.perf_counter() - start_asr) * 1000)
-
-    debug_info["steps"].append(
-        {
-            "step": "ASR",
-            "name": "asr",
-            "input": {"lang": source_lang},
-            "output": asr_text,
-            "model": asr_json.get("debug", {}).get("model"),
-            "error": asr_json.get("error"),
-            "duration": round(time.perf_counter() - start_asr, 3),
-            "started_at": asr_started_at.isoformat() + "Z",
-            "completed_at": asr_completed_at.isoformat() + "Z",
-            "duration_ms": asr_duration_ms,
-        }
-    )
-    # Translation
-    start_trans = time.perf_counter()
-    translation_started_at = utc_now()
-    translation_payload = {
-        "text": asr_text,
-        "source_lang": source_lang,
-        "target_lang": target_lang,
-        "model": "m2m100_1.2B",
-        "debug": str(debug).lower(),
-    }
-    translation_resp = requests.post(
-        TRANSLATION_URL, json=translation_payload, timeout=30
-    )
-    translation_completed_at = utc_now()
-    translation_json = translation_resp.json()
-    translation_text = translation_json.get("translations", "")
-    translation_duration_ms = int((time.perf_counter() - start_trans) * 1000)
-
-    debug_info["steps"].append(
-        {
-            "step": "Translation",
-            "name": "translation",
-            "input": translation_payload,
-            "output": translation_text,
-            "error": translation_json.get("error"),
-            "duration": round(time.perf_counter() - start_trans, 3),
-            "started_at": translation_started_at.isoformat() + "Z",
-            "completed_at": translation_completed_at.isoformat() + "Z",
-            "duration_ms": translation_duration_ms,
-        }
-    )
-    # Fehlerbehandlung
-    if translation_resp.status_code != 200:
-        error_msg = translation_json.get("detail") or str(translation_json)
-        return _pipeline_error_result(
-            debug_info=debug_info,
-            start_total=start_total,
-            error_message=f"Translation-Fehler: {error_msg}",
-            asr_text=asr_text,
-            translation_text=None,
-            audio_bytes=None,
-            upstream_response=translation_resp,
+        # ASR
+        start_asr = time.perf_counter()
+        asr_started_at = utc_now()
+        asr_resp = requests.post(
+            ASR_URL,
+            files={"file": ("input.wav", file_bytes, AUDIO_WAV_MIME)},
+            data={"lang": source_lang, "debug": str(debug).lower()},
+            timeout=60,  # ASR kann länger dauern
         )
-    # Optional LLM refinement
-    if translation_refiner.is_active:
-        refinement_started_at = utc_now()
-        outcome = translation_refiner.refine(
-            translation_text,
-            source_lang,
-            target_lang,
-            context={"original_text": asr_text, "pipeline": "audio"},
-        )
-        refinement_completed_at = utc_now()
-        translation_text = outcome.text
-        refinement_duration_ms = outcome.latency_ms or 0
+        asr_completed_at = utc_now()
+        asr_duration_ms = int((time.perf_counter() - start_asr) * 1000)
+
+        # The status was never checked here, so a failed transcription became an
+        # empty string and went on to be "successfully" translated -- the audio
+        # path's failure rows went missing entirely. upstream_response keeps a
+        # 503 transient, exactly as the translation and TTS steps already do.
+        if asr_resp.status_code != 200:
+            error_msg = _upstream_error_message(asr_resp)
+            debug_info["steps"].append(
+                {
+                    "step": "ASR",
+                    "name": "asr",
+                    "input": {"lang": source_lang},
+                    "output": None,
+                    "error": error_msg,
+                    "duration": round(asr_duration_ms / 1000, 3),
+                    "started_at": asr_started_at.isoformat() + "Z",
+                    "completed_at": asr_completed_at.isoformat() + "Z",
+                    "duration_ms": asr_duration_ms,
+                }
+            )
+            return _pipeline_error_result(
+                debug_info=debug_info,
+                start_total=start_total,
+                error_message=f"ASR-Fehler: {error_msg}",
+                asr_text=None,
+                translation_text=None,
+                audio_bytes=None,
+                upstream_response=asr_resp,
+            )
+
+        asr_json = asr_resp.json()
+        asr_text = asr_json.get("text", "")
 
         debug_info["steps"].append(
             {
-                "step": "LLM_Refinement",
-                "name": "refinement",
-                "input": {"enabled": True, "changed": outcome.changed},
-                "output": translation_text,
-                "error": outcome.error,
-                "duration": round((outcome.latency_ms or 0.0) / 1000, 3),
-                "started_at": refinement_started_at.isoformat() + "Z",
-                "completed_at": refinement_completed_at.isoformat() + "Z",
-                "duration_ms": int(refinement_duration_ms),
-                "model": outcome.model,
-                "refinement_comparison": {
-                    "primary_model": outcome.model,
-                    "primary_status": "error" if outcome.error else "success",
-                    "candidate_model": outcome.candidate_model,
-                    "candidate_status": outcome.candidate_status,
-                },
+                "step": "ASR",
+                "name": "asr",
+                "input": {"lang": source_lang},
+                "output": asr_text,
+                "model": asr_json.get("debug", {}).get("model"),
+                "error": asr_json.get("error"),
+                "duration": round(time.perf_counter() - start_asr, 3),
+                "started_at": asr_started_at.isoformat() + "Z",
+                "completed_at": asr_completed_at.isoformat() + "Z",
+                "duration_ms": asr_duration_ms,
             }
         )
-    # TTS
-    start_tts = time.perf_counter()
-    tts_started_at = utc_now()
-    tts_resp = requests.post(
-        TTS_URL,
-        json={
-            "text": translation_text,
-            "lang": target_lang,
+        # Translation
+        start_trans = time.perf_counter()
+        translation_started_at = utc_now()
+        translation_payload = {
+            "text": asr_text,
+            "source_lang": source_lang,
+            "target_lang": target_lang,
+            "model": "m2m100_1.2B",
             "debug": str(debug).lower(),
-        },
-        timeout=45,  # TTS kann auch länger dauern
-    )
-    tts_completed_at = utc_now()
-    tts_duration_ms = int((time.perf_counter() - start_tts) * 1000)
+        }
+        translation_resp = requests.post(
+            TRANSLATION_URL, json=translation_payload, timeout=30
+        )
+        translation_completed_at = utc_now()
+        translation_json = translation_resp.json()
+        translation_text = translation_json.get("translations", "")
+        translation_duration_ms = int((time.perf_counter() - start_trans) * 1000)
 
-    if (
-        tts_resp.status_code != 200
-        or tts_resp.headers.get("content-type", "") != AUDIO_WAV_MIME
-    ):
-        try:
-            tts_json = tts_resp.json()
-            error_msg = tts_json.get("error") or str(tts_json)
-        except Exception:
-            error_msg = tts_resp.text
+        debug_info["steps"].append(
+            {
+                "step": "Translation",
+                "name": "translation",
+                "input": translation_payload,
+                "output": translation_text,
+                "error": translation_json.get("error"),
+                "duration": round(time.perf_counter() - start_trans, 3),
+                "started_at": translation_started_at.isoformat() + "Z",
+                "completed_at": translation_completed_at.isoformat() + "Z",
+                "duration_ms": translation_duration_ms,
+            }
+        )
+        # Fehlerbehandlung
+        if translation_resp.status_code != 200:
+            error_msg = translation_json.get("detail") or str(translation_json)
+            return _pipeline_error_result(
+                debug_info=debug_info,
+                start_total=start_total,
+                error_message=f"Translation-Fehler: {error_msg}",
+                asr_text=asr_text,
+                translation_text=None,
+                audio_bytes=None,
+                upstream_response=translation_resp,
+            )
+        # Optional LLM refinement
+        if translation_refiner.is_active:
+            refinement_started_at = utc_now()
+            outcome = translation_refiner.refine(
+                translation_text,
+                source_lang,
+                target_lang,
+                context={"original_text": asr_text, "pipeline": "audio"},
+            )
+            refinement_completed_at = utc_now()
+            translation_text = outcome.text
+            refinement_duration_ms = outcome.latency_ms or 0
+
+            debug_info["steps"].append(
+                {
+                    "step": "LLM_Refinement",
+                    "name": "refinement",
+                    "input": {"enabled": True, "changed": outcome.changed},
+                    "output": translation_text,
+                    "error": outcome.error,
+                    "duration": round((outcome.latency_ms or 0.0) / 1000, 3),
+                    "started_at": refinement_started_at.isoformat() + "Z",
+                    "completed_at": refinement_completed_at.isoformat() + "Z",
+                    "duration_ms": int(refinement_duration_ms),
+                    "model": outcome.model,
+                    "refinement_comparison": {
+                        "primary_model": outcome.model,
+                        "primary_status": "error" if outcome.error else "success",
+                        "candidate_model": outcome.candidate_model,
+                        "candidate_status": outcome.candidate_status,
+                    },
+                }
+            )
+        # TTS
+        start_tts = time.perf_counter()
+        tts_started_at = utc_now()
+        tts_resp = requests.post(
+            TTS_URL,
+            json={
+                "text": translation_text,
+                "lang": target_lang,
+                "debug": str(debug).lower(),
+            },
+            timeout=45,  # TTS kann auch länger dauern
+        )
+        tts_completed_at = utc_now()
+        tts_duration_ms = int((time.perf_counter() - start_tts) * 1000)
+
+        if (
+            tts_resp.status_code != 200
+            or tts_resp.headers.get("content-type", "") != AUDIO_WAV_MIME
+        ):
+            try:
+                tts_json = tts_resp.json()
+                error_msg = tts_json.get("error") or str(tts_json)
+            except Exception:
+                error_msg = tts_resp.text
+            debug_info["steps"].append(
+                {
+                    "step": "TTS",
+                    "name": "tts",
+                    "input": {"lang": target_lang, "text": translation_text},
+                    "output": None,
+                    "error": error_msg,
+                    "duration": round(time.perf_counter() - start_tts, 3),
+                    "started_at": tts_started_at.isoformat() + "Z",
+                    "completed_at": tts_completed_at.isoformat() + "Z",
+                    "duration_ms": tts_duration_ms,
+                }
+            )
+            return _pipeline_error_result(
+                debug_info=debug_info,
+                start_total=start_total,
+                error_message=f"TTS-Fehler: {error_msg}",
+                asr_text=asr_text,
+                translation_text=translation_text,
+                audio_bytes=None,
+                upstream_response=tts_resp,
+            )
+        audio_bytes = tts_resp.content
         debug_info["steps"].append(
             {
                 "step": "TTS",
                 "name": "tts",
                 "input": {"lang": target_lang, "text": translation_text},
-                "output": None,
-                "error": error_msg,
+                "output": AUDIO_WAV_MIME,
+                "error": None,
                 "duration": round(time.perf_counter() - start_tts, 3),
                 "started_at": tts_started_at.isoformat() + "Z",
                 "completed_at": tts_completed_at.isoformat() + "Z",
                 "duration_ms": tts_duration_ms,
             }
         )
+
+        _finalize_pipeline_success(debug_info, start_total)
+        return {
+            "error": False,
+            "asr_text": asr_text,
+            "translation_text": translation_text,
+            "audio_bytes": audio_bytes,
+            "debug": debug_info,
+        }
+
+    except Exception as e:
         return _pipeline_error_result(
             debug_info=debug_info,
             start_total=start_total,
-            error_message=f"TTS-Fehler: {error_msg}",
-            asr_text=asr_text,
-            translation_text=translation_text,
+            error_message=f"Pipeline-Fehler: {str(e)}",
+            asr_text=None,
+            translation_text=None,
             audio_bytes=None,
-            upstream_response=tts_resp,
         )
-    audio_bytes = tts_resp.content
-    debug_info["steps"].append(
-        {
-            "step": "TTS",
-            "name": "tts",
-            "input": {"lang": target_lang, "text": translation_text},
-            "output": AUDIO_WAV_MIME,
-            "error": None,
-            "duration": round(time.perf_counter() - start_tts, 3),
-            "started_at": tts_started_at.isoformat() + "Z",
-            "completed_at": tts_completed_at.isoformat() + "Z",
-            "duration_ms": tts_duration_ms,
-        }
-    )
-
-    _finalize_pipeline_success(debug_info, start_total)
-    return {
-        "error": False,
-        "asr_text": asr_text,
-        "translation_text": translation_text,
-        "audio_bytes": audio_bytes,
-        "debug": debug_info,
-    }

--- a/services/api_gateway/quality_telemetry.py
+++ b/services/api_gateway/quality_telemetry.py
@@ -10,6 +10,7 @@ openspec/changes/add-clickhouse-quality-telemetry/design.md.
 from __future__ import annotations
 
 import logging
+import re
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -24,20 +25,145 @@ logger = logging.getLogger(__name__)
 
 SCHEMA_VERSION: Final[int] = 1
 
+
+class QualityEventType(str, Enum):
+    """The closed set of event types this pipeline knows how to store."""
+
+    TELEMETRY_PROBE = "telemetry_probe"
+    REFINEMENT_ATTEMPT = "refinement_attempt"
+
+
+class QualityErrorCode(str, Enum):
+    """Stable failure classification (task 1.1).
+
+    A raw upstream message must never reach ClickHouse, so every failure is
+    reduced to one of these tokens before it is emitted. Values are part of the
+    stored contract: rename one and every historical row disagrees with it.
+    """
+
+    NONE = "none"
+    UPSTREAM_BUSY = "upstream_busy"
+    UPSTREAM_TIMEOUT = "upstream_timeout"
+    UPSTREAM_UNREACHABLE = "upstream_unreachable"
+    UPSTREAM_REJECTED = "upstream_rejected"
+    UPSTREAM_ERROR = "upstream_error"
+    UPSTREAM_MALFORMED_RESPONSE = "upstream_malformed_response"
+    AUDIO_VALIDATION_FAILED = "audio_validation_failed"
+    TEXT_VALIDATION_FAILED = "text_validation_failed"
+    CONTENT_REJECTED = "content_rejected"
+    REFINEMENT_OVERLOADED = "refinement_overloaded"
+    INTERNAL_ERROR = "internal_error"
+    UNKNOWN = "unknown"
+
+
+class PipelineStage(str, Enum):
+    """Where in the pipeline a terminal outcome was decided."""
+
+    NONE = "none"
+    VALIDATION = "validation"
+    ASR = "asr"
+    TRANSLATION = "translation"
+    REFINEMENT = "refinement"
+    TTS = "tts"
+    DELIVERY = "delivery"
+
+
+class RefinerRole(str, Enum):
+    PRIMARY = "primary"
+    CANDIDATE = "candidate"
+
+
+class RefinementOutcomeCode(str, Enum):
+    SUCCESS = "success"
+    ERROR = "error"
+    SKIPPED_OVERLOAD = "skipped_overload"
+    SUBMISSION_FAILED = "submission_failed"
+
+
+class AttributeKind(str, Enum):
+    """What shape an allowlisted value may take.
+
+    There is deliberately no free-text kind. Task 3.1 and 3.2 require every
+    field to be a number, a closed enum, or an opaque reference, and the only
+    way to enforce that is to make "arbitrary string" unrepresentable here.
+    """
+
+    UUID = "uuid"
+    NUMBER = "number"
+    ENUM = "enum"
+    LABEL = "label"
+    LANGUAGE = "language"
+    OPAQUE_REF = "opaque_ref"
+
+
+# A label is operator-set configuration (a model name, a release token), not
+# user content: no whitespace, no punctuation that would let a sentence through.
+_LABEL_PATTERN: Final = re.compile(r"^[A-Za-z0-9._:+/-]{1,64}$")
+_NUMBER_PATTERN: Final = re.compile(r"^-?\d{1,19}$")
+_LANGUAGE_PATTERN: Final = re.compile(r"^[A-Za-z]{2,3}(-[A-Za-z0-9]{2,8})?$")
+_OPAQUE_REF_PATTERN: Final = re.compile(r"^[0-9a-f]{16,64}$")
+
+
+@dataclass(frozen=True, slots=True)
+class AttributeSpec:
+    kind: AttributeKind
+    values: frozenset[str] | None = None
+
+    def __post_init__(self) -> None:
+        if (self.kind is AttributeKind.ENUM) != bool(self.values):
+            raise ValueError("exactly the ENUM kind declares a closed value set")
+
+
+def _enum_values(enum_class: type[Enum]) -> frozenset[str]:
+    return frozenset(str(member.value) for member in enum_class)
+
+
+# The single manifest. Every key names its value shape, so widening the
+# allowlist cannot smuggle in a free-text field by accident.
+#
 # event.name is deliberately absent: OTLP carries the event name as a top-level
 # LogRecord field, which the exporter writes to its typed `EventName` column.
 # See spike finding 9.1 in the design document.
-ALLOWED_ATTRIBUTE_KEYS: Final[frozenset[str]] = frozenset(
-    {
-        "ssf.quality.event_id",
-        "ssf.quality.schema_version",
-    }
-)
+ALLOWED_ATTRIBUTES: Final[Mapping[str, AttributeSpec]] = {
+    "ssf.quality.event_id": AttributeSpec(AttributeKind.UUID),
+    "ssf.quality.schema_version": AttributeSpec(AttributeKind.NUMBER),
+    "ssf.quality.refiner_role": AttributeSpec(
+        AttributeKind.ENUM, _enum_values(RefinerRole)
+    ),
+    "ssf.quality.model_ref": AttributeSpec(AttributeKind.LABEL),
+    "ssf.quality.refinement_outcome": AttributeSpec(
+        AttributeKind.ENUM, _enum_values(RefinementOutcomeCode)
+    ),
+    "ssf.quality.refinement_latency_ms": AttributeSpec(AttributeKind.NUMBER),
+    "ssf.quality.refinement_changed": AttributeSpec(
+        AttributeKind.ENUM, frozenset({"true", "false"})
+    ),
+    "ssf.quality.source_lang": AttributeSpec(AttributeKind.LANGUAGE),
+    "ssf.quality.target_lang": AttributeSpec(AttributeKind.LANGUAGE),
+    "ssf.quality.error_code": AttributeSpec(
+        AttributeKind.ENUM, _enum_values(QualityErrorCode)
+    ),
+}
+
+ALLOWED_ATTRIBUTE_KEYS: Final[frozenset[str]] = frozenset(ALLOWED_ATTRIBUTES)
 
 
 class TelemetryMode(str, Enum):
+    """DISABLED and PROBE keep exactly the meanings they shipped with.
+
+    ENABLED is additive: it emits real pipeline events as well as the admin
+    probe. PROBE therefore stays a pure transport check, so an operator can
+    verify the pipeline without turning on production event volume, and
+    nothing already deployed on `probe` changes behaviour on upgrade.
+    """
+
     DISABLED = "disabled"
     PROBE = "probe"
+    ENABLED = "enabled"
+
+    @property
+    def emits_pipeline_events(self) -> bool:
+        return self is TelemetryMode.ENABLED
 
     @classmethod
     def parse(cls, raw: str | None) -> "TelemetryMode":
@@ -71,6 +197,15 @@ class DisallowedTelemetryAttribute(ValueError):
     """Raised when an attribute key is not on the allowlist."""
 
 
+class DisallowedTelemetryValue(ValueError):
+    """Raised when an allowlisted key carries a value of the wrong shape.
+
+    The key allowlist alone stops a *new* field leaking content; this stops an
+    *existing* field being used as a smuggling channel -- an `error_code` set
+    to a raw upstream message, say.
+    """
+
+
 @dataclass(frozen=True, slots=True)
 class QualityProbeEvent:
     event_id: UUID
@@ -85,6 +220,66 @@ class QualityProbeEvent:
             raise ValueError("event_type must not be empty")
         if self.schema_version < 1:
             raise ValueError("schema_version must be positive")
+
+
+def _validate_envelope(
+    emitted_at_utc: datetime, event_type: str, schema_version: int
+) -> None:
+    if emitted_at_utc.tzinfo is None:
+        raise ValueError("emitted_at_utc must be timezone-aware UTC")
+    if not event_type:
+        raise ValueError("event_type must not be empty")
+    if schema_version < 1:
+        raise ValueError("schema_version must be positive")
+
+
+@dataclass(frozen=True, slots=True)
+class RefinementAttemptEvent:
+    """One LLM refinement attempt, primary or shadow candidate.
+
+    Every field is a number or a closed enum except `model_ref`, which is an
+    operator-set configuration token constrained to a label charset. Nothing
+    here can express the text being refined, so this event carries no privacy
+    risk by construction rather than by review.
+    """
+
+    event_id: UUID
+    schema_version: int
+    emitted_at_utc: datetime
+    event_type: QualityEventType
+    refiner_role: RefinerRole
+    model_ref: str
+    outcome: RefinementOutcomeCode
+    latency_ms: int
+    changed: bool
+    source_lang: str
+    target_lang: str
+    error_code: QualityErrorCode
+
+    def __post_init__(self) -> None:
+        _validate_envelope(self.emitted_at_utc, self.event_type, self.schema_version)
+        if self.latency_ms < 0:
+            raise ValueError("latency_ms must not be negative")
+        if not _LABEL_PATTERN.match(self.model_ref):
+            raise ValueError(f"model_ref is not a label token: {self.model_ref!r}")
+        for code in (self.source_lang, self.target_lang):
+            if not _LANGUAGE_PATTERN.match(code):
+                raise ValueError(f"not a language code: {code!r}")
+
+    def _attributes(self) -> dict[str, str]:
+        return {
+            "ssf.quality.refiner_role": self.refiner_role.value,
+            "ssf.quality.model_ref": self.model_ref,
+            "ssf.quality.refinement_outcome": self.outcome.value,
+            "ssf.quality.refinement_latency_ms": str(self.latency_ms),
+            "ssf.quality.refinement_changed": "true" if self.changed else "false",
+            "ssf.quality.source_lang": self.source_lang,
+            "ssf.quality.target_lang": self.target_lang,
+            "ssf.quality.error_code": self.error_code.value,
+        }
+
+
+QualityEvent = QualityProbeEvent | RefinementAttemptEvent
 
 
 @dataclass(frozen=True, slots=True)
@@ -102,14 +297,108 @@ def enforce_allowlist(attributes: Mapping[str, str]) -> None:
         raise DisallowedTelemetryAttribute(f"disallowed attribute keys: {disallowed}")
 
 
-def to_otlp_attributes(event: QualityProbeEvent) -> dict[str, str]:
+_SHAPE_PATTERNS: Final[Mapping[AttributeKind, "re.Pattern[str]"]] = {
+    AttributeKind.NUMBER: _NUMBER_PATTERN,
+    AttributeKind.LABEL: _LABEL_PATTERN,
+    AttributeKind.LANGUAGE: _LANGUAGE_PATTERN,
+    AttributeKind.OPAQUE_REF: _OPAQUE_REF_PATTERN,
+}
+
+
+def _value_has_declared_shape(spec: AttributeSpec, value: str) -> bool:
+    if spec.kind is AttributeKind.ENUM:
+        return value in (spec.values or frozenset())
+    if spec.kind is AttributeKind.UUID:
+        try:
+            UUID(value)
+        except (ValueError, AttributeError, TypeError):
+            return False
+        return True
+    return bool(_SHAPE_PATTERNS[spec.kind].match(value))
+
+
+def enforce_value_shapes(attributes: Mapping[str, str]) -> None:
+    """Fail closed on the value as well as the key.
+
+    The rejection message names the key and its declared kind, never the value:
+    a guard that echoes what it rejected would log the content it exists to
+    keep out of the logs.
+    """
+    for key, value in attributes.items():
+        spec = ALLOWED_ATTRIBUTES.get(key)
+        if spec is None:
+            raise DisallowedTelemetryAttribute(f"disallowed attribute key: {key!r}")
+        if not isinstance(value, str) or not _value_has_declared_shape(spec, value):
+            raise DisallowedTelemetryValue(
+                f"{key!r} does not match its declared shape {spec.kind.value!r}"
+            )
+
+
+def to_otlp_attributes(event: QualityEvent) -> dict[str, str]:
     """Map a typed event onto OTel semantic-convention attribute keys."""
     attributes = {
         "ssf.quality.event_id": str(event.event_id),
         "ssf.quality.schema_version": str(event.schema_version),
     }
+    per_event = getattr(event, "_attributes", None)
+    if per_event is not None:
+        attributes.update(per_event())
     enforce_allowlist(attributes)
+    enforce_value_shapes(attributes)
     return attributes
+
+
+UNDETERMINED_LANGUAGE: Final[str] = "und"
+UNKNOWN_LABEL: Final[str] = "unknown"
+
+
+def _as_label(value: str) -> str:
+    return value if _LABEL_PATTERN.match(str(value or "")) else UNKNOWN_LABEL
+
+
+def _as_language(value: str) -> str:
+    """ISO 639-2's `und` is the standard way to say "not determined"."""
+    return value if _LANGUAGE_PATTERN.match(str(value or "")) else UNDETERMINED_LANGUAGE
+
+
+def classify_upstream_status(status_code: int) -> QualityErrorCode:
+    """Reduce an upstream HTTP status to a stable, storable token."""
+    if 200 <= status_code < 300:
+        return QualityErrorCode.NONE
+    if status_code == 503:
+        return QualityErrorCode.UPSTREAM_BUSY
+    if status_code in (408, 504):
+        return QualityErrorCode.UPSTREAM_TIMEOUT
+    if 400 <= status_code < 500:
+        return QualityErrorCode.UPSTREAM_REJECTED
+    if 500 <= status_code < 600:
+        return QualityErrorCode.UPSTREAM_ERROR
+    return QualityErrorCode.UNKNOWN
+
+
+# Matched by class name rather than by import so this module stays free of the
+# HTTP client: requests' Timeout and ConnectionError are not the builtins.
+_TIMEOUT_NAMES: Final[frozenset[str]] = frozenset(
+    {"TimeoutError", "Timeout", "ReadTimeout", "ConnectTimeout", "ReadTimeoutError"}
+)
+_UNREACHABLE_NAMES: Final[frozenset[str]] = frozenset(
+    {"ConnectionError", "NewConnectionError", "ProxyError", "SSLError"}
+)
+_MALFORMED_NAMES: Final[frozenset[str]] = frozenset(
+    {"JSONDecodeError", "ValueError", "ContentDecodingError"}
+)
+
+
+def classify_exception(exception: BaseException) -> QualityErrorCode:
+    """Reduce an exception to a stable token, never carrying its message."""
+    names = {klass.__name__ for klass in type(exception).__mro__}
+    if names & _TIMEOUT_NAMES:
+        return QualityErrorCode.UPSTREAM_TIMEOUT
+    if names & _UNREACHABLE_NAMES:
+        return QualityErrorCode.UPSTREAM_UNREACHABLE
+    if names & _MALFORMED_NAMES:
+        return QualityErrorCode.UPSTREAM_MALFORMED_RESPONSE
+    return QualityErrorCode.INTERNAL_ERROR
 
 
 _EVENTS_COUNTER_NAME = "ssf_quality_telemetry_events_total"
@@ -176,18 +465,68 @@ class QualityTelemetry:
             # from "never wired up".
             return self._record(ProbeOutcome.DISABLED, None)
 
-        event = QualityProbeEvent(
-            event_id=uuid4(),
-            schema_version=SCHEMA_VERSION,
-            emitted_at_utc=datetime.now(timezone.utc),
-            event_type=event_type,
+        return self._export(
+            QualityProbeEvent(
+                event_id=uuid4(),
+                schema_version=SCHEMA_VERSION,
+                emitted_at_utc=datetime.now(timezone.utc),
+                event_type=event_type,
+            )
         )
 
+    def emit_refinement_attempt(
+        self,
+        *,
+        refiner_role: RefinerRole,
+        model_ref: str,
+        outcome: RefinementOutcomeCode,
+        latency_ms: int,
+        changed: bool,
+        source_lang: str,
+        target_lang: str,
+        error_code: QualityErrorCode,
+    ) -> ProbeResult:
+        """One shadow or primary refinement attempt.
+
+        Gated on ENABLED, not on "not DISABLED": PROBE stays a pure transport
+        check so an operator can verify the pipeline without switching on
+        production event volume.
+
+        Every argument is coerced rather than trusted. A model name or language
+        the manifest would reject becomes a placeholder instead of dropping the
+        event: a missing row makes the denominator wrong for every ratio built
+        on it, which is a worse failure than an imprecise label.
+        """
+        if not self._mode.emits_pipeline_events:
+            return self._record(ProbeOutcome.DISABLED, None)
+
         try:
-            self._exporter(
-                event.event_type, to_otlp_attributes(event), event.emitted_at_utc
+            event = RefinementAttemptEvent(
+                event_id=uuid4(),
+                schema_version=SCHEMA_VERSION,
+                emitted_at_utc=datetime.now(timezone.utc),
+                event_type=QualityEventType.REFINEMENT_ATTEMPT,
+                refiner_role=refiner_role,
+                model_ref=_as_label(model_ref),
+                outcome=outcome,
+                latency_ms=max(0, int(latency_ms or 0)),
+                changed=bool(changed),
+                source_lang=_as_language(source_lang),
+                target_lang=_as_language(target_lang),
+                error_code=error_code,
             )
-        except DisallowedTelemetryAttribute:
+        except (ValueError, TypeError):
+            logger.warning("Quality telemetry event rejected before export")
+            return self._record(ProbeOutcome.DROPPED_DISALLOWED, None)
+
+        return self._export(event)
+
+    def _export(self, event: QualityEvent) -> ProbeResult:
+        event_type = event.event_type
+        name = event_type.value if isinstance(event_type, Enum) else str(event_type)
+        try:
+            self._exporter(name, to_otlp_attributes(event), event.emitted_at_utc)
+        except (DisallowedTelemetryAttribute, DisallowedTelemetryValue):
             logger.warning("Quality telemetry attribute rejected by the allowlist")
             return self._record(ProbeOutcome.DROPPED_DISALLOWED, event.event_id)
         except Exception:  # telemetry must never reach the caller

--- a/services/api_gateway/quality_telemetry.py
+++ b/services/api_gateway/quality_telemetry.py
@@ -98,10 +98,16 @@ class AttributeKind(str, Enum):
 
 # A label is operator-set configuration (a model name, a release token), not
 # user content: no whitespace, no punctuation that would let a sentence through.
-_LABEL_PATTERN: Final = re.compile(r"^[A-Za-z0-9._:+/-]{1,64}$")
-_NUMBER_PATTERN: Final = re.compile(r"^-?\d{1,19}$")
-_LANGUAGE_PATTERN: Final = re.compile(r"^[A-Za-z]{2,3}(-[A-Za-z0-9]{2,8})?$")
-_OPAQUE_REF_PATTERN: Final = re.compile(r"^[0-9a-f]{16,64}$")
+# \Z, not $: `$` also matches immediately before a trailing newline, so a
+# "no whitespace" guard was accepting "gpt-oss:20b\n". [0-9] and re.ASCII, not
+# \d: \d accepts Unicode decimal digits, and "١٢٣" is not a number ClickHouse
+# will parse into a UInt32 -- toUInt32OrZero turns it into a silent 0.
+_LABEL_PATTERN: Final = re.compile(r"\A[A-Za-z0-9._:+/-]{1,64}\Z", re.ASCII)
+_NUMBER_PATTERN: Final = re.compile(r"\A-?[0-9]{1,19}\Z", re.ASCII)
+_LANGUAGE_PATTERN: Final = re.compile(
+    r"\A[A-Za-z]{2,3}(-[A-Za-z0-9]{2,8})?\Z", re.ASCII
+)
+_OPAQUE_REF_PATTERN: Final = re.compile(r"\A[0-9a-f]{16,64}\Z", re.ASCII)
 
 
 @dataclass(frozen=True, slots=True)
@@ -414,15 +420,40 @@ def _events_counter(registry: CollectorRegistry) -> Counter:
     prometheus_client raises on a second registration of the same metric name,
     so this mirrors app.py's own precedent of registering a series once and
     reusing it thereafter.
+
+    Registration is attempted through the public API first, and every fallback
+    ends in a counter rather than an exception. Telemetry is optional; a
+    registry this cannot register into must not be able to stop the gateway.
     """
-    existing = registry._names_to_collectors.get(_EVENTS_COUNTER_NAME)
+    try:
+        return Counter(
+            _EVENTS_COUNTER_NAME,
+            "Quality telemetry events by outcome",
+            ["outcome"],
+            registry=registry,
+        )
+    except ValueError:
+        pass  # already registered on this registry, or the name is taken
+
+    # _names_to_collectors is private and may be renamed by a library bump, so
+    # reuse is best-effort and never the only path out of here.
+    existing = getattr(registry, "_names_to_collectors", {}).get(_EVENTS_COUNTER_NAME)
     if isinstance(existing, Counter):
         return existing
+
+    # The name is held by something that is not our counter. Count into an
+    # unregistered collector rather than raising: the series will not be
+    # scraped, which is a reporting gap, not an outage.
+    logger.warning(
+        "%s is not available on the gateway registry; telemetry counters "
+        "will not be scraped",
+        _EVENTS_COUNTER_NAME,
+    )
     return Counter(
         _EVENTS_COUNTER_NAME,
         "Quality telemetry events by outcome",
         ["outcome"],
-        registry=registry,
+        registry=CollectorRegistry(),
     )
 
 

--- a/services/api_gateway/quality_telemetry_otlp.py
+++ b/services/api_gateway/quality_telemetry_otlp.py
@@ -14,7 +14,7 @@ from opentelemetry.sdk._logs import LoggerProvider
 from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
 from opentelemetry.sdk.resources import Resource
 
-from .quality_telemetry import enforce_allowlist
+from .quality_telemetry import enforce_allowlist, enforce_value_shapes
 
 _NANOS_PER_SECOND = 1_000_000_000
 
@@ -37,8 +37,11 @@ class OtlpQualityExporter:
         attributes: Mapping[str, str],
         emitted_at_utc: datetime,
     ) -> None:
-        # Last checkpoint before the wire, so no caller can widen what ships.
+        # Last checkpoint before the wire, so no caller can widen what ships --
+        # keys *and* values. Enforcing only the keys here let an emitter that
+        # built its own dict ship a raw message under an allowlisted key.
         enforce_allowlist(attributes)
+        enforce_value_shapes(attributes)
         # emit() takes kwargs directly; no LogRecord is constructed. event_name is
         # a top-level OTLP field and reaches the typed EventName column. Without
         # an explicit timestamp the SDK sends none and the column silently

--- a/services/api_gateway/translation_refiner.py
+++ b/services/api_gateway/translation_refiner.py
@@ -87,6 +87,13 @@ class BaseTranslationRefiner:
 
     is_active: bool = False
 
+    #: Set by the gateway's lifespan. None means telemetry is not wired up,
+    #: which must be indistinguishable from telemetry being switched off.
+    quality_telemetry: Optional[Any] = None
+
+    def attach_quality_telemetry(self, telemetry: Optional[Any]) -> None:
+        self.quality_telemetry = telemetry
+
     def refine(
         self,
         text: str,
@@ -267,6 +274,55 @@ class ShadowComparisonRefiner(OllamaTranslationRefiner):
         self.pending = 0
         self.lock = Lock()
 
+    @staticmethod
+    def _requested_languages(args: Any, kwargs: Any) -> tuple[str, str]:
+        """`refine(text, source_lang, target_lang, context=None)`, called either
+        way round by the two pipelines."""
+        source = kwargs.get("source_lang") or (args[1] if len(args) > 1 else "")
+        target = kwargs.get("target_lang") or (args[2] if len(args) > 2 else "")
+        return str(source), str(target)
+
+    def _emit_attempt(self, result: RefinementOutcome, args: Any, kwargs: Any) -> None:
+        """Record the attempt. Never allowed to affect the caller.
+
+        The candidate's latency is measured here and has never been retained --
+        it went into a log line and nowhere else. The refinement benchmarking
+        work asks exactly this question and has no data for it.
+        """
+        telemetry = self.quality_telemetry
+        if telemetry is None:
+            return
+        try:
+            from .quality_telemetry import (
+                QualityErrorCode,
+                RefinementOutcomeCode,
+                RefinerRole,
+                classify_exception,
+            )
+
+            source_lang, target_lang = self._requested_languages(args, kwargs)
+            failed = bool(result.error)
+            telemetry.emit_refinement_attempt(
+                refiner_role=RefinerRole.CANDIDATE,
+                model_ref=self.candidate_model,
+                outcome=(
+                    RefinementOutcomeCode.ERROR
+                    if failed
+                    else RefinementOutcomeCode.SUCCESS
+                ),
+                latency_ms=int(result.latency_ms or 0),
+                changed=bool(result.changed),
+                source_lang=source_lang,
+                target_lang=target_lang,
+                error_code=(
+                    classify_exception(RuntimeError(result.error))
+                    if failed
+                    else QualityErrorCode.NONE
+                ),
+            )
+        except Exception:  # telemetry must never change an outcome
+            logger.warning("Quality telemetry emit failed for shadow candidate")
+
     def _run_candidate(self, *args: Any, **kwargs: Any) -> None:
         try:
             candidate = OllamaTranslationRefiner(
@@ -285,6 +341,7 @@ class ShadowComparisonRefiner(OllamaTranslationRefiner):
                 status,
                 result.latency_ms,
             )
+            self._emit_attempt(result, args, kwargs)
         finally:
             with self.lock:
                 self.pending -= 1

--- a/services/api_gateway/translation_refiner.py
+++ b/services/api_gateway/translation_refiner.py
@@ -9,6 +9,14 @@ from typing import Any, Dict, Optional
 import requests
 from requests import Response, exceptions
 
+from .quality_telemetry import (
+    QualityErrorCode,
+    RefinementOutcomeCode,
+    RefinerRole,
+    classify_exception,
+    classify_upstream_status,
+)
+
 logger = logging.getLogger(__name__)
 
 # Languages listed as supported by the Phi-4-mini-instruct model card.  Phi is
@@ -65,12 +73,30 @@ def _strtobool(value: str) -> bool:
     return str(value).strip().lower() in {"1", "true", "yes", "on"}
 
 
+def _classify_refinement_failure(exc: BaseException) -> QualityErrorCode:
+    """Classify at the catch site, where the exception class still exists.
+
+    `error` is a string by the time anything downstream sees it, and
+    `classify_exception(RuntimeError(message))` cannot recover the class -- it
+    matches on the MRO, and RuntimeError's MRO intersects none of the name sets,
+    so every failure would collapse to `internal_error`.
+
+    requests raises one class, HTTPError, for every non-2xx status, so a status
+    is read from the response in preference to the class.
+    """
+    status = getattr(getattr(exc, "response", None), "status_code", None)
+    if isinstance(status, int):
+        return classify_upstream_status(status)
+    return classify_exception(exc)
+
+
 @dataclass
 class RefinementOutcome:
     text: str
     changed: bool
     latency_ms: Optional[float] = None
     error: Optional[str] = None
+    error_code: QualityErrorCode = QualityErrorCode.NONE
     raw_response: Optional[Dict[str, Any]] = None
     model: Optional[str] = None
     candidate_model: Optional[str] = None
@@ -93,6 +119,59 @@ class BaseTranslationRefiner:
 
     def attach_quality_telemetry(self, telemetry: Optional[Any]) -> None:
         self.quality_telemetry = telemetry
+
+    def _emit_attempt(
+        self,
+        *,
+        role: "RefinerRole",
+        model_ref: str,
+        outcome: "RefinementOutcomeCode",
+        latency_ms: int,
+        changed: bool,
+        source_lang: str,
+        target_lang: str,
+        error_code: "QualityErrorCode",
+    ) -> None:
+        """Record one attempt. Never allowed to affect the caller."""
+        telemetry = self.quality_telemetry
+        if telemetry is None:
+            return
+        try:
+            telemetry.emit_refinement_attempt(
+                refiner_role=role,
+                model_ref=model_ref,
+                outcome=outcome,
+                latency_ms=latency_ms,
+                changed=changed,
+                source_lang=source_lang,
+                target_lang=target_lang,
+                error_code=error_code,
+            )
+        except Exception:  # telemetry must never change an outcome
+            logger.warning("Quality telemetry emit failed for a refinement attempt")
+
+    def _emit_outcome(
+        self,
+        outcome: "RefinementOutcome",
+        *,
+        role: "RefinerRole",
+        model_ref: str,
+        source_lang: str,
+        target_lang: str,
+    ) -> None:
+        failed = bool(outcome.error)
+        self._emit_attempt(
+            role=role,
+            model_ref=model_ref,
+            outcome=(
+                RefinementOutcomeCode.ERROR if failed else RefinementOutcomeCode.SUCCESS
+            ),
+            latency_ms=int(outcome.latency_ms or 0),
+            changed=bool(outcome.changed),
+            source_lang=source_lang,
+            target_lang=target_lang,
+            error_code=outcome.error_code,
+        )
 
     def refine(
         self,
@@ -188,6 +267,30 @@ class OllamaTranslationRefiner(BaseTranslationRefiner):
         target_lang: str,
         context: Optional[Dict[str, Any]] = None,
     ) -> RefinementOutcome:
+        """Refine in-path, recording the attempt.
+
+        The emit lives here rather than in the shadow subclass because
+        production runs `primary_only`: an event reachable only from the shadow
+        candidate is an event production never produces, and a dashboard that
+        is empty exactly where it matters.
+        """
+        outcome = self._perform_refinement(text, source_lang, target_lang, context)
+        self._emit_outcome(
+            outcome,
+            role=RefinerRole.PRIMARY,
+            model_ref=self.model,
+            source_lang=source_lang,
+            target_lang=target_lang,
+        )
+        return outcome
+
+    def _perform_refinement(
+        self,
+        text: str,
+        source_lang: str,
+        target_lang: str,
+        context: Optional[Dict[str, Any]] = None,
+    ) -> RefinementOutcome:
         if not text:
             return RefinementOutcome(
                 text=text, changed=False, latency_ms=0.0, error=None, model=self.model
@@ -208,6 +311,7 @@ class OllamaTranslationRefiner(BaseTranslationRefiner):
         start_time = time.perf_counter()
 
         last_error: Optional[str] = None
+        last_error_code = QualityErrorCode.UNKNOWN
         for attempt in range(1, self.max_retries + 1):
             try:
                 response = self._request(prompt)
@@ -222,6 +326,7 @@ class OllamaTranslationRefiner(BaseTranslationRefiner):
                         changed=False,
                         latency_ms=elapsed_ms,
                         error="empty_response",
+                        error_code=QualityErrorCode.UPSTREAM_MALFORMED_RESPONSE,
                         raw_response=data,
                         model=self.model,
                     )
@@ -237,6 +342,7 @@ class OllamaTranslationRefiner(BaseTranslationRefiner):
                 )
             except exceptions.Timeout as exc:
                 last_error = str(exc)
+                last_error_code = QualityErrorCode.UPSTREAM_TIMEOUT
                 if attempt < self.max_retries:
                     logger.warning(
                         "Translation refinement timeout (attempt %s/%s), retrying...",
@@ -248,6 +354,7 @@ class OllamaTranslationRefiner(BaseTranslationRefiner):
                 logger.warning("Translation refinement failed after retries: %s", exc)
             except Exception as exc:  # noqa: BLE001
                 last_error = str(exc)
+                last_error_code = _classify_refinement_failure(exc)
                 logger.warning("Translation refinement failed: %s", exc)
                 break
 
@@ -257,6 +364,7 @@ class OllamaTranslationRefiner(BaseTranslationRefiner):
             changed=False,
             latency_ms=elapsed_ms,
             error=last_error,
+            error_code=last_error_code,
             raw_response=None,
             model=self.model,
         )
@@ -282,47 +390,6 @@ class ShadowComparisonRefiner(OllamaTranslationRefiner):
         target = kwargs.get("target_lang") or (args[2] if len(args) > 2 else "")
         return str(source), str(target)
 
-    def _emit_attempt(self, result: RefinementOutcome, args: Any, kwargs: Any) -> None:
-        """Record the attempt. Never allowed to affect the caller.
-
-        The candidate's latency is measured here and has never been retained --
-        it went into a log line and nowhere else. The refinement benchmarking
-        work asks exactly this question and has no data for it.
-        """
-        telemetry = self.quality_telemetry
-        if telemetry is None:
-            return
-        try:
-            from .quality_telemetry import (
-                QualityErrorCode,
-                RefinementOutcomeCode,
-                RefinerRole,
-                classify_exception,
-            )
-
-            source_lang, target_lang = self._requested_languages(args, kwargs)
-            failed = bool(result.error)
-            telemetry.emit_refinement_attempt(
-                refiner_role=RefinerRole.CANDIDATE,
-                model_ref=self.candidate_model,
-                outcome=(
-                    RefinementOutcomeCode.ERROR
-                    if failed
-                    else RefinementOutcomeCode.SUCCESS
-                ),
-                latency_ms=int(result.latency_ms or 0),
-                changed=bool(result.changed),
-                source_lang=source_lang,
-                target_lang=target_lang,
-                error_code=(
-                    classify_exception(RuntimeError(result.error))
-                    if failed
-                    else QualityErrorCode.NONE
-                ),
-            )
-        except Exception:  # telemetry must never change an outcome
-            logger.warning("Quality telemetry emit failed for shadow candidate")
-
     def _run_candidate(self, *args: Any, **kwargs: Any) -> None:
         try:
             candidate = OllamaTranslationRefiner(
@@ -333,7 +400,9 @@ class ShadowComparisonRefiner(OllamaTranslationRefiner):
                 self.max_retries,
                 self.think,
             )
-            result = candidate.refine(*args, **kwargs)
+            # _perform_refinement, not refine: the latter would emit this as a
+            # PRIMARY attempt under the candidate's model name.
+            result = candidate._perform_refinement(*args, **kwargs)
             status = "error" if result.error else "success"
             logger.info(
                 "Shadow candidate model=%s status=%s latency_ms=%s",
@@ -341,10 +410,42 @@ class ShadowComparisonRefiner(OllamaTranslationRefiner):
                 status,
                 result.latency_ms,
             )
-            self._emit_attempt(result, args, kwargs)
+            source_lang, target_lang = self._requested_languages(args, kwargs)
+            # The candidate's latency has always been measured here and thrown
+            # away into that log line. The refinement benchmarking work asks
+            # exactly this question and has had no data for it.
+            self._emit_outcome(
+                result,
+                role=RefinerRole.CANDIDATE,
+                model_ref=self.candidate_model,
+                source_lang=source_lang,
+                target_lang=target_lang,
+            )
         finally:
             with self.lock:
                 self.pending -= 1
+
+    def _emit_candidate_not_run(
+        self, outcome_code: RefinementOutcomeCode, args: Any, kwargs: Any
+    ) -> None:
+        """A candidate that never ran is still an attempt worth counting.
+
+        Without this, shadow-queue overload is invisible: the run produces no
+        row, so the dashboard shows a lower attempt count rather than a
+        saturated queue, and SKIPPED_OVERLOAD and SUBMISSION_FAILED are
+        unreachable enum values.
+        """
+        source_lang, target_lang = self._requested_languages(args, kwargs)
+        self._emit_attempt(
+            role=RefinerRole.CANDIDATE,
+            model_ref=self.candidate_model,
+            outcome=outcome_code,
+            latency_ms=0,
+            changed=False,
+            source_lang=source_lang,
+            target_lang=target_lang,
+            error_code=QualityErrorCode.REFINEMENT_OVERLOADED,
+        )
 
     def refine(self, *args: Any, **kwargs: Any) -> RefinementOutcome:
         outcome = super().refine(*args, **kwargs)
@@ -352,6 +453,9 @@ class ShadowComparisonRefiner(OllamaTranslationRefiner):
         with self.lock:
             if self.pending >= self.queue_limit:
                 outcome.candidate_status = "skipped_overload"
+                self._emit_candidate_not_run(
+                    RefinementOutcomeCode.SKIPPED_OVERLOAD, args, kwargs
+                )
                 return outcome
             self.pending += 1
         outcome.candidate_status = "scheduled"
@@ -362,6 +466,9 @@ class ShadowComparisonRefiner(OllamaTranslationRefiner):
                 self.pending -= 1
             outcome.candidate_status = "submission_failed"
             logger.warning("Unable to schedule shadow candidate refinement")
+            self._emit_candidate_not_run(
+                RefinementOutcomeCode.SUBMISSION_FAILED, args, kwargs
+            )
         return outcome
 
 

--- a/tests/integration/test_quality_events_schema_apply.py
+++ b/tests/integration/test_quality_events_schema_apply.py
@@ -5,6 +5,7 @@ grep for "ReplacingMergeTree" proves the file says it, not that a duplicate
 collapses or that a malformed id is kept out.
 """
 
+import re
 import subprocess
 import time
 import uuid
@@ -17,6 +18,15 @@ pytestmark = pytest.mark.integration
 ROOT = Path(__file__).parents[2]
 MIGRATIONS = sorted((ROOT / "deploy" / "clickhouse" / "migrations").glob("*.sql"))
 SCRATCH_DB = "ssf_schema_apply_test"
+
+# Every object the repository's migrations own, in ORDER BY name order.
+EXPECTED_TABLES = [
+    "otel_logs",
+    "quality_events",
+    "quality_events_daily",
+    "quality_events_daily_mv",
+    "quality_events_mv",
+]
 
 # Exactly the columns the ClickHouse exporter names in its INSERT. Bronze must
 # accept all of them or every export fails.
@@ -89,7 +99,7 @@ def test_the_migrations_apply_to_an_empty_database(scratch_db: str) -> None:
         "SELECT name FROM system.tables WHERE database = currentDatabase() ORDER BY name",
         database=scratch_db,
     ).splitlines()
-    assert tables == ["otel_logs", "quality_events", "quality_events_mv"]
+    assert tables == EXPECTED_TABLES
 
 
 def test_bronze_accepts_every_column_the_exporter_inserts(scratch_db: str) -> None:
@@ -151,14 +161,16 @@ def test_a_duplicated_delivery_collapses_to_one_silver_row(scratch_db: str) -> N
     assert count == "1"
 
 
-def test_both_tiers_expire_on_their_documented_retention(scratch_db: str) -> None:
-    """7 days bronze, 30 days silver. A missing TTL grows the disk forever."""
+def test_every_tier_expires_on_its_documented_retention(scratch_db: str) -> None:
+    """7 days bronze, 30 days silver, 13 months gold. ClickHouse fixes TTL at
+    creation, so a tier that ships without one can never be given one."""
     ddl = {
         table: _client(f"SHOW CREATE TABLE {table}", database=scratch_db)
-        for table in ("otel_logs", "quality_events")
+        for table in ("otel_logs", "quality_events", "quality_events_daily")
     }
     assert "toIntervalDay(7)" in ddl["otel_logs"], ddl["otel_logs"]
     assert "toIntervalDay(30)" in ddl["quality_events"], ddl["quality_events"]
+    assert "toIntervalMonth(13)" in ddl["quality_events_daily"], ddl["quality_events_daily"]
 
 
 def test_silver_stores_no_content_column(scratch_db: str) -> None:
@@ -168,8 +180,94 @@ def test_silver_stores_no_content_column(scratch_db: str) -> None:
         "AND table = 'quality_events'",
         database=scratch_db,
     ).splitlines()
-    forbidden = ("body", "text", "audio", "transcript", "error", "ip", "session")
-    assert not [c for c in columns if any(f in c for f in forbidden)], columns
+    # Whole segments, not substrings: "error" also matches `error_code`, a
+    # closed enum from the taxonomy, and "ip" matches "pipeline". The value-level
+    # guarantee lives in the attribute manifest, which declares a shape for every
+    # key and has no free-text kind; this stays a naming tripwire on top of it.
+    forbidden = re.compile(
+        r"(?:^|_)(?:body|text|transcript|message|detail|payload|url|uri|ip|prompt)(?:_|$)"
+    )
+    assert not [c for c in columns if forbidden.search(c)], columns
+
+
+def _insert_refinement(db: str, event_id: str, *, latency_ms: str, changed: str) -> None:
+    _client(
+        f"INSERT INTO otel_logs ({', '.join(_EXPORTER_COLUMNS)}) VALUES "
+        f"(now64(9), '', '', 0, '', 0, 'api_gateway', '', '', "
+        f"{{'service.version': 'itest', 'deployment.environment.name': 'itest'}}, "
+        f"'', 'ssf.quality', '', {{}}, "
+        f"{{'ssf.quality.event_id': '{event_id}', 'ssf.quality.schema_version': '1', "
+        f"'ssf.quality.refiner_role': 'candidate', 'ssf.quality.model_ref': 'phi4-mini', "
+        f"'ssf.quality.refinement_outcome': 'success', "
+        f"'ssf.quality.refinement_latency_ms': '{latency_ms}', "
+        f"'ssf.quality.refinement_changed': '{changed}', "
+        f"'ssf.quality.source_lang': 'en', 'ssf.quality.target_lang': 'de', "
+        f"'ssf.quality.error_code': 'none'}}, 'refinement_attempt')",
+        database=db,
+    )
+
+
+def test_the_silver_view_projects_every_typed_field(scratch_db: str) -> None:
+    event_id = str(uuid.uuid4())
+    _insert_refinement(scratch_db, event_id, latency_ms="340", changed="true")
+
+    row = _client(
+        "SELECT refiner_role, model_ref, refinement_outcome, refinement_latency_ms, "
+        f"refinement_changed, source_lang, target_lang, error_code FROM quality_events "
+        f"FINAL WHERE event_id = '{event_id}'",
+        database=scratch_db,
+    )
+    assert row.split("\t") == [
+        "candidate",
+        "phi4-mini",
+        "success",
+        "340",
+        "1",
+        "en",
+        "de",
+        "none",
+    ]
+
+
+def test_a_gold_count_is_not_inflated_by_a_duplicated_delivery(scratch_db: str) -> None:
+    """Task 4.4, aggregate correctness.
+
+    The retry path delivers the same event_id twice and silver's
+    ReplacingMergeTree only collapses that at merge time, so a plain counter in
+    gold would over-report permanently -- an aggregate cannot be un-counted.
+    A sumState-based `changed_events` was observed reporting 2 for one event.
+    """
+    event_id = str(uuid.uuid4())
+    for _ in range(2):
+        _insert_refinement(scratch_db, event_id, latency_ms="500", changed="true")
+
+    counts = _client(
+        "SELECT uniqExactMerge(events), uniqExactMerge(changed_events) "
+        "FROM quality_events_daily WHERE model_ref = 'phi4-mini'",
+        database=scratch_db,
+    )
+    events, changed = counts.split("\t")
+    duplicates = _client(
+        f"SELECT count() FROM otel_logs WHERE LogAttributes['ssf.quality.event_id'] = '{event_id}'",
+        database=scratch_db,
+    )
+
+    assert duplicates == "2", "the duplicate delivery must actually have landed"
+    assert int(events) == int(changed), (events, changed)
+
+
+def test_gold_totals_agree_with_the_silver_rows_they_summarise(scratch_db: str) -> None:
+    gold = _client(
+        "SELECT uniqExactMerge(events) FROM quality_events_daily "
+        "WHERE event_type = 'refinement_attempt'",
+        database=scratch_db,
+    )
+    silver = _client(
+        "SELECT uniqExact(event_id) FROM quality_events FINAL "
+        "WHERE event_type = 'refinement_attempt'",
+        database=scratch_db,
+    )
+    assert gold == silver, (gold, silver)
 
 
 def test_a_fresh_volume_gets_both_tiers_in_the_configured_database() -> None:
@@ -204,11 +302,11 @@ def test_a_fresh_volume_gets_both_tiers_in_the_configured_database() -> None:
         check=True,
     )
     try:
-        tables = _await_tables(container)
+        tables = _await_tables(container, EXPECTED_TABLES)
     finally:
         subprocess.run(["docker", "rm", "-f", container], capture_output=True, check=False)
 
-    assert tables == ["otel_logs", "quality_events", "quality_events_mv"], tables
+    assert tables == EXPECTED_TABLES, tables
 
 
 def _clickhouse_image() -> str:
@@ -219,7 +317,7 @@ def _clickhouse_image() -> str:
     raise AssertionError("clickhouse image not found in docker-compose.yml")
 
 
-def _await_tables(container: str) -> list[str]:
+def _await_tables(container: str, expected: list[str]) -> list[str]:
     """Poll past the entrypoint's temporary init server to the real one."""
     query = [
         "docker",
@@ -236,9 +334,9 @@ def _await_tables(container: str) -> list[str]:
     deadline = time.monotonic() + 90
     while time.monotonic() < deadline:
         completed = subprocess.run(query, capture_output=True, text=True)
-        names = completed.stdout.split()
-        if len(names) == 3:
-            return sorted(names)
+        names = sorted(completed.stdout.split())
+        if names == expected:
+            return names
         time.sleep(2)
     pytest.fail(
         f"fresh container never created the tables: {completed.stdout!r} {completed.stderr!r}"

--- a/tests/test_grafana_clickhouse_datasource_configuration.py
+++ b/tests/test_grafana_clickhouse_datasource_configuration.py
@@ -213,12 +213,27 @@ def test_every_windowed_read_uses_the_dashboard_time_range() -> None:
 
     Retention verification is exempt by design: its whole purpose is to find the
     oldest surviving row, which a time filter would hide. The gold tier is
-    exempt because it is keyed on event_date, not emitted_at_utc.
+    keyed on event_date, a Date, so it takes the date-filter macro instead --
+    exempting it entirely meant it scanned all thirteen months on every refresh
+    and drew an x-axis the time picker did not control.
     """
     for sql in _clickhouse_queries():
-        if "oldest_row" in sql or "quality_events_daily" in sql:
+        if "oldest_row" in sql:
+            continue
+        if "quality_events_daily" in sql and "uniqExactMerge" in sql:
+            assert "$__dateFilter(event_date)" in sql, sql
             continue
         assert "$__timeFilter(emitted_at_utc)" in sql, sql
+
+
+def test_no_panel_counts_the_untyped_default_as_a_failure() -> None:
+    """error_code defaults to '' for rows written before migration 002. Counting
+    that as a failure makes "Failed Attempts" equal total attempts, which reads
+    as a total outage rather than the schema problem it actually is."""
+    for sql in _clickhouse_queries():
+        if "error_code" not in sql:
+            continue
+        assert "error_code != 'none'" not in sql, sql
 
 
 def test_the_dashboard_reads_both_medallion_tiers() -> None:

--- a/tests/test_grafana_clickhouse_datasource_configuration.py
+++ b/tests/test_grafana_clickhouse_datasource_configuration.py
@@ -1,0 +1,277 @@
+"""Grafana must reach ClickHouse over the compose network, never a host port.
+
+Assertions run against `docker compose config` for the local stack (the
+resolved configuration a deploy actually gets), and against the production
+Compose file's own text, mirroring
+tests/test_otel_collector_compose_configuration.py.
+"""
+
+import json
+import os
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).parents[1]
+DATASOURCES_CONFIG = (
+    ROOT / "monitoring" / "grafana-provisioning" / "datasources" / "datasources.yml"
+)
+DASHBOARD = ROOT / "monitoring" / "grafana-dashboards" / "ssf-telemetry.json"
+GITIGNORE = ROOT / ".gitignore"
+
+
+def _services() -> dict:
+    # All nine variables are required: `docker compose config` fails outright if
+    # any interpolation is unsatisfied, including Keycloak's. Mirrors the pattern
+    # in tests/test_otel_collector_compose_configuration.py.
+    with tempfile.NamedTemporaryFile(mode="w", delete=False) as env_file:
+        env_file.write("CLICKHOUSE_DB=ssf_analytics_test\n")
+        env_file.write("CLICKHOUSE_USER=ssf_telemetry_test\n")
+        env_file.write("CLICKHOUSE_PASSWORD=test-only-password\n")
+        env_file.write("KEYCLOAK_DB_NAME=keycloak_test\n")
+        env_file.write("KEYCLOAK_DB_USER=keycloak_test_user\n")
+        env_file.write("KEYCLOAK_DB_PASSWORD=test-only-db-password\n")
+        env_file.write("KEYCLOAK_BOOTSTRAP_ADMIN_USERNAME=bootstrap_admin\n")
+        env_file.write("KEYCLOAK_BOOTSTRAP_ADMIN_PASSWORD=test-only-admin-password\n")
+        env_file.write("KEYCLOAK_HOSTNAME=auth.test.example\n")
+    try:
+        # -f pins to the committed base file only: a developer's local, untracked
+        # docker-compose.override.yml (see CLAUDE.md) may gate monitoring services
+        # behind a profile for convenience, which must not change what this test
+        # verifies about the committed configuration CI actually sees.
+        result = subprocess.run(
+            [
+                "docker",
+                "compose",
+                "-f",
+                "docker-compose.yml",
+                "--env-file",
+                env_file.name,
+                "config",
+            ],
+            cwd=ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    finally:
+        os.unlink(env_file.name)
+    return yaml.safe_load(result.stdout)["services"]
+
+
+def _production() -> dict:
+    return yaml.safe_load(
+        (ROOT / "deploy" / "production" / "docker-compose.production.yml").read_text()
+    )["services"]
+
+
+def _production_env(service: str) -> dict:
+    return dict(
+        entry.split("=", 1) for entry in _production()[service]["environment"] if "=" in entry
+    )
+
+
+def _datasources() -> dict:
+    return yaml.safe_load(DATASOURCES_CONFIG.read_text())
+
+
+def _clickhouse_datasource() -> dict:
+    matches = [d for d in _datasources()["datasources"] if d["uid"] == "clickhouse-ssf"]
+    assert matches, _datasources()["datasources"]
+    return matches[0]
+
+
+def _plugin_pin(env: dict) -> tuple[str, str]:
+    """Split GF_INSTALL_PLUGINS into (id, version).
+
+    Grafana's entrypoint word-splits each comma-separated entry into
+    `grafana cli plugins install <id> <version>`, so a version is pinned by a
+    space, not a colon or an `@`.
+    """
+    parts = env["GF_INSTALL_PLUGINS"].split()
+
+    assert len(parts) == 2, f"plugin version not pinned: {env['GF_INSTALL_PLUGINS']!r}"
+    return parts[0], parts[1]
+
+
+def test_local_grafana_installs_a_pinned_clickhouse_plugin() -> None:
+    """Every production image is pinned by digest; a plugin fetched from
+    grafana.com at each container start must be pinned too, or a restart
+    installs a version the dashboard was never verified against."""
+    plugin_id, version = _plugin_pin(_services()["grafana"]["environment"])
+
+    assert plugin_id == "grafana-clickhouse-datasource"
+    assert re.fullmatch(r"\d+\.\d+\.\d+", version), version
+
+
+def test_local_grafana_has_clickhouse_credentials() -> None:
+    env = _services()["grafana"]["environment"]
+
+    assert env["CLICKHOUSE_DB"] == "ssf_analytics_test"
+    assert env["CLICKHOUSE_USER"] == "ssf_telemetry_test"
+    assert env["CLICKHOUSE_PASSWORD"] == "test-only-password"
+
+
+def test_local_grafana_gets_no_new_public_surface() -> None:
+    """Wiring the datasource must not add a host port or Traefik route to ClickHouse."""
+    clickhouse = _services()["clickhouse"]
+
+    assert clickhouse.get("ports") is None
+    assert clickhouse.get("labels") is None
+
+
+def test_production_grafana_installs_the_same_pinned_plugin() -> None:
+    """Drift between the two stacks means production runs a plugin version
+    nobody verified locally."""
+    assert _plugin_pin(_production_env("grafana")) == _plugin_pin(
+        _services()["grafana"]["environment"]
+    )
+
+
+def test_production_grafana_has_clickhouse_credentials() -> None:
+    env = _production_env("grafana")
+
+    assert {"CLICKHOUSE_DB", "CLICKHOUSE_USER", "CLICKHOUSE_PASSWORD"} <= set(env)
+
+
+def test_production_clickhouse_still_has_no_public_surface() -> None:
+    clickhouse = _production()["clickhouse"]
+
+    assert clickhouse.get("ports") is None
+    assert clickhouse.get("labels") is None
+
+
+def test_clickhouse_datasource_is_provisioned_with_the_right_settings() -> None:
+    datasource = _clickhouse_datasource()
+
+    assert datasource["type"] == "grafana-clickhouse-datasource"
+    assert datasource["access"] == "proxy"
+    assert datasource["editable"] is False
+    assert datasource["jsonData"] == {
+        "host": "clickhouse",
+        "port": 9000,
+        "protocol": "native",
+        "defaultDatabase": "$CLICKHOUSE_DB",
+        "username": "$CLICKHOUSE_USER",
+    }
+    assert datasource["secureJsonData"] == {"password": "$CLICKHOUSE_PASSWORD"}
+
+
+def test_reprovisioning_removes_a_stale_clickhouse_datasource_first() -> None:
+    """Prometheus and Loki are both deleted-then-recreated; ClickHouse must match."""
+    names = {entry["name"] for entry in _datasources()["deleteDatasources"]}
+
+    assert "ClickHouse" in names
+
+
+def test_dashboard_json_is_valid() -> None:
+    json.loads(DASHBOARD.read_text())
+
+
+def _clickhouse_queries() -> list[str]:
+    """Only the ClickHouse targets. The dashboard also carries Prometheus
+    panels for writer health, which have an expr and no rawSql."""
+    dashboard = json.loads(DASHBOARD.read_text())
+    return [
+        " ".join(target["rawSql"].split())
+        for panel in dashboard["panels"]
+        for target in panel.get("targets", [])
+        if target.get("rawSql")
+    ]
+
+
+def test_every_raw_tier_read_deduplicates() -> None:
+    """quality_events is a ReplacingMergeTree: undeduplicated reads double-count
+    rows still awaiting a background merge.
+
+    The gold tier is deliberately exempt. quality_events_daily is an
+    AggregatingMergeTree whose counts are uniqExact over event_id, so it is
+    already idempotent and FINAL there would only cost a merge pass.
+    """
+    queries = _clickhouse_queries()
+    assert queries, "dashboard has no ClickHouse queries"
+
+    # Per FROM clause, not per query: the retention panel unions both tiers, so
+    # asking whether the whole statement mentions FINAL answers nothing.
+    reads = [
+        (match.group(1), bool(match.group(2)))
+        for sql in queries
+        for match in re.finditer(r"FROM\s+(quality_events_daily|quality_events)\b(\s+FINAL)?", sql)
+    ]
+    assert reads, "no reads of either tier"
+
+    for table, deduplicated in reads:
+        assert deduplicated is (table == "quality_events"), (table, deduplicated)
+
+
+def test_every_windowed_read_uses_the_dashboard_time_range() -> None:
+    """A panel that ignores the picker reports the whole retention window and
+    silently disagrees with every other panel on screen.
+
+    Retention verification is exempt by design: its whole purpose is to find the
+    oldest surviving row, which a time filter would hide. The gold tier is
+    exempt because it is keyed on event_date, not emitted_at_utc.
+    """
+    for sql in _clickhouse_queries():
+        if "oldest_row" in sql or "quality_events_daily" in sql:
+            continue
+        assert "$__timeFilter(emitted_at_utc)" in sql, sql
+
+
+def test_the_dashboard_reads_both_medallion_tiers() -> None:
+    """A gold tier nothing reads is a tier nobody notices has stopped filling."""
+    queries = _clickhouse_queries()
+    assert any("quality_events_daily" in sql for sql in queries)
+    assert any("quality_events FINAL" in sql for sql in queries)
+
+
+def test_writer_health_comes_from_prometheus_not_clickhouse() -> None:
+    """ClickHouse cannot report events that never reached it."""
+    dashboard = json.loads(DASHBOARD.read_text())
+    exprs = [
+        target["expr"]
+        for panel in dashboard["panels"]
+        for target in panel.get("targets", [])
+        if target.get("expr")
+    ]
+    assert any("ssf_quality_telemetry_events_total" in e for e in exprs)
+    assert any("otelcol_receiver_accepted_log_records" in e for e in exprs)
+
+
+def test_gitignore_excludes_the_plugin_install_directory() -> None:
+    lines = GITIGNORE.read_text().splitlines()
+
+    assert "monitoring/grafana/plugins/" in lines
+
+
+def test_gitignore_does_not_blanket_ignore_the_grafana_bind_mount() -> None:
+    """monitoring/grafana/alerting/1/__default__.tmpl is a tracked file; a
+    wholesale ignore of monitoring/grafana would silently untrack it."""
+    result = subprocess.run(
+        [
+            "git",
+            "check-ignore",
+            "monitoring/grafana/alerting/1/__default__.tmpl",
+        ],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1, result.stdout
+
+    result = subprocess.run(
+        [
+            "git",
+            "check-ignore",
+            "monitoring/grafana/plugins/grafana-clickhouse-datasource/plugin.json",
+        ],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stdout

--- a/tests/test_otel_collector_compose_configuration.py
+++ b/tests/test_otel_collector_compose_configuration.py
@@ -166,7 +166,7 @@ def test_the_production_collector_is_not_publicly_reachable() -> None:
 
     assert service.get("ports") is None
     assert service.get("labels") is None
-    assert sorted(str(port) for port in service["expose"]) == ["13133", "4318"]
+    assert sorted(str(port) for port in service["expose"]) == ["13133", "4318", "8888"]
 
 
 def test_the_production_collector_mounts_its_config_read_only() -> None:

--- a/tests/test_pipeline_failure_finalisation.py
+++ b/tests/test_pipeline_failure_finalisation.py
@@ -1,0 +1,163 @@
+"""Guards for the audio pipeline's failure path and its duration bookkeeping.
+
+The audio path used to leave three gaps that make any instrumentation built on
+top of it report confident nonsense: a non-200 ASR reply was never checked, so a
+failed transcription became an empty but "successful" translation; failure rows
+carried no millisecond duration and no completion timestamp, so they could not
+be compared with success rows; and the two duration fields were read from two
+separate clock samples, so they disagreed.
+"""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from services.api_gateway.pipeline_logic import (
+    UPSTREAM_BUSY_ERROR_CODE,
+    _finalize_pipeline_success,
+    _mark_pipeline_failure,
+    process_wav,
+)
+
+AUDIO_WAV_MIME = "audio/wav"
+
+
+def _ok_translation() -> Mock:
+    response = Mock()
+    response.status_code = 200
+    response.json.return_value = {"translations": "Hallo Welt"}
+    return response
+
+
+def _ok_tts() -> Mock:
+    response = Mock()
+    response.status_code = 200
+    response.content = b"fake-audio"
+    response.headers = {"content-type": AUDIO_WAV_MIME}
+    return response
+
+
+class TestAudioPipelineAsrFailure:
+    """process_wav must treat a failed ASR as a pipeline failure, not as silence."""
+
+    @patch("services.api_gateway.pipeline_logic.requests.post")
+    def test_a_non_200_asr_reply_fails_the_pipeline(self, mock_post):
+        asr = Mock()
+        asr.status_code = 500
+        asr.json.return_value = {"error": "model not loaded"}
+        # Translation and TTS are stubbed so the defect is observable as a
+        # "successful" empty result rather than as a StopIteration.
+        mock_post.side_effect = [asr, _ok_translation(), _ok_tts()]
+
+        result = process_wav(b"not-really-audio", "en", "de", validate_audio=False)
+
+        assert result["error"] is True
+        assert "ASR" in result["error_msg"]
+        assert result["translation_text"] is None
+        assert result["audio_bytes"] is None
+
+    @patch("services.api_gateway.pipeline_logic.requests.post")
+    def test_a_503_from_asr_keeps_its_transient_meaning(self, mock_post):
+        asr = Mock()
+        asr.status_code = 503
+        asr.headers = {"Retry-After": "7"}
+        asr.json.return_value = {"detail": "overloaded"}
+        mock_post.side_effect = [asr, _ok_translation(), _ok_tts()]
+
+        result = process_wav(b"not-really-audio", "en", "de", validate_audio=False)
+
+        assert result["error"] is True
+        assert result["error_code"] == UPSTREAM_BUSY_ERROR_CODE
+        assert result["retry_after_seconds"] == 7
+
+    @patch("services.api_gateway.pipeline_logic.requests.post")
+    def test_an_unparseable_asr_reply_fails_the_pipeline_instead_of_raising(self, mock_post):
+        asr = Mock()
+        asr.status_code = 200
+        asr.json.side_effect = ValueError("Expecting value: line 1 column 1")
+        mock_post.side_effect = [asr, _ok_translation(), _ok_tts()]
+
+        result = process_wav(b"not-really-audio", "en", "de", validate_audio=False)
+
+        assert result["error"] is True
+        assert result["audio_bytes"] is None
+
+    @patch("services.api_gateway.pipeline_logic.requests.post")
+    def test_an_asr_transport_error_fails_the_pipeline_instead_of_raising(self, mock_post):
+        mock_post.side_effect = OSError("connection reset by peer")
+
+        result = process_wav(b"not-really-audio", "en", "de", validate_audio=False)
+
+        assert result["error"] is True
+        assert result["audio_bytes"] is None
+
+
+class TestFailureFinalisation:
+    """A failure row must carry the same duration bookkeeping as a success row."""
+
+    def test_a_failed_pipeline_records_a_millisecond_duration(self):
+        debug_info = {"steps": []}
+
+        _mark_pipeline_failure(debug_info, 0.0, "ASR-Fehler: boom")
+
+        assert isinstance(debug_info["total_duration_ms"], int)
+
+    def test_a_failed_pipeline_records_its_completion_timestamp(self):
+        debug_info = {"steps": []}
+
+        _mark_pipeline_failure(debug_info, 0.0, "ASR-Fehler: boom")
+
+        assert debug_info["pipeline_completed_at"].endswith("Z")
+
+    @patch("services.api_gateway.pipeline_logic.requests.post")
+    def test_a_failed_audio_pipeline_reports_both_durations(self, mock_post):
+        asr = Mock()
+        asr.status_code = 500
+        asr.json.return_value = {"error": "model not loaded"}
+        mock_post.side_effect = [asr, _ok_translation(), _ok_tts()]
+
+        result = process_wav(b"not-really-audio", "en", "de", validate_audio=False)
+
+        assert result["error"] is True
+        assert isinstance(result["debug"]["total_duration_ms"], int)
+        assert "pipeline_completed_at" in result["debug"]
+
+
+class TestSingleClockRead:
+    """Both duration fields must come from one perf_counter sample, not two.
+
+    A monotonically advancing fake clock makes a second read visibly disagree
+    with the first, which is exactly the drift the production code had.
+    """
+
+    @staticmethod
+    def _advancing_clock():
+        counter = {"reads": 0}
+
+        def perf_counter() -> float:
+            counter["reads"] += 1
+            return float(counter["reads"])
+
+        return perf_counter
+
+    def test_success_finalisation_reads_the_clock_once(self, monkeypatch):
+        monkeypatch.setattr(
+            "services.api_gateway.pipeline_logic.time.perf_counter",
+            self._advancing_clock(),
+        )
+        debug_info = {"steps": []}
+
+        _finalize_pipeline_success(debug_info, 0.0)
+
+        assert debug_info["total_duration_ms"] == pytest.approx(debug_info["total_duration"] * 1000)
+
+    def test_failure_finalisation_reads_the_clock_once(self, monkeypatch):
+        monkeypatch.setattr(
+            "services.api_gateway.pipeline_logic.time.perf_counter",
+            self._advancing_clock(),
+        )
+        debug_info = {"steps": []}
+
+        _mark_pipeline_failure(debug_info, 0.0, "ASR-Fehler: boom")
+
+        assert debug_info["total_duration_ms"] == pytest.approx(debug_info["total_duration"] * 1000)

--- a/tests/test_pipeline_failure_finalisation.py
+++ b/tests/test_pipeline_failure_finalisation.py
@@ -11,6 +11,7 @@ separate clock samples, so they disagreed.
 from unittest.mock import Mock, patch
 
 import pytest
+from requests import exceptions
 
 from services.api_gateway.pipeline_logic import (
     UPSTREAM_BUSY_ERROR_CODE,
@@ -161,3 +162,74 @@ class TestSingleClockRead:
         _mark_pipeline_failure(debug_info, 0.0, "ASR-Fehler: boom")
 
         assert debug_info["total_duration_ms"] == pytest.approx(debug_info["total_duration"] * 1000)
+
+
+class TestTheExceptionPathDoesNotLeakInternals:
+    """The audio route serialises error_msg and debug straight to the browser
+    (routes/pipeline.py), so a raw requests exception there discloses the
+    internal service hostname and port."""
+
+    @staticmethod
+    def _transport_error() -> Exception:
+        """The exception requests actually raises for an unreachable upstream."""
+        return exceptions.ConnectionError(
+            "HTTPConnectionPool(host='asr', port=8001): Max retries exceeded "
+            "with url: /transcribe (Caused by NewConnectionError(...))"
+        )
+
+    @patch("services.api_gateway.pipeline_logic.requests.post")
+    def test_the_upstream_hostname_and_port_are_not_in_the_result(self, mock_post):
+        mock_post.side_effect = self._transport_error()
+
+        result = process_wav(b"not-really-audio", "en", "de", validate_audio=False)
+
+        rendered = f"{result['error_msg']} {result['debug']}"
+        assert "HTTPConnectionPool" not in rendered
+        assert "8001" not in rendered
+        assert "Max retries exceeded" not in rendered
+
+    @patch("services.api_gateway.pipeline_logic.requests.post")
+    def test_the_failure_carries_a_stable_code_instead(self, mock_post):
+        mock_post.side_effect = self._transport_error()
+
+        result = process_wav(b"not-really-audio", "en", "de", validate_audio=False)
+
+        assert result["debug"]["error_code"] == "upstream_unreachable"
+
+    @patch("services.api_gateway.pipeline_logic.requests.post")
+    def test_a_timeout_is_classified_as_a_timeout(self, mock_post):
+        mock_post.side_effect = TimeoutError("read timed out")
+
+        result = process_wav(b"not-really-audio", "en", "de", validate_audio=False)
+
+        assert result["debug"]["error_code"] == "upstream_timeout"
+
+
+class TestTheExceptionPathKeepsWhatItAlreadyHas:
+    """The explicit non-200 branches pass the real asr_text and
+    translation_text; the exception branch discarded both. Two failure modes of
+    the same step should not produce two different payloads."""
+
+    @patch("services.api_gateway.pipeline_logic.requests.post")
+    def test_a_tts_transport_failure_keeps_the_transcript(self, mock_post):
+        asr = Mock()
+        asr.status_code = 200
+        asr.json.return_value = {"text": "Hello world"}
+        translation = _ok_translation()
+        mock_post.side_effect = [asr, translation, OSError("connection reset")]
+
+        result = process_wav(b"not-really-audio", "en", "de", validate_audio=False)
+
+        assert result["error"] is True
+        assert result["asr_text"] == "Hello world"
+        assert result["translation_text"] == "Hallo Welt"
+        assert result["audio_bytes"] is None
+
+    @patch("services.api_gateway.pipeline_logic.requests.post")
+    def test_an_asr_transport_failure_still_has_nothing_to_keep(self, mock_post):
+        mock_post.side_effect = OSError("connection reset")
+
+        result = process_wav(b"not-really-audio", "en", "de", validate_audio=False)
+
+        assert result["asr_text"] is None
+        assert result["translation_text"] is None

--- a/tests/test_quality_events_schema_contract.py
+++ b/tests/test_quality_events_schema_contract.py
@@ -1,0 +1,131 @@
+"""Static guards on the ClickHouse migrations, as the fourth allowlist consumer.
+
+`test_otel_collector_compose_configuration.py` already proves the view reads
+*only* allowlisted keys. That is one direction. The failure mode this file
+exists for is the other one: a key opened in Python and in the collector but
+never given a column, which makes the field vanish between the collector and
+the table with no error anywhere in the pipeline.
+
+These are text guards, not container guards, so they run in CI. The applied
+behaviour (TTL actually set, inserts actually landing) is covered by
+`tests/integration/test_quality_events_schema_apply.py`.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+from services.api_gateway.quality_telemetry import ALLOWED_ATTRIBUTE_KEYS
+
+MIGRATIONS = Path(__file__).resolve().parents[1] / "deploy" / "clickhouse" / "migrations"
+
+SILVER = MIGRATIONS / "001_quality_events.sql"
+GOLD = MIGRATIONS / "002_quality_events_fields_and_gold.sql"
+
+# The envelope keys 001 already projects; everything else must arrive in 002.
+ENVELOPE_KEYS = {"ssf.quality.event_id", "ssf.quality.schema_version"}
+
+
+def _sql() -> str:
+    return "\n".join(path.read_text() for path in sorted(MIGRATIONS.glob("*.sql")))
+
+
+def _projected_attribute_keys(sql: str) -> set[str]:
+    return set(re.findall(r"LogAttributes\['([^']+)'\]", sql))
+
+
+class TestEveryAllowlistedKeyReachesAColumn:
+    def test_no_allowlisted_key_is_dropped_between_collector_and_table(self):
+        missing = set(ALLOWED_ATTRIBUTE_KEYS) - _projected_attribute_keys(_sql())
+        assert not missing, f"allowlisted but never projected into a column: {missing}"
+
+    def test_the_migrations_project_nothing_outside_the_allowlist(self):
+        extra = _projected_attribute_keys(_sql()) - set(ALLOWED_ATTRIBUTE_KEYS)
+        assert not extra, f"projected but not allowlisted: {extra}"
+
+    @pytest.mark.parametrize("key", sorted(set(ALLOWED_ATTRIBUTE_KEYS) - ENVELOPE_KEYS))
+    def test_each_non_envelope_key_is_projected_by_the_second_migration(self, key):
+        assert key in _projected_attribute_keys(GOLD.read_text())
+
+
+class TestSilverGainsTypedColumns:
+    def test_the_new_columns_are_added_rather_than_recreated(self):
+        """Production's table already exists, so 002 must ALTER, never CREATE."""
+        sql = GOLD.read_text()
+        assert "ALTER TABLE quality_events" in sql
+        assert "DROP TABLE quality_events" not in sql
+
+    def test_adding_a_column_twice_is_safe(self):
+        adds = re.findall(r"ADD COLUMN(?! IF NOT EXISTS)", GOLD.read_text())
+        assert not adds, "every ADD COLUMN must be IF NOT EXISTS; apply.sh re-runs"
+
+    @pytest.mark.parametrize(
+        "column",
+        [
+            "refiner_role",
+            "model_ref",
+            "refinement_outcome",
+            "refinement_latency_ms",
+            "refinement_changed",
+            "source_lang",
+            "target_lang",
+            "error_code",
+        ],
+    )
+    def test_the_silver_table_has_a_column_for_each_new_field(self, column):
+        assert re.search(rf"ADD COLUMN IF NOT EXISTS\s+{column}\b", GOLD.read_text())
+
+    def test_numeric_projections_cannot_throw(self):
+        """A view that throws fails the INSERT into otel_logs; the collector
+        then retries that batch forever."""
+        sql = GOLD.read_text()
+        assert "toUInt32OrZero(LogAttributes['ssf.quality.refinement_latency_ms'])" in sql
+
+
+class TestGoldTier:
+    def test_the_gold_table_exists(self):
+        assert "CREATE TABLE IF NOT EXISTS quality_events_daily" in GOLD.read_text()
+
+    def test_the_gold_tier_expires_after_thirteen_months(self):
+        assert re.search(r"TTL\s+event_date\s*\+\s*INTERVAL\s+13\s+MONTH", GOLD.read_text())
+
+    def test_the_raw_tier_keeps_its_thirty_day_retention(self):
+        """002 must not silently change what 001 fixed at table creation."""
+        assert re.search(r"INTERVAL\s+30\s+DAY", SILVER.read_text())
+        assert "MODIFY TTL" not in GOLD.read_text()
+
+    def test_the_gold_tier_aggregates_rather_than_stores_rows(self):
+        assert "AggregatingMergeTree" in GOLD.read_text()
+
+    def test_counting_is_idempotent_under_duplicate_delivery(self):
+        """A retried export inserts the bronze row twice, and the silver
+        ReplacingMergeTree only collapses it at merge time -- so the gold tier
+        must count distinct event_ids, not rows, or a retry inflates it."""
+        sql = GOLD.read_text()
+        assert "uniqExactState(event_id)" in sql
+        assert "uniqExactStateIf(event_id, refinement_changed = 1)" in sql
+        # A sumState-based counter reported 2 for one duplicated event while
+        # uniqExact reported 1; no plain counter may return.
+        assert "countState()" not in sql
+        assert "sumState(" not in sql
+
+    def test_the_gold_view_is_fed_from_silver(self):
+        assert re.search(
+            r"CREATE MATERIALIZED VIEW IF NOT EXISTS quality_events_daily_mv\s+TO\s+quality_events_daily",
+            GOLD.read_text(),
+        )
+
+
+class TestMigrationIsIdempotent:
+    def test_every_create_is_guarded(self):
+        unguarded = re.findall(
+            r"CREATE (?:TABLE|MATERIALIZED VIEW)(?! IF NOT EXISTS)", GOLD.read_text()
+        )
+        assert not unguarded
+
+    def test_the_silver_view_is_modified_in_place_not_dropped(self):
+        """DROP VIEW leaves a window where inserts are not projected at all."""
+        sql = GOLD.read_text()
+        assert "ALTER TABLE quality_events_mv MODIFY QUERY" in sql
+        assert "DROP VIEW" not in sql

--- a/tests/test_quality_telemetry_alerting.py
+++ b/tests/test_quality_telemetry_alerting.py
@@ -1,0 +1,108 @@
+"""Writer-health alerts and the scrape that makes them possible (task 3.3).
+
+Delivery here is lossy by design: the SDK's BatchLogRecordProcessor drops on
+overflow and does not surface that in `ssf_quality_telemetry_events_total`.
+That blind spot is why task 2.1 cannot be decided yet, so the instrument that
+closes it is part of this work rather than a follow-up.
+
+The gap between what the gateway counted as queued and what the collector
+counted as received *is* the SDK's drop. Neither number alone can show it.
+
+Every collector metric named here was read from a running 0.159.0 collector's
+:8888 endpoint, not from documentation.
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+ALERTS = ROOT / "monitoring" / "alert_rules.yml"
+PROMETHEUS = ROOT / "monitoring" / "prometheus.yml"
+COLLECTOR = ROOT / "monitoring" / "otel-collector-config.yaml"
+
+GROUP = "ssf-quality-telemetry"
+
+
+def _rules() -> dict[str, dict]:
+    """Empty rather than raising when the group is absent, so a deleted group
+    fails these tests one by one instead of erroring the whole collection."""
+    groups = yaml.safe_load(ALERTS.read_text())["groups"]
+    group = next((g for g in groups if g["name"] == GROUP), None)
+    return {rule["alert"]: rule for rule in group["rules"]} if group else {}
+
+
+class TestTheCollectorIsScrapeable:
+    def test_the_collector_exposes_its_internal_metrics_off_localhost(self):
+        """The default binds localhost, which no other container can reach."""
+        telemetry = yaml.safe_load(COLLECTOR.read_text())["service"]["telemetry"]
+        reader = telemetry["metrics"]["readers"][0]["pull"]["exporter"]["prometheus"]
+        assert reader["host"] == "0.0.0.0"
+        assert reader["port"] == 8888
+
+    def test_prometheus_scrapes_the_collector(self):
+        config = yaml.safe_load(PROMETHEUS.read_text())
+        jobs = {j["job_name"]: j for j in config["scrape_configs"]}
+        assert "otel_collector" in jobs
+        targets = jobs["otel_collector"]["static_configs"][0]["targets"]
+        assert targets == ["otel-collector:8888"]
+
+    @pytest.mark.parametrize(
+        "compose",
+        ["docker-compose.yml", "deploy/production/docker-compose.production.yml"],
+    )
+    def test_the_metrics_port_is_exposed_but_not_published(self, compose):
+        """expose, never ports: the collector stays internal to the network."""
+        service = yaml.safe_load((ROOT / compose).read_text())["services"]["otel-collector"]
+        assert "8888" in [str(p) for p in service["expose"]]
+        assert "ports" not in service
+
+
+class TestWriterHealthAlerts:
+    @pytest.mark.parametrize(
+        "alert",
+        [
+            "QualityTelemetryExportFailing",
+            "QualityTelemetryAttributeRejected",
+            "QualityTelemetryEventsLostBeforeCollector",
+            "QualityTelemetryClickHouseWritesFailing",
+            "QualityTelemetryExporterQueueFilling",
+            "QualityTelemetryCollectorRefusingRecords",
+            "QualityTelemetryCollectorDown",
+        ],
+    )
+    def test_the_alert_exists(self, alert):
+        assert alert in _rules()
+
+    def test_the_sdk_drop_is_measured_as_a_gap_not_a_counter(self):
+        """There is no counter for it. The gateway counts what it queued and
+        the collector counts what arrived; only the difference reveals a drop."""
+        expr = _rules()["QualityTelemetryEventsLostBeforeCollector"]["expr"]
+        assert 'ssf_quality_telemetry_events_total{outcome="emitted"}' in expr
+        assert "otelcol_receiver_accepted_log_records" in expr
+
+    def test_a_rejected_attribute_alerts_without_a_delay(self):
+        """dropped_disallowed means the six places disagree -- a code defect
+        that silently loses a field, not a transient condition to wait out."""
+        rule = _rules()["QualityTelemetryAttributeRejected"]
+        assert 'outcome="dropped_disallowed"' in rule["expr"]
+        assert rule.get("for", "0m") in ("0m", None)
+
+    @pytest.mark.parametrize("alert", sorted(_rules()))
+    def test_every_alert_says_what_to_do(self, alert):
+        annotations = _rules()[alert]["annotations"]
+        assert annotations["summary"].strip()
+        assert annotations["description"].strip()
+
+    @pytest.mark.parametrize("alert", sorted(_rules()))
+    def test_every_alert_is_labelled_as_telemetry(self, alert):
+        labels = _rules()[alert]["labels"]
+        assert labels["component"] == "quality-telemetry"
+        assert labels["severity"] in ("warning", "critical")
+
+    def test_telemetry_failure_is_never_critical(self):
+        """Telemetry is optional; the gateway is not. A dead collector must not
+        page anyone at 03:00 -- translation is unaffected by design."""
+        severities = {a: r["labels"]["severity"] for a, r in _rules().items()}
+        assert set(severities.values()) == {"warning"}, severities

--- a/tests/test_quality_telemetry_contract.py
+++ b/tests/test_quality_telemetry_contract.py
@@ -192,9 +192,42 @@ def test_event_name_is_not_an_attribute() -> None:
     assert "event.name" not in to_otlp_attributes(_event())
 
 
-def test_allowlist_contains_no_content_namespaces() -> None:
-    forbidden = ("text", "audio", "error", "ip", "transcript", "body")
-    assert not [k for k in ALLOWED_ATTRIBUTE_KEYS if any(f in k for f in forbidden)]
+# Whole segments, not substrings. The previous substring form rejected "ip"
+# inside "pipeline" and "error" inside "error_code" -- a closed enum, not a
+# message -- so it could not survive the allowlist widening past the envelope.
+# The real invariant now lives in the manifest: every key declares a value
+# shape, and there is no free-text kind to declare. This stays as a naming
+# tripwire on top of that.
+_CONTENT_SEGMENT = re.compile(
+    r"(?:^|[._])(?:text|transcript|message|detail|payload|url|uri|ip|body|prompt"
+    r"|email|username|useragent|token|secret)(?:[._]|$)"
+)
+
+
+def test_allowlist_contains_no_content_bearing_segment() -> None:
+    offenders = [k for k in ALLOWED_ATTRIBUTE_KEYS if _CONTENT_SEGMENT.search(k)]
+    assert not offenders, offenders
+
+
+@pytest.mark.parametrize(
+    "content_key",
+    [
+        "ssf.quality.source_text",
+        "ssf.quality.asr_transcript",
+        "ssf.quality.error_message",
+        "ssf.quality.audio_url",
+        "net.peer.ip",
+        "ssf.quality.request_body",
+    ],
+)
+def test_the_naming_tripwire_rejects_a_content_bearing_key(content_key: str) -> None:
+    """Proving the guard fails: without this the regex above could match nothing."""
+    assert _CONTENT_SEGMENT.search(content_key)
+
+
+def test_no_attribute_may_be_declared_as_free_text() -> None:
+    """The structural guarantee behind the naming tripwire."""
+    assert not [k for k in dir(contract.AttributeKind) if k in ("TEXT", "FREEFORM")]
 
 
 @pytest.mark.parametrize(
@@ -204,7 +237,7 @@ def test_allowlist_contains_no_content_namespaces() -> None:
         ("probe", TelemetryMode.PROBE),
         ("  PROBE  ", TelemetryMode.PROBE),
         ("true", TelemetryMode.DISABLED),
-        ("enabled", TelemetryMode.DISABLED),
+        ("enabled", TelemetryMode.ENABLED),
         ("", TelemetryMode.DISABLED),
         (None, TelemetryMode.DISABLED),
     ],

--- a/tests/test_quality_telemetry_lifespan.py
+++ b/tests/test_quality_telemetry_lifespan.py
@@ -13,6 +13,7 @@ from fastapi.testclient import TestClient
 
 from services.api_gateway.app import app
 from services.api_gateway.quality_telemetry import TelemetryMode
+from services.api_gateway.translation_refiner import translation_refiner
 
 
 def _batch_threads() -> list[str]:
@@ -24,7 +25,7 @@ def _quiet_env(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
     monkeypatch.setenv("SSF_AUDIO_BASE_DIR", str(tmp_path))
 
 
-@pytest.mark.parametrize("bad_mode", ["enabled", "true", "1", "on", "", "  ", "PROBE!"])
+@pytest.mark.parametrize("bad_mode", ["true", "1", "on", "", "  ", "PROBE!"])
 def test_an_unknown_mode_disables_telemetry_instead_of_killing_the_gateway(
     monkeypatch: pytest.MonkeyPatch, bad_mode: str
 ) -> None:
@@ -113,9 +114,7 @@ def test_a_wedged_telemetry_shutdown_does_not_hold_the_gateway_open(
     try:
         with TestClient(app):
             app.state.quality_telemetry_exporter.shutdown()
-            monkeypatch.setattr(
-                app.state, "quality_telemetry_exporter", _WedgedExporter()
-            )
+            monkeypatch.setattr(app.state, "quality_telemetry_exporter", _WedgedExporter())
             started = time.monotonic()
         elapsed = time.monotonic() - started
     finally:
@@ -136,8 +135,31 @@ def test_a_failing_telemetry_shutdown_is_reported_and_teardown_continues(
 
     with TestClient(app):
         app.state.quality_telemetry_exporter.shutdown()
-        monkeypatch.setattr(
-            app.state, "quality_telemetry_exporter", _BrokenExporter()
-        )
+        monkeypatch.setattr(app.state, "quality_telemetry_exporter", _BrokenExporter())
 
     assert "collector connection reset" in capsys.readouterr().out
+
+
+def test_the_shadow_refiner_is_given_the_telemetry_the_lifespan_built(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The refiner is a module-level singleton created at import time, while
+    telemetry is built per lifespan -- so the two only meet if the lifespan
+    says so. Without this the refinement event silently never fires."""
+    monkeypatch.setenv("SSF_QUALITY_TELEMETRY_MODE", "enabled")
+
+    with TestClient(app):
+        assert translation_refiner.quality_telemetry is app.state.quality_telemetry
+
+
+def test_the_refiner_is_released_when_the_lifespan_ends(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stale QualityTelemetry outliving its exporter would emit into a
+    provider that has already been shut down."""
+    monkeypatch.setenv("SSF_QUALITY_TELEMETRY_MODE", "enabled")
+
+    with TestClient(app):
+        pass
+
+    assert translation_refiner.quality_telemetry is None

--- a/tests/test_quality_telemetry_lifespan.py
+++ b/tests/test_quality_telemetry_lifespan.py
@@ -163,3 +163,48 @@ def test_the_refiner_is_released_when_the_lifespan_ends(
         pass
 
     assert translation_refiner.quality_telemetry is None
+
+
+def test_a_registry_that_cannot_take_the_counter_still_yields_telemetry() -> None:
+    """The counter helper reached into registry._names_to_collectors, a private
+    attribute. A prometheus_client rename, or a non-Counter collector already
+    holding the name, raised inside lifespan -- so an optional subsystem could
+    take down translation, sessions and WebSocket delivery."""
+    from prometheus_client import CollectorRegistry, Gauge
+
+    from services.api_gateway.quality_telemetry import _events_counter
+
+    registry = CollectorRegistry()
+    Gauge(
+        "ssf_quality_telemetry_events_total",
+        "an impostor holding the name",
+        registry=registry,
+    )
+
+    counter = _events_counter(registry)
+
+    counter.labels(outcome="emitted").inc()
+
+
+def test_a_hostile_registry_leaves_a_serving_gateway(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """QualityTelemetry sat outside the exporter's fallback-to-disabled block,
+    so a registry it could not register into raised inside lifespan.
+
+    The counter helper now ends every path in a counter, so this asserts the
+    outcome that matters -- a gateway that serves, with telemetry present and
+    usable -- rather than a specific internal fallback.
+    """
+    monkeypatch.setenv("SSF_QUALITY_TELEMETRY_MODE", "enabled")
+
+    class _HostileRegistry:
+        def register(self, _collector):
+            raise RuntimeError("registry moved")
+
+    monkeypatch.setattr(app.state, "prometheus_registry", _HostileRegistry())
+
+    with TestClient(app) as client:
+        assert client.get("/health").status_code == 200
+        assert app.state.quality_telemetry is not None
+        app.state.quality_telemetry.emit_probe(event_type="telemetry_probe")

--- a/tests/test_quality_telemetry_otlp.py
+++ b/tests/test_quality_telemetry_otlp.py
@@ -14,6 +14,7 @@ from services.api_gateway.quality_telemetry_otlp import build_otlp_exporter
 
 ROOT = pathlib.Path(__file__).parents[1]
 CONTRACT_MODULE = ROOT / "services" / "api_gateway" / "quality_telemetry.py"
+_EVENT_ID = "6f1b2c3d-4e5f-4a6b-8c9d-0e1f2a3b4c5d"
 _EMITTED_AT = datetime(2026, 9, 1, 12, 34, 56, tzinfo=timezone.utc)
 
 
@@ -91,7 +92,7 @@ def test_the_resource_carries_only_the_three_declared_fields(
     exporter = _build(monkeypatch, sink)
 
     try:
-        exporter("telemetry_probe", {"ssf.quality.event_id": "abc"}, _EMITTED_AT)
+        exporter("telemetry_probe", {'ssf.quality.event_id': _EVENT_ID}, _EMITTED_AT)
 
         resource = _one_record(exporter, sink).resource
         assert dict(resource.attributes) == {
@@ -118,7 +119,7 @@ def test_the_events_own_emission_time_becomes_the_otlp_timestamp(exported) -> No
     """Silver's emitted_at_utc must be the event's time, not an exporter fallback."""
     exporter, sink = exported
 
-    exporter("telemetry_probe", {"ssf.quality.event_id": "abc"}, _EMITTED_AT)
+    exporter("telemetry_probe", {'ssf.quality.event_id': _EVENT_ID}, _EMITTED_AT)
 
     record = _one_record(exporter, sink).log_record
     assert record.timestamp is not None
@@ -129,7 +130,7 @@ def test_the_exporter_always_sends_an_empty_body(exported) -> None:
     """Body must always be empty — the bronze table indexes lower(Body)."""
     exporter, sink = exported
 
-    exporter("telemetry_probe", {"ssf.quality.event_id": "abc"}, _EMITTED_AT)
+    exporter("telemetry_probe", {'ssf.quality.event_id': _EVENT_ID}, _EMITTED_AT)
 
     assert _one_record(exporter, sink).log_record.body == ""
 
@@ -138,7 +139,7 @@ def test_the_event_type_travels_as_the_top_level_event_name(exported) -> None:
     """Not as an attribute — it must reach the typed EventName column."""
     exporter, sink = exported
 
-    exporter("telemetry_probe", {"ssf.quality.event_id": "abc"}, _EMITTED_AT)
+    exporter("telemetry_probe", {'ssf.quality.event_id': _EVENT_ID}, _EMITTED_AT)
 
     record = _one_record(exporter, sink).log_record
     assert record.event_name == "telemetry_probe"

--- a/tests/test_quality_telemetry_refinement_emit.py
+++ b/tests/test_quality_telemetry_refinement_emit.py
@@ -64,7 +64,7 @@ def _refiner(monkeypatch, telemetry, *, outcome: RefinementOutcome):
         def __init__(self, *args, **kwargs) -> None:
             pass
 
-        def refine(self, *args, **kwargs) -> RefinementOutcome:
+        def _perform_refinement(self, *args, **kwargs) -> RefinementOutcome:
             return outcome
 
     monkeypatch.setattr(
@@ -125,9 +125,18 @@ class TestTheModeGatesPipelineEvents:
 
 class TestTheEventDescribesWhatHappened:
     def test_a_failed_candidate_is_classified_not_quoted(self, monkeypatch):
+        """Asserts the specific code, not merely that it differs from `none`.
+
+        The weaker assertion passed while every failure collapsed to
+        `internal_error`, which is exactly the bug it should have caught.
+        """
         exporter = _RecordingExporter()
         outcome = RefinementOutcome(
-            text="Hallo", changed=False, latency_ms=12.0, error="connection refused"
+            text="Hallo",
+            changed=False,
+            latency_ms=12.0,
+            error="connection refused",
+            error_code=QualityErrorCode.UPSTREAM_UNREACHABLE,
         )
         refiner = _refiner(
             monkeypatch, _telemetry(TelemetryMode.ENABLED, exporter), outcome=outcome
@@ -137,7 +146,7 @@ class TestTheEventDescribesWhatHappened:
 
         _, attributes, _ = exporter.calls[0]
         assert attributes["ssf.quality.refinement_outcome"] == "error"
-        assert attributes["ssf.quality.error_code"] != "none"
+        assert attributes["ssf.quality.error_code"] == QualityErrorCode.UPSTREAM_UNREACHABLE.value
         assert "connection refused" not in str(attributes)
 
     def test_keyword_call_sites_still_yield_the_languages(self, monkeypatch):
@@ -222,3 +231,128 @@ class TestTelemetryNeverChangesTheRefiner:
             {"outcome": ProbeOutcome.EMITTED.value},
         )
         assert emitted == 1.0
+
+
+class TestThePrimaryPathEmitsToo:
+    """Production runs LLM_REFINEMENT_MODE=primary_only, so a refinement event
+    reachable only from the shadow candidate is a dashboard that is empty
+    exactly where it matters. RefinerRole.PRIMARY must be reachable."""
+
+    @staticmethod
+    def _primary(monkeypatch, telemetry, *, payload=None, raises=None):
+        from services.api_gateway.translation_refiner import OllamaTranslationRefiner
+
+        refiner = OllamaTranslationRefiner("http://ollama:11434", "gpt-oss:20b", 4.0, 0.7, 1, False)
+        refiner.attach_quality_telemetry(telemetry)
+
+        def post(*_args, **_kwargs):
+            if raises is not None:
+                raise raises
+            response = Mock()
+            response.status_code = 200
+            response.raise_for_status.return_value = None
+            response.json.return_value = payload
+            return response
+
+        monkeypatch.setattr("services.api_gateway.translation_refiner.requests.post", post)
+        return refiner
+
+    def test_a_primary_refinement_emits_with_the_primary_role(self, monkeypatch):
+        exporter = _RecordingExporter()
+        refiner = self._primary(
+            monkeypatch,
+            _telemetry(TelemetryMode.ENABLED, exporter),
+            payload={"response": "Hallo Welt"},
+        )
+
+        refiner.refine("Hello world", "en", "de")
+
+        assert len(exporter.calls) == 1
+        _, attributes, _ = exporter.calls[0]
+        assert attributes["ssf.quality.refiner_role"] == RefinerRole.PRIMARY.value
+        assert attributes["ssf.quality.model_ref"] == "gpt-oss:20b"
+        assert attributes["ssf.quality.error_code"] == QualityErrorCode.NONE.value
+
+    def test_a_primary_timeout_records_upstream_timeout_not_internal_error(self, monkeypatch):
+        from requests import exceptions
+
+        exporter = _RecordingExporter()
+        refiner = self._primary(
+            monkeypatch,
+            _telemetry(TelemetryMode.ENABLED, exporter),
+            raises=exceptions.ReadTimeout("read timed out"),
+        )
+
+        refiner.refine("Hello world", "en", "de")
+
+        _, attributes, _ = exporter.calls[0]
+        assert attributes["ssf.quality.error_code"] == QualityErrorCode.UPSTREAM_TIMEOUT.value
+        assert attributes["ssf.quality.refinement_outcome"] == "error"
+
+    def test_a_noop_refiner_emits_nothing(self, monkeypatch):
+        """No refinement happened, so there is no attempt to record."""
+        from services.api_gateway.translation_refiner import NoOpTranslationRefiner
+
+        exporter = _RecordingExporter()
+        refiner = NoOpTranslationRefiner()
+        refiner.attach_quality_telemetry(_telemetry(TelemetryMode.ENABLED, exporter))
+
+        refiner.refine("Hello world", "en", "de")
+
+        assert exporter.calls == []
+
+
+class TestShadowQueueOverloadIsVisible:
+    """`skipped_overload` and `submission_failed` are reserved enum members and
+    were unreachable: the candidate never runs, so nothing emitted them."""
+
+    @staticmethod
+    def _shadow(monkeypatch, telemetry, *, pending):
+        refiner = ShadowComparisonRefiner(
+            "http://ollama:11434",
+            "gpt-oss:20b",
+            4.0,
+            0.7,
+            1,
+            False,
+            candidate_model="phi4-mini",
+            queue_limit=1,
+        )
+        refiner.attach_quality_telemetry(telemetry)
+        refiner.pending = pending
+
+        def post(*_args, **_kwargs):
+            response = Mock()
+            response.status_code = 200
+            response.raise_for_status.return_value = None
+            response.json.return_value = {"response": "Hallo Welt"}
+            return response
+
+        monkeypatch.setattr("services.api_gateway.translation_refiner.requests.post", post)
+        return refiner
+
+    def test_a_skipped_candidate_is_recorded(self, monkeypatch):
+        exporter = _RecordingExporter()
+        refiner = self._shadow(monkeypatch, _telemetry(TelemetryMode.ENABLED, exporter), pending=1)
+
+        outcome = refiner.refine("Hello world", "en", "de")
+
+        assert outcome.candidate_status == "skipped_overload"
+        roles = [a["ssf.quality.refiner_role"] for _, a, _ in exporter.calls]
+        outcomes = [a["ssf.quality.refinement_outcome"] for _, a, _ in exporter.calls]
+        assert RefinerRole.PRIMARY.value in roles
+        assert RefinementOutcomeCode.SKIPPED_OVERLOAD.value in outcomes
+
+    def test_a_skipped_candidate_reports_the_candidate_model(self, monkeypatch):
+        exporter = _RecordingExporter()
+        refiner = self._shadow(monkeypatch, _telemetry(TelemetryMode.ENABLED, exporter), pending=1)
+
+        refiner.refine("Hello world", "en", "de")
+
+        skipped = [
+            a
+            for _, a, _ in exporter.calls
+            if a["ssf.quality.refinement_outcome"] == RefinementOutcomeCode.SKIPPED_OVERLOAD.value
+        ]
+        assert skipped[0]["ssf.quality.model_ref"] == "phi4-mini"
+        assert skipped[0]["ssf.quality.error_code"] == QualityErrorCode.REFINEMENT_OVERLOADED.value

--- a/tests/test_quality_telemetry_refinement_emit.py
+++ b/tests/test_quality_telemetry_refinement_emit.py
@@ -1,0 +1,224 @@
+"""The first real pipeline event: one row per shadow refinement attempt.
+
+`ShadowComparisonRefiner._run_candidate` already measures candidate latency and
+throws it away into a log line. This is the pilot for the six-places workflow --
+small enough to get right, and every field a number or a closed enum, so it
+carries no privacy risk by construction.
+
+Task 2.4 applies here too: the refiner must behave identically whether telemetry
+is off, attached, or attached to something broken.
+"""
+
+from unittest.mock import Mock
+
+import pytest
+
+from prometheus_client import CollectorRegistry
+
+from services.api_gateway.quality_telemetry import (
+    ProbeOutcome,
+    QualityErrorCode,
+    QualityTelemetry,
+    RefinerRole,
+    RefinementOutcomeCode,
+    TelemetryMode,
+)
+from services.api_gateway.translation_refiner import (
+    RefinementOutcome,
+    ShadowComparisonRefiner,
+)
+
+
+class _RecordingExporter:
+    def __init__(self) -> None:
+        self.calls: list[tuple] = []
+
+    def __call__(self, event_name, attributes, emitted_at_utc) -> None:
+        self.calls.append((event_name, dict(attributes), emitted_at_utc))
+
+
+def _telemetry(mode: TelemetryMode, exporter=None, registry=None) -> QualityTelemetry:
+    return QualityTelemetry(
+        mode=mode,
+        exporter=exporter or _RecordingExporter(),
+        registry=registry or CollectorRegistry(),
+    )
+
+
+def _refiner(monkeypatch, telemetry, *, outcome: RefinementOutcome):
+    refiner = ShadowComparisonRefiner(
+        "http://ollama:11434",
+        "gpt-oss:20b",
+        4.0,
+        0.7,
+        1,
+        False,
+        candidate_model="phi4-mini",
+        queue_limit=4,
+    )
+    refiner.attach_quality_telemetry(telemetry)
+
+    # The candidate refiner is constructed inside _run_candidate; stub the
+    # class it builds so no HTTP happens.
+    class _StubCandidate:
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+        def refine(self, *args, **kwargs) -> RefinementOutcome:
+            return outcome
+
+    monkeypatch.setattr(
+        "services.api_gateway.translation_refiner.OllamaTranslationRefiner",
+        _StubCandidate,
+    )
+    refiner.pending = 1
+    return refiner
+
+
+def _success() -> RefinementOutcome:
+    return RefinementOutcome(text="Hallo Welt", changed=True, latency_ms=340.0)
+
+
+class TestTheModeGatesPipelineEvents:
+    def test_enabled_emits_one_refinement_attempt(self, monkeypatch):
+        exporter = _RecordingExporter()
+        refiner = _refiner(
+            monkeypatch, _telemetry(TelemetryMode.ENABLED, exporter), outcome=_success()
+        )
+
+        refiner._run_candidate("Hello world", "en", "de")
+
+        assert len(exporter.calls) == 1
+        event_name, attributes, _ = exporter.calls[0]
+        assert event_name == "refinement_attempt"
+        assert attributes["ssf.quality.refiner_role"] == RefinerRole.CANDIDATE.value
+        assert attributes["ssf.quality.model_ref"] == "phi4-mini"
+        assert attributes["ssf.quality.refinement_outcome"] == "success"
+        assert attributes["ssf.quality.refinement_latency_ms"] == "340"
+        assert attributes["ssf.quality.refinement_changed"] == "true"
+        assert attributes["ssf.quality.source_lang"] == "en"
+        assert attributes["ssf.quality.target_lang"] == "de"
+        assert attributes["ssf.quality.error_code"] == QualityErrorCode.NONE.value
+
+    def test_probe_mode_emits_no_pipeline_events(self, monkeypatch):
+        """PROBE stays a pure transport check, so dev does not start emitting
+        production volume merely by upgrading."""
+        exporter = _RecordingExporter()
+        refiner = _refiner(
+            monkeypatch, _telemetry(TelemetryMode.PROBE, exporter), outcome=_success()
+        )
+
+        refiner._run_candidate("Hello world", "en", "de")
+
+        assert exporter.calls == []
+
+    def test_disabled_emits_nothing(self, monkeypatch):
+        exporter = _RecordingExporter()
+        refiner = _refiner(
+            monkeypatch, _telemetry(TelemetryMode.DISABLED, exporter), outcome=_success()
+        )
+
+        refiner._run_candidate("Hello world", "en", "de")
+
+        assert exporter.calls == []
+
+
+class TestTheEventDescribesWhatHappened:
+    def test_a_failed_candidate_is_classified_not_quoted(self, monkeypatch):
+        exporter = _RecordingExporter()
+        outcome = RefinementOutcome(
+            text="Hallo", changed=False, latency_ms=12.0, error="connection refused"
+        )
+        refiner = _refiner(
+            monkeypatch, _telemetry(TelemetryMode.ENABLED, exporter), outcome=outcome
+        )
+
+        refiner._run_candidate("Hello world", "en", "de")
+
+        _, attributes, _ = exporter.calls[0]
+        assert attributes["ssf.quality.refinement_outcome"] == "error"
+        assert attributes["ssf.quality.error_code"] != "none"
+        assert "connection refused" not in str(attributes)
+
+    def test_keyword_call_sites_still_yield_the_languages(self, monkeypatch):
+        exporter = _RecordingExporter()
+        refiner = _refiner(
+            monkeypatch, _telemetry(TelemetryMode.ENABLED, exporter), outcome=_success()
+        )
+
+        refiner._run_candidate("Hello", source_lang="fr", target_lang="ar")
+
+        _, attributes, _ = exporter.calls[0]
+        assert attributes["ssf.quality.source_lang"] == "fr"
+        assert attributes["ssf.quality.target_lang"] == "ar"
+
+    def test_an_unusable_language_is_recorded_as_undetermined(self, monkeypatch):
+        """Better a row marked `und` than no row: dropping the event would make
+        the denominator wrong for every ratio built on it."""
+        exporter = _RecordingExporter()
+        refiner = _refiner(
+            monkeypatch, _telemetry(TelemetryMode.ENABLED, exporter), outcome=_success()
+        )
+
+        refiner._run_candidate("Hello", "not a language code", "de")
+
+        _, attributes, _ = exporter.calls[0]
+        assert attributes["ssf.quality.source_lang"] == "und"
+
+    def test_a_missing_latency_is_recorded_as_zero(self, monkeypatch):
+        exporter = _RecordingExporter()
+        outcome = RefinementOutcome(text="Hallo", changed=False, latency_ms=None)
+        refiner = _refiner(
+            monkeypatch, _telemetry(TelemetryMode.ENABLED, exporter), outcome=outcome
+        )
+
+        refiner._run_candidate("Hello", "en", "de")
+
+        _, attributes, _ = exporter.calls[0]
+        assert attributes["ssf.quality.refinement_latency_ms"] == "0"
+
+
+class TestTelemetryNeverChangesTheRefiner:
+    """Task 2.4, at the one call site that exists so far."""
+
+    def test_an_exploding_exporter_does_not_break_the_candidate_run(self, monkeypatch):
+        def explode(*_args, **_kwargs):
+            raise RuntimeError("clickhouse is gone")
+
+        refiner = _refiner(
+            monkeypatch, _telemetry(TelemetryMode.ENABLED, explode), outcome=_success()
+        )
+
+        refiner._run_candidate("Hello world", "en", "de")
+
+        assert refiner.pending == 0, "the queue slot must still be released"
+
+    def test_a_refiner_with_no_telemetry_attached_still_runs(self, monkeypatch):
+        refiner = _refiner(monkeypatch, _telemetry(TelemetryMode.ENABLED), outcome=_success())
+        refiner.attach_quality_telemetry(None)
+
+        refiner._run_candidate("Hello world", "en", "de")
+
+        assert refiner.pending == 0
+
+    def test_a_broken_telemetry_object_does_not_break_the_candidate_run(self, monkeypatch):
+        broken = Mock()
+        broken.emit_refinement_attempt.side_effect = RuntimeError("boom")
+        refiner = _refiner(monkeypatch, broken, outcome=_success())
+
+        refiner._run_candidate("Hello world", "en", "de")
+
+        assert refiner.pending == 0
+
+    def test_the_outcome_is_counted_for_the_operator(self, monkeypatch):
+        registry = CollectorRegistry()
+        telemetry = _telemetry(TelemetryMode.ENABLED, registry=registry)
+        refiner = _refiner(monkeypatch, telemetry, outcome=_success())
+
+        refiner._run_candidate("Hello world", "en", "de")
+
+        emitted = registry.get_sample_value(
+            "ssf_quality_telemetry_events_total",
+            {"outcome": ProbeOutcome.EMITTED.value},
+        )
+        assert emitted == 1.0

--- a/tests/test_quality_telemetry_taxonomy.py
+++ b/tests/test_quality_telemetry_taxonomy.py
@@ -1,0 +1,205 @@
+"""The event and error taxonomy: closed, typed, and incapable of carrying content.
+
+Task 1.1 asks for versioned, typed, allowlisted event models and a stable error
+taxonomy; 3.1 and 3.2 constrain every field to a number, a closed enum, or an
+opaque reference. Those are the same requirement seen from two sides, so they
+are enforced here as one rule: an attribute may only be emitted if the manifest
+declares what shape its value has, and the value must actually have that shape.
+
+Name-based checks alone cannot do this -- `error_code` reads like content and is
+not, `translation_duration_ms` reads like content and is not -- so the manifest
+declares a kind per key and the value is checked against it.
+"""
+
+from datetime import datetime, timezone
+from uuid import uuid4
+
+import pytest
+
+from services.api_gateway.quality_telemetry import (
+    ALLOWED_ATTRIBUTE_KEYS,
+    ALLOWED_ATTRIBUTES,
+    SCHEMA_VERSION,
+    AttributeKind,
+    DisallowedTelemetryAttribute,
+    DisallowedTelemetryValue,
+    PipelineStage,
+    QualityErrorCode,
+    QualityEventType,
+    RefinementAttemptEvent,
+    RefinerRole,
+    RefinementOutcomeCode,
+    TelemetryMode,
+    classify_upstream_status,
+    classify_exception,
+    enforce_value_shapes,
+    to_otlp_attributes,
+)
+
+REFINEMENT_KEYS = {
+    "ssf.quality.refiner_role",
+    "ssf.quality.model_ref",
+    "ssf.quality.refinement_outcome",
+    "ssf.quality.refinement_latency_ms",
+    "ssf.quality.refinement_changed",
+    "ssf.quality.source_lang",
+    "ssf.quality.target_lang",
+    "ssf.quality.error_code",
+}
+
+
+def _refinement_event(**overrides) -> RefinementAttemptEvent:
+    defaults = dict(
+        event_id=uuid4(),
+        schema_version=SCHEMA_VERSION,
+        emitted_at_utc=datetime.now(timezone.utc),
+        event_type=QualityEventType.REFINEMENT_ATTEMPT,
+        refiner_role=RefinerRole.CANDIDATE,
+        model_ref="phi4-mini",
+        outcome=RefinementOutcomeCode.SUCCESS,
+        latency_ms=340,
+        changed=True,
+        source_lang="en",
+        target_lang="de",
+        error_code=QualityErrorCode.NONE,
+    )
+    defaults.update(overrides)
+    return RefinementAttemptEvent(**defaults)
+
+
+class TestManifestIsClosed:
+    def test_every_allowlisted_key_declares_a_value_shape(self):
+        assert set(ALLOWED_ATTRIBUTES) == set(ALLOWED_ATTRIBUTE_KEYS)
+
+    def test_every_enum_attribute_declares_a_non_empty_closed_value_set(self):
+        enums = {
+            key: spec for key, spec in ALLOWED_ATTRIBUTES.items() if spec.kind is AttributeKind.ENUM
+        }
+        assert enums, "the manifest should declare at least one closed enum"
+        assert all(spec.values for spec in enums.values())
+
+    def test_no_attribute_is_declared_as_free_text(self):
+        """There is deliberately no free-text kind. If one appears, this fails."""
+        assert not hasattr(AttributeKind, "TEXT")
+        assert not hasattr(AttributeKind, "FREEFORM")
+
+
+class TestValueShapesAreEnforced:
+    def test_the_shipped_refinement_event_passes_its_own_shape_check(self):
+        enforce_value_shapes(to_otlp_attributes(_refinement_event()))
+
+    def test_a_value_outside_a_closed_enum_is_rejected(self):
+        attributes = to_otlp_attributes(_refinement_event())
+        attributes["ssf.quality.error_code"] = "asr returned 500: model not loaded"
+        with pytest.raises(DisallowedTelemetryValue):
+            enforce_value_shapes(attributes)
+
+    def test_a_sentence_in_a_label_slot_is_rejected(self):
+        attributes = to_otlp_attributes(_refinement_event())
+        attributes["ssf.quality.model_ref"] = "Übersetze folgenden Satz ins Deutsche"
+        with pytest.raises(DisallowedTelemetryValue):
+            enforce_value_shapes(attributes)
+
+    def test_a_non_numeric_value_in_a_number_slot_is_rejected(self):
+        attributes = to_otlp_attributes(_refinement_event())
+        attributes["ssf.quality.refinement_latency_ms"] = "quite slow"
+        with pytest.raises(DisallowedTelemetryValue):
+            enforce_value_shapes(attributes)
+
+    def test_a_transcript_in_a_language_slot_is_rejected(self):
+        attributes = to_otlp_attributes(_refinement_event())
+        attributes["ssf.quality.source_lang"] = "guten Tag, wie geht es Ihnen"
+        with pytest.raises(DisallowedTelemetryValue):
+            enforce_value_shapes(attributes)
+
+
+class TestRefinementAttemptEvent:
+    def test_it_maps_exactly_the_expected_attribute_keys(self):
+        envelope = {"ssf.quality.event_id", "ssf.quality.schema_version"}
+        assert set(to_otlp_attributes(_refinement_event())) == envelope | REFINEMENT_KEYS
+
+    def test_every_mapped_key_is_on_the_allowlist(self):
+        assert set(to_otlp_attributes(_refinement_event())) <= ALLOWED_ATTRIBUTE_KEYS
+
+    def test_every_mapped_value_is_a_string(self):
+        values = to_otlp_attributes(_refinement_event()).values()
+        assert all(isinstance(value, str) for value in values)
+
+    def test_it_is_immutable(self):
+        from dataclasses import FrozenInstanceError
+
+        event = _refinement_event()
+        with pytest.raises(FrozenInstanceError):
+            event.latency_ms = 1
+
+    def test_it_rejects_a_negative_latency(self):
+        with pytest.raises(ValueError):
+            _refinement_event(latency_ms=-1)
+
+    def test_it_rejects_a_model_reference_that_could_carry_a_sentence(self):
+        with pytest.raises(ValueError):
+            _refinement_event(model_ref="please translate the following text")
+
+    def test_it_cannot_be_constructed_with_a_content_field(self):
+        with pytest.raises(TypeError):
+            _refinement_event(source_text="guten Tag")
+
+
+class TestErrorTaxonomyIsStable:
+    @pytest.mark.parametrize(
+        ("status", "expected"),
+        [
+            (200, QualityErrorCode.NONE),
+            (503, QualityErrorCode.UPSTREAM_BUSY),
+            (504, QualityErrorCode.UPSTREAM_TIMEOUT),
+            (500, QualityErrorCode.UPSTREAM_ERROR),
+            (400, QualityErrorCode.UPSTREAM_REJECTED),
+        ],
+    )
+    def test_an_upstream_status_maps_to_a_stable_code(self, status, expected):
+        assert classify_upstream_status(status) is expected
+
+    @pytest.mark.parametrize(
+        ("exception", "expected"),
+        [
+            (TimeoutError(), QualityErrorCode.UPSTREAM_TIMEOUT),
+            (ConnectionError(), QualityErrorCode.UPSTREAM_UNREACHABLE),
+            (ValueError("Expecting value"), QualityErrorCode.UPSTREAM_MALFORMED_RESPONSE),
+            (RuntimeError("boom"), QualityErrorCode.INTERNAL_ERROR),
+        ],
+    )
+    def test_an_exception_maps_to_a_stable_code(self, exception, expected):
+        assert classify_exception(exception) is expected
+
+    def test_classification_never_carries_the_original_message(self):
+        code = classify_exception(RuntimeError("ASR said: guten Tag, wie geht es"))
+        assert code.value in {member.value for member in QualityErrorCode}
+        assert "guten Tag" not in code.value
+
+    def test_classification_never_raises_on_an_unexpected_exception(self):
+        class Weird(Exception):
+            pass
+
+        assert classify_exception(Weird()) is QualityErrorCode.INTERNAL_ERROR
+
+    def test_every_error_code_is_a_lowercase_token(self):
+        for member in QualityErrorCode:
+            assert member.value == member.value.lower()
+            assert " " not in member.value
+
+    def test_every_pipeline_stage_is_a_lowercase_token(self):
+        for member in PipelineStage:
+            assert member.value == member.value.lower()
+            assert " " not in member.value
+
+
+class TestTelemetryModeGainsAnEventsValue:
+    def test_enabled_is_a_distinct_mode(self):
+        assert TelemetryMode.parse("enabled") is TelemetryMode.ENABLED
+        assert TelemetryMode.ENABLED is not TelemetryMode.PROBE
+
+    def test_probe_keeps_its_existing_meaning(self):
+        assert TelemetryMode.parse("probe") is TelemetryMode.PROBE
+
+    def test_an_unknown_mode_still_falls_back_to_disabled(self):
+        assert TelemetryMode.parse("on") is TelemetryMode.DISABLED

--- a/tests/test_quality_telemetry_taxonomy.py
+++ b/tests/test_quality_telemetry_taxonomy.py
@@ -203,3 +203,68 @@ class TestTelemetryModeGainsAnEventsValue:
 
     def test_an_unknown_mode_still_falls_back_to_disabled(self):
         assert TelemetryMode.parse("on") is TelemetryMode.DISABLED
+
+
+class TestTheAdapterIsActuallyTheLastCheckpoint:
+    """`__call__` enforced only the key allowlist, while value shapes were
+    checked in to_otlp_attributes. Any emitter building its own dict therefore
+    shipped an unvalidated value for an allowlisted key -- exactly the
+    error_code-carrying-a-raw-message case the manifest exists to prevent."""
+
+    @staticmethod
+    def _adapter():
+        from unittest.mock import Mock
+
+        from services.api_gateway.quality_telemetry_otlp import OtlpQualityExporter
+
+        provider = Mock()
+        provider.get_logger.return_value = Mock()
+        return OtlpQualityExporter(provider), provider.get_logger.return_value
+
+    def test_an_allowlisted_key_with_a_raw_message_is_rejected_at_the_wire(self):
+        from datetime import datetime, timezone
+
+        adapter, sink = self._adapter()
+        smuggled = {
+            "ssf.quality.event_id": str(uuid4()),
+            "ssf.quality.schema_version": "1",
+            "ssf.quality.error_code": "ASR said: guten Tag, wie geht es Ihnen",
+        }
+
+        with pytest.raises(DisallowedTelemetryValue):
+            adapter("refinement_attempt", smuggled, datetime.now(timezone.utc))
+
+        sink.emit.assert_not_called()
+
+    def test_a_well_formed_event_still_ships(self):
+        adapter, sink = self._adapter()
+        event = _refinement_event()
+
+        adapter(
+            event.event_type.value,
+            to_otlp_attributes(event),
+            event.emitted_at_utc,
+        )
+
+        sink.emit.assert_called_once()
+
+
+class TestShapePatternsRejectTrailingWhitespaceAndUnicodeDigits:
+    """`$` matches before a trailing newline and `\\d` accepts Unicode digits,
+    so a guard whose stated purpose is that a label carry no whitespace was
+    accepting `gpt-oss:20b\\n`."""
+
+    @pytest.mark.parametrize(
+        ("key", "value"),
+        [
+            ("ssf.quality.model_ref", "gpt-oss:20b\n"),
+            ("ssf.quality.refinement_latency_ms", "123\n"),
+            ("ssf.quality.source_lang", "de\n"),
+            ("ssf.quality.refinement_latency_ms", "١٢٣"),
+        ],
+    )
+    def test_the_value_is_rejected(self, key, value):
+        attributes = to_otlp_attributes(_refinement_event())
+        attributes[key] = value
+        with pytest.raises(DisallowedTelemetryValue):
+            enforce_value_shapes(attributes)

--- a/tests/test_refinement_error_classification.py
+++ b/tests/test_refinement_error_classification.py
@@ -1,0 +1,91 @@
+"""The refinement error taxonomy must survive the trip to the emitter.
+
+`RefinementOutcome.error` is a string. Classifying it at the emitter by
+wrapping it in `RuntimeError` cannot work: `classify_exception` matches on the
+exception class MRO, and RuntimeError's MRO intersects none of the name sets, so
+every failure collapses to `internal_error` and the whole enum reduces to one
+value. The type only exists at the catch site, so that is where it must be read.
+"""
+
+from unittest.mock import Mock
+
+import pytest
+from requests import exceptions
+
+from services.api_gateway.quality_telemetry import QualityErrorCode
+from services.api_gateway.translation_refiner import OllamaTranslationRefiner
+
+
+def _refiner(**kwargs) -> OllamaTranslationRefiner:
+    return OllamaTranslationRefiner(
+        "http://ollama:11434", "phi4-mini", 4.0, 0.7, kwargs.pop("max_retries", 0), False
+    )
+
+
+@pytest.mark.parametrize(
+    ("raised", "expected"),
+    [
+        (exceptions.ConnectTimeout("timed out"), QualityErrorCode.UPSTREAM_TIMEOUT),
+        (exceptions.ReadTimeout("read timed out"), QualityErrorCode.UPSTREAM_TIMEOUT),
+        (exceptions.ConnectionError("refused"), QualityErrorCode.UPSTREAM_UNREACHABLE),
+        (ValueError("Expecting value"), QualityErrorCode.UPSTREAM_MALFORMED_RESPONSE),
+        (RuntimeError("something else"), QualityErrorCode.INTERNAL_ERROR),
+    ],
+)
+def test_a_transport_failure_keeps_its_class(monkeypatch, raised, expected):
+    def boom(*_args, **_kwargs):
+        raise raised
+
+    monkeypatch.setattr("services.api_gateway.translation_refiner.requests.post", boom)
+
+    outcome = _refiner().refine("Hello", "en", "de")
+
+    assert outcome.error_code is expected
+
+
+def test_an_http_status_is_classified_by_its_status_not_its_class(monkeypatch):
+    """raise_for_status raises one class for every status; 503 is not a 500."""
+    response = Mock()
+    response.status_code = 503
+    error = exceptions.HTTPError("503 Server Error")
+    error.response = response
+    response.raise_for_status.side_effect = error
+    monkeypatch.setattr(
+        "services.api_gateway.translation_refiner.requests.post",
+        lambda *a, **k: response,
+    )
+
+    outcome = _refiner().refine("Hello", "en", "de")
+
+    assert outcome.error_code is QualityErrorCode.UPSTREAM_BUSY
+
+
+def test_an_empty_reply_is_a_malformed_response(monkeypatch):
+    response = Mock()
+    response.status_code = 200
+    response.raise_for_status.return_value = None
+    response.json.return_value = {"response": "   "}
+    monkeypatch.setattr(
+        "services.api_gateway.translation_refiner.requests.post",
+        lambda *a, **k: response,
+    )
+
+    outcome = _refiner().refine("Hello", "en", "de")
+
+    assert outcome.error_code is QualityErrorCode.UPSTREAM_MALFORMED_RESPONSE
+
+
+def test_a_successful_refinement_carries_no_error_code(monkeypatch):
+    response = Mock()
+    response.status_code = 200
+    response.raise_for_status.return_value = None
+    response.json.return_value = {"response": "Hallo Welt"}
+    monkeypatch.setattr(
+        "services.api_gateway.translation_refiner.requests.post",
+        lambda *a, **k: response,
+    )
+
+    outcome = _refiner().refine("Hello", "en", "de")
+
+    assert outcome.error_code is QualityErrorCode.NONE
+    assert outcome.error is None


### PR DESCRIPTION
Part 1 of 3 for `add-clickhouse-quality-telemetry` (issue #199 delivered only
section 5, the transport probe). Closes tasks **1.1, 1.3, 3.1, 3.3, 4.1, 4.4**.

**Labelled Do Not Merge at the author's request** — this is up for review, not
for merging yet.

## Why these things are together

The Grafana work alone would ship a dashboard that is **empty in production**:
the mode is `disabled` there, so no row can exist. A dashboard is only worth
reviewing next to something to put on it, so the schema, the first real event
and the dashboard land together.

## Three commits

1. **`fix(pipeline)`** — three defect fixes on the audio path. Deliberately
   isolated so it can be split into its own PR if review gets unwieldy; it
   depends on nothing else here.
2. **`feat(telemetry)`** — the taxonomy, migration `002`, and
   `refinement_attempt`.
3. **`feat(monitoring)`** — datasource, dashboard, writer-health alerts, runbook.

## The pipeline defect fixes

`process_wav` had **no `try:` anywhere in its body** and never checked the ASR
status code, so `asr_resp.json()` ran unguarded. A non-200 reply became an empty
string that went on to be "successfully" translated, and a transport error
propagated out with no `debug_info` finalisation — the audio path's failure rows
went missing entirely. `process_text_pipeline` has wrapped its body and checked
its upstream statuses all along.

`_mark_pipeline_failure` also set only `total_duration`, so failure rows carried
no millisecond duration and no completion timestamp and could not be compared
with success rows. And the two duration fields were two separate
`perf_counter()` reads that disagreed by however long collecting system metrics
took.

Instrumenting any of this unfixed would produce confident-looking wrong answers.

**Behaviour diff, success path:** `total_duration_ms` and
`pipeline_completed_at` are unchanged in value and position. Only
`total_duration` moves, to agree with `total_duration_ms`.

**Behaviour diff, failure path:** a transport exception no longer propagates
out of `process_wav` as an HTTP 500. It returns `error=True`, which
`routes/pipeline.py` serialises as **HTTP 400** — matching
`process_text_pipeline`, which has behaved this way all along. A retryable
outage is therefore reported to the client as a permanent error on both paths;
unifying that is out of scope here and wants its own change.

The raw exception no longer reaches the client on either path. `error_msg` and
`debug` are both serialised to the browser, and a `requests` exception carries
the internal service hostname and port, so the detail now goes to the server
log and the response carries the stable taxonomy code instead.

## Two design decisions worth a reviewer's attention

**The allowlist is now a manifest with a value shape per key.** There is
deliberately no free-text kind to declare, so an `error_code` carrying a raw
upstream message is rejected as firmly as an unknown key would be. Key-only
allowlisting stops a *new* field leaking content; this also stops an *existing*
field being used as a smuggling channel.

**`TelemetryMode` gains `ENABLED`; `PROBE` keeps its exact shipped meaning.**
`probe` emits no pipeline events, so an operator can verify the path end to end
without switching on production volume — and a deployment already running
`probe` does not start emitting real events merely by being upgraded.

## A bug the tests did not catch

The gold tier double-counted retries. Static guards passed while a live
duplicated delivery produced `events: 1, changed: 2` — `uniqExactState(event_id)`
was idempotent but `sumState` was not, and an aggregate cannot be un-counted.
Every gold counter is now `uniqExact` over `event_id`, verified live at `1, 1`,
with an integration test and a guard that bans `sumState(` outright.

The latency aggregates keep the skew, because `avg` and the t-digest have no
distinct-by form. That is documented in the migration rather than hidden, and
bounded by the retry rate the new alerts make visible.

## Making the SDK's invisible drops measurable

The OTel SDK's `BatchLogRecordProcessor` drops on queue overflow and reports it
**nowhere** — not in `ssf_quality_telemetry_events_total`, not as an
`export_failed` outcome. The gateway counts what it *queued*; the collector
counts what *arrived*; the gap is the only measurement of the loss.

`QualityTelemetryEventsLostBeforeCollector` is that gap. It is the evidence task
2.1 should be decided on in PR 3 — if it stays at zero at production volume, the
SDK's 2048-event queue is adequate and that is a finding, not a gap.

Every alert is a **warning** by design: telemetry is optional and a dead
collector cannot affect translation, sessions or WebSocket delivery, so none of
this should page anyone.

## Verification

- **708 passed, 52 skipped** (baseline 589), plus **12 integration passed** with
  `--run-integration`.
- **11 mutations, all rejected, restored green after each.** Every new guard was
  watched failing before being trusted.
- Migration `002` applied to a scratch database and re-applied for idempotency.
- Alert rules validated with `promtool check rules`: 35 rules found.
- Collector metric names read from a running 0.159.0 collector, not from docs.
- Every dashboard query run against a live ClickHouse.
- **Full six-places proof:** an OTLP record carrying all eight fields plus a
  smuggled `ssf.quality.SMUGGLED_TEXT` attribute — all eight land typed in
  silver, gold aggregates correctly, and the smuggled attribute is **0 rows in
  bronze**. The collector's independent layer holds against a sender that
  bypasses the gateway entirely.

## Not verified

- **Production internals.** ClickHouse has no host port or Traefik route by
  design and host access was unavailable. Confirmed remotely only that
  `/api/admin/telemetry/probe` is in production's live `openapi.json`.
- **Grafana panel rendering.** The dashboard provisions with zero errors and
  Grafana registers a live channel for its uid, but the API could not be
  authenticated, so the JSON and the SQL were validated instead of panels drawn.
- `openspec validate --strict` — the CLI is not installed on the dev machine.

## Deployment note

**Merging changes nothing in production**: the mode stays `disabled` in
`deploy/production/docker-compose.production.yml`.

Turning it on is runbook step 11, and **order matters**. Emitting
`refinement_attempt` while migration `002` is unapplied writes rows whose typed
columns are all defaults, and those rows **cannot be repaired** — the attributes
are dropped at projection time and bronze expires after 7 days. `initdb` does
not re-run on a volume that already has data, so `apply.sh` must be run by hand.
The dashboard's `Rows Missing Typed Fields` panel exists to catch exactly this.

## Still open

`1.2` and `3.2` are **not** ticked. `1.2` names session and translation records,
which arrive with their emitters in PRs 2 and 3; `3.2` needs consent snapshots
and content references, and nothing emitted so far refers to content at all.
`tasks.md` says so in place.

Next: PR 2 (`translation_message`) closes 2.3, 2.4 and 4.3.

