### PR TITLE
fix(report): reconcile work package status evidence

### DIFF
--- a/apps/project-report/scripts/project-status-sync.mjs
+++ b/apps/project-report/scripts/project-status-sync.mjs
@@ -55,10 +55,7 @@ const healthFor = (items, fallback) => {
   return healths.reduce((current, health) => healthSeverity[health] > healthSeverity[current] ? health : current);
 };
 
-const matchesWorkPackage = (workPackage, item) =>
-  item.workPackageId === workPackage.id ||
-  item.workPackageIds?.includes(workPackage.id) ||
-  workPackage.tracking?.githubIssues?.includes(item.issueNumber);
+const matchesWorkPackage = (workPackage, item) => item.workPackageId === workPackage.id;
 
 export const applyProjectSnapshot = (report, projectItems, updatedAt) => {
   const result = structuredClone(report);

--- a/apps/project-report/scripts/project-status-sync.test.mjs
+++ b/apps/project-report/scripts/project-status-sync.test.mjs
@@ -13,9 +13,9 @@ const report = () => ({
 });
 
 describe('applyProjectSnapshot', () => {
-  it('derives work-package status and health from matching issue and draft Project items', () => {
+  it('derives work-package status and health from primary Project work-package items', () => {
     const result = applyProjectSnapshot(report(), [
-      { issueNumber: 189, status: 'Implementation', health: 'At risk' },
+      { workPackageId: 'WP-001', status: 'Implementation', health: 'At risk' },
       { workPackageId: 'WP-002', status: 'Done', health: 'On track' },
     ], '2026-08-31');
 
@@ -26,10 +26,21 @@ describe('applyProjectSnapshot', () => {
     expect(result.meta.updatedAt).toBe('2026-08-31');
   });
 
-  it('does not regress a package to done until every matching item is done', () => {
+  it('does not use an issue-linked Project item without a primary work package as status evidence', () => {
     const result = applyProjectSnapshot(report(), [
       { issueNumber: 189, status: 'Done', health: 'On track' },
-      { issueNumber: 189, status: 'Planned', health: 'Needs attention' },
+    ], '2026-08-31');
+
+    expect(result.milestones[0].workPackages[0]).toMatchObject({
+      status: 'planned',
+      health: 'on_track',
+    });
+  });
+
+  it('does not regress a package to done until every matching item is done', () => {
+    const result = applyProjectSnapshot(report(), [
+      { workPackageId: 'WP-001', status: 'Done', health: 'On track' },
+      { workPackageId: 'WP-001', status: 'Planned', health: 'Needs attention' },
     ], '2026-08-31');
 
     expect(result.milestones[0].workPackages[0]).toMatchObject({ status: 'planned', health: 'needs_attention' });
@@ -40,7 +51,7 @@ describe('applyProjectSnapshot', () => {
     recovered.milestones[0].workPackages[0].health = 'blocked';
 
     const result = applyProjectSnapshot(recovered, [
-      { issueNumber: 189, status: 'Implementation', health: 'On track' },
+      { workPackageId: 'WP-001', status: 'Implementation', health: 'On track' },
     ], '2026-08-31');
 
     expect(result.milestones[0].workPackages[0]).toMatchObject({ health: 'on_track' });
@@ -48,8 +59,8 @@ describe('applyProjectSnapshot', () => {
 
   it('preserves the current status when a matching Project item has no recognized status', () => {
     const result = applyProjectSnapshot(report(), [
-      { issueNumber: 189, status: 'Done', health: 'On track' },
-      { issueNumber: 189, status: undefined, health: 'On track' },
+      { workPackageId: 'WP-001', status: 'Done', health: 'On track' },
+      { workPackageId: 'WP-001', status: undefined, health: 'On track' },
     ], '2026-08-31');
 
     expect(result.milestones[0].workPackages[0]).toMatchObject({ status: 'planned' });
@@ -63,14 +74,14 @@ describe('applyProjectSnapshot', () => {
     expect(result.milestones[0].workPackages[1]).toMatchObject({ status: 'prototype', health: 'on_track' });
   });
 
-  it('updates every work package named in a multi-package Project link', () => {
+  it('does not use a multi-package roadmap link as package-status evidence', () => {
     const result = applyProjectSnapshot(report(), [
       { workPackageIds: ['WP-001', 'WP-002'], status: 'Testing', health: 'On track' },
     ], '2026-08-31');
 
     expect(result.milestones[0].workPackages).toMatchObject([
-      { id: 'WP-001', status: 'testing' },
-      { id: 'WP-002', status: 'testing' },
+      { id: 'WP-001', status: 'planned' },
+      { id: 'WP-002', status: 'planned' },
     ]);
   });
 });

--- a/plugins/project-steward/scripts/priority-report.mjs
+++ b/plugins/project-steward/scripts/priority-report.mjs
@@ -32,6 +32,18 @@ const statusByProjectStatus = {
   Done: 'done',
 };
 
+const statusProgress = {
+  idea: 0,
+  commissioned: 0,
+  planned: 10,
+  prototype: 20,
+  implementation: 45,
+  optimization: 70,
+  testing: 80,
+  acceptance: 90,
+  done: 100,
+};
+
 const parseDeadline = (title) => {
   const match = /Deadline:\s*(\d{2})\.(\d{2})\.(\d{4})/.exec(title ?? '');
   return match ? `${match[3]}-${match[2]}-${match[1]}` : undefined;
@@ -51,14 +63,19 @@ const rationaleFor = (workPackage, dependencyState, dependentCount, deadline) =>
   return rationale;
 };
 
-const projectItemsFor = (workPackage, projectItems) => projectItems.filter((item) => {
-  const linkedWorkPackages = String(item['roadmap links'] ?? item['roadmap Links'] ?? item['Roadmap links'] ?? '')
-    .split(',')
-    .map((value) => value.trim());
-  return item['work Package'] === workPackage.id
-    || linkedWorkPackages.includes(workPackage.id)
-    || workPackage.tracking?.githubIssues?.includes(item.content?.number);
-});
+const projectItemsFor = (workPackage, projectItems) => projectItems.filter(
+  (item) => item['work Package'] === workPackage.id,
+);
+
+const statusForProjectItems = (items) => {
+  const statuses = items
+    .map((item) => statusByProjectStatus[item.status])
+    .filter(Boolean);
+  if (statuses.length === 0) return undefined;
+  return statuses.reduce((leastAdvanced, status) => (
+    statusProgress[status] < statusProgress[leastAdvanced] ? status : leastAdvanced
+  ));
+};
 
 const linkedIssuesFor = (workPackage, issues) => issues
   .filter((issue) => workPackage.tracking?.githubIssues?.includes(issue.number));
@@ -91,9 +108,12 @@ const resolveStatus = (workPackage, evidence) => {
       .filter((decision) => decision.workPackageId === workPackage.id && decision.status)
       .map((decision) => ({ status: decision.status, source: 'documented project decision' })),
     github: [
-      ...projectItemsFor(workPackage, evidence.projectItems?.items ?? [])
-        .map((item) => ({ status: statusByProjectStatus[item.status], source: 'GitHub Project' }))
-        .filter((item) => item.status),
+      ...(() => {
+        const status = statusForProjectItems(
+          projectItemsFor(workPackage, evidence.projectItems?.items ?? []),
+        );
+        return status ? [{ status, source: 'GitHub Project' }] : [];
+      })(),
       ...linkedIssuesFor(workPackage, evidence.issues ?? [])
         .flatMap((issue) => String(issue.state ?? 'OPEN').toUpperCase() === 'OPEN'
           ? [{ status: 'planned', source: `GitHub issue #${issue.number}` }]

--- a/plugins/project-steward/scripts/priority-report.test.mjs
+++ b/plugins/project-steward/scripts/priority-report.test.mjs
@@ -138,7 +138,7 @@ describe('rankWorkPackages', () => {
       issues: [{ number: 42, state: 'CLOSED' }],
     }, { limit: 3, today: '2026-08-30' });
 
-    expect(result.priorities[0]).toMatchObject({
+    expect(result.priorities.find((item) => item.workPackageId === 'WP-001')).toMatchObject({
       workPackageId: 'WP-001',
       status: 'planned',
       source: 'project-status.json',
@@ -181,7 +181,7 @@ describe('rankWorkPackages', () => {
     expect(result.conflicts).toEqual([]);
   });
 
-  it('reports conflicting GitHub Project status instead of silently ranking it', () => {
+  it('uses the least advanced primary GitHub Project status for a work package', () => {
     const result = rankEvidence({
       projectStatus: report(),
       projectItems: { items: [
@@ -190,15 +190,58 @@ describe('rankWorkPackages', () => {
       ] },
     }, { limit: 3, today: '2026-08-30' });
 
-    expect(result.conflicts).toEqual([{
+    expect(result.conflicts).toEqual([]);
+    expect(result.priorities[0]).toMatchObject({
       workPackageId: 'WP-001',
+      status: 'planned',
       source: 'GitHub Project',
-      field: 'status',
-      values: ['Done', 'Planned'],
-    }]);
-    expect(result.priorities.map((item) => item.workPackageId)).not.toContain('WP-001');
-    expect(renderPriorityMarkdown(result)).toContain('## Conflicts');
-    expect(renderPriorityMarkdown(result)).toContain('WP-001: GitHub Project status conflicts (Done, Planned). No plan update.');
+    });
+  });
+
+  it('does not use a roadmap link as status evidence for another work package', () => {
+    const result = rankEvidence({
+      projectStatus: report(),
+      projectItems: { items: [
+        {
+          status: 'Done',
+          health: 'On track',
+          'work Package': 'WP-002',
+          'roadmap links': 'WP-001, WP-002',
+        },
+        {
+          status: 'Planned',
+          health: 'On track',
+          'work Package': 'WP-001',
+        },
+      ] },
+    }, { limit: 3, today: '2026-08-30' });
+
+    expect(result.conflicts).toEqual([]);
+    expect(result.priorities[0]).toMatchObject({
+      workPackageId: 'WP-001',
+      status: 'planned',
+      source: 'GitHub Project',
+    });
+  });
+
+  it('does not use an issue-linked Project item without a primary work package as status evidence', () => {
+    const projectStatus = report();
+    projectStatus.milestones[0].workPackages[0].tracking = { githubIssues: [42] };
+
+    const result = rankEvidence({
+      projectStatus,
+      projectItems: { items: [{
+        status: 'Done',
+        health: 'On track',
+        content: { number: 42 },
+      }] },
+    }, { limit: 3, today: '2026-08-30' });
+
+    expect(result.priorities[0]).toMatchObject({
+      workPackageId: 'WP-001',
+      status: 'planned',
+      source: 'project-status.json',
+    });
   });
 
   it('reports conflicting GitHub source evidence rather than selecting a status', () => {

--- a/tests/integration/test_websocket_integration.py
+++ b/tests/integration/test_websocket_integration.py
@@ -28,17 +28,17 @@ from enum import Enum
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-class TestResult(Enum):
+class WebSocketCheckResult(Enum):
     PASSED = "✅ PASSED"
     FAILED = "❌ FAILED"
     SKIPPED = "⏭️ SKIPPED"
     WARNING = "⚠️ WARNING"
 
 @dataclass
-class TestCase:
+class WebSocketCheckCase:
     name: str
     description: str
-    result: TestResult = TestResult.SKIPPED
+    result: WebSocketCheckResult = WebSocketCheckResult.SKIPPED
     duration: float = 0.0
     error_message: str = ""
     details: Dict = None
@@ -53,7 +53,7 @@ class WebSocketIntegrationTester:
     def __init__(self, base_url: str = "http://localhost:8000"):
         self.base_url = base_url
         self.ws_url = base_url.replace("http", "ws")
-        self.test_results: List[TestCase] = []
+        self.test_results: List[WebSocketCheckCase] = []
         self.session = None
         self.current_session_id = None
 
@@ -66,9 +66,9 @@ class WebSocketIntegrationTester:
         if self.session:
             await self.session.close()
 
-    async def run_test(self, test_func, test_name: str, test_description: str) -> TestCase:
+    async def run_test(self, test_func, test_name: str, test_description: str) -> WebSocketCheckCase:
         """Run a single test with error handling and timing"""
-        test_case = TestCase(
+        test_case = WebSocketCheckCase(
             name=test_name,
             description=test_description
         )
@@ -85,18 +85,18 @@ class WebSocketIntegrationTester:
                 result = test_func()
 
             if result is True:
-                test_case.result = TestResult.PASSED
+                test_case.result = WebSocketCheckResult.PASSED
                 logger.info(f"✅ {test_name} - PASSED")
             elif result is False:
-                test_case.result = TestResult.FAILED
+                test_case.result = WebSocketCheckResult.FAILED
                 logger.error(f"❌ {test_name} - FAILED")
             else:
-                test_case.result = TestResult.WARNING
+                test_case.result = WebSocketCheckResult.WARNING
                 test_case.error_message = str(result)
                 logger.warning(f"⚠️ {test_name} - WARNING: {result}")
 
         except Exception as e:
-            test_case.result = TestResult.FAILED
+            test_case.result = WebSocketCheckResult.FAILED
             test_case.error_message = str(e)
             logger.error(f"❌ {test_name} - FAILED: {e}")
 
@@ -439,7 +439,7 @@ class WebSocketIntegrationTester:
             )
 
             session_result = None
-            if session_test.result == TestResult.PASSED and hasattr(session_test, 'session_data'):
+            if session_test.result == WebSocketCheckResult.PASSED and hasattr(session_test, 'session_data'):
                 session_result = session_test.session_data
             else:
                 # Try to get session result directly for further tests
@@ -448,7 +448,7 @@ class WebSocketIntegrationTester:
                 except:
                     session_result = (False, "")
 
-            if session_test.result == TestResult.PASSED and self.current_session_id:
+            if session_test.result == WebSocketCheckResult.PASSED and self.current_session_id:
                 session_id = self.current_session_id
                 session_test.details["session_id"] = session_id
 
@@ -520,9 +520,9 @@ class WebSocketIntegrationTester:
     def generate_report(self) -> Dict:
         """Generate comprehensive test report"""
         total_tests = len(self.test_results)
-        passed_tests = sum(1 for t in self.test_results if t.result == TestResult.PASSED)
-        failed_tests = sum(1 for t in self.test_results if t.result == TestResult.FAILED)
-        warning_tests = sum(1 for t in self.test_results if t.result == TestResult.WARNING)
+        passed_tests = sum(1 for t in self.test_results if t.result == WebSocketCheckResult.PASSED)
+        failed_tests = sum(1 for t in self.test_results if t.result == WebSocketCheckResult.FAILED)
+        warning_tests = sum(1 for t in self.test_results if t.result == WebSocketCheckResult.WARNING)
 
         total_duration = sum(t.duration for t in self.test_results)
 

--- a/tests/load/test_websocket_load_performance.py
+++ b/tests/load/test_websocket_load_performance.py
@@ -34,7 +34,7 @@ import tracemalloc
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 logger = logging.getLogger(__name__)
 
-class TestResult(Enum):
+class WebSocketCheckResult(Enum):
     PASSED = "✅ PASSED"
     FAILED = "❌ FAILED"
     SKIPPED = "⏭️ SKIPPED"
@@ -70,10 +70,10 @@ class PerformanceMetrics:
         return statistics.quantiles(self.response_times, n=100)[98] if len(self.response_times) > 1 else 0
 
 @dataclass
-class TestCase:
+class WebSocketCheckCase:
     name: str
     description: str
-    result: TestResult = TestResult.SKIPPED
+    result: WebSocketCheckResult = WebSocketCheckResult.SKIPPED
     duration: float = 0.0
     error_message: str = ""
     details: Dict = None
@@ -92,7 +92,7 @@ class LoadTestingFramework:
     def __init__(self, base_url: str = "http://localhost:8000", max_sessions: int = 150):
         self.base_url = base_url
         self.max_sessions = max_sessions
-        self.test_cases: List[TestCase] = []
+        self.test_cases: List[WebSocketCheckCase] = []
         self.session_timeout = 30
         self.concurrent_limit = 50  # Concurrent connection limit
 
@@ -159,9 +159,9 @@ class LoadTestingFramework:
             logger.warning(f"Session creation failed for index {index}: {e}")
         return None
 
-    async def test_concurrent_session_handling(self) -> TestCase:
+    async def test_concurrent_session_handling(self) -> WebSocketCheckCase:
         """Test system capability to handle 100+ concurrent sessions"""
-        test = TestCase(
+        test = WebSocketCheckCase(
             name="Concurrent Session Handling",
             description="Validate system performance with 100+ concurrent sessions",
             success_criteria=[
@@ -223,26 +223,26 @@ class LoadTestingFramework:
                 test.metrics.p95_response_time <= self.thresholds["p95_response_time"]):
 
                 if test.metrics.success_rate >= 99.0 and test.metrics.avg_response_time <= 1.0:
-                    test.result = TestResult.EXCELLENT
+                    test.result = WebSocketCheckResult.EXCELLENT
                 else:
-                    test.result = TestResult.PASSED
+                    test.result = WebSocketCheckResult.PASSED
             elif (test.metrics.success_rate >= 80.0 and
                   test.metrics.avg_response_time <= self.thresholds["avg_response_time"] * 1.5):
-                test.result = TestResult.WARNING
+                test.result = WebSocketCheckResult.WARNING
             else:
-                test.result = TestResult.FAILED
+                test.result = WebSocketCheckResult.FAILED
                 test.error_message = f"Performance below thresholds: {test.metrics.success_rate:.1f}% success, {test.metrics.avg_response_time:.2f}s avg response"
 
         except Exception as e:
             test.error_message = f"Concurrent session test failed: {str(e)}"
-            test.result = TestResult.FAILED
+            test.result = WebSocketCheckResult.FAILED
 
         test.duration = time.time() - start_time
         return test
 
-    async def test_message_throughput_under_load(self) -> TestCase:
+    async def test_message_throughput_under_load(self) -> WebSocketCheckCase:
         """Test message processing throughput under high load"""
-        test = TestCase(
+        test = WebSocketCheckCase(
             name="Message Throughput Under Load",
             description="Validate message processing performance with concurrent sessions",
             success_criteria=[
@@ -267,7 +267,7 @@ class LoadTestingFramework:
 
             if len(session_ids) < session_count // 2:
                 test.error_message = f"Insufficient sessions created: {len(session_ids)}/{session_count}"
-                test.result = TestResult.FAILED
+                test.result = WebSocketCheckResult.FAILED
                 return test
 
             # Activate fallback for all sessions
@@ -326,26 +326,26 @@ class LoadTestingFramework:
             # Evaluate performance
             if (test.metrics.success_rate >= 95.0 and
                 test.metrics.throughput >= self.thresholds["throughput"]):
-                test.result = TestResult.PASSED
+                test.result = WebSocketCheckResult.PASSED
                 if test.metrics.throughput >= self.thresholds["throughput"] * 2:
-                    test.result = TestResult.EXCELLENT
+                    test.result = WebSocketCheckResult.EXCELLENT
             elif (test.metrics.success_rate >= 80.0 and
                   test.metrics.throughput >= self.thresholds["throughput"] * 0.7):
-                test.result = TestResult.WARNING
+                test.result = WebSocketCheckResult.WARNING
             else:
-                test.result = TestResult.FAILED
+                test.result = WebSocketCheckResult.FAILED
                 test.error_message = f"Throughput below threshold: {test.metrics.throughput:.1f} < {self.thresholds['throughput']}"
 
         except Exception as e:
             test.error_message = f"Message throughput test failed: {str(e)}"
-            test.result = TestResult.FAILED
+            test.result = WebSocketCheckResult.FAILED
 
         test.duration = time.time() - start_time
         return test
 
-    async def test_fallback_performance_peak_usage(self) -> TestCase:
+    async def test_fallback_performance_peak_usage(self) -> WebSocketCheckCase:
         """Test fallback system performance during peak usage simulation"""
-        test = TestCase(
+        test = WebSocketCheckCase(
             name="Fallback Performance at Peak Usage",
             description="Validate fallback system under sustained peak load conditions",
             success_criteria=[
@@ -382,7 +382,7 @@ class LoadTestingFramework:
             # Simplified peak usage simulation focusing on available operations
             if len(fallback_pools) == 0:
                 test.error_message = "No fallback pools available for peak testing"
-                test.result = TestResult.FAILED
+                test.result = WebSocketCheckResult.FAILED
                 return test
 
             peak_start = time.time()
@@ -467,27 +467,27 @@ class LoadTestingFramework:
             if (success_rate >= 95.0 and
                 avg_ops_per_sec >= 10.0 and
                 memory_growth < 100):  # Less than 100MB growth
-                test.result = TestResult.PASSED
+                test.result = WebSocketCheckResult.PASSED
                 if success_rate >= 98.0 and memory_growth < 50:
-                    test.result = TestResult.EXCELLENT
+                    test.result = WebSocketCheckResult.EXCELLENT
             elif (success_rate >= 85.0 and
                   avg_ops_per_sec >= 5.0 and
                   memory_growth < 200):
-                test.result = TestResult.WARNING
+                test.result = WebSocketCheckResult.WARNING
             else:
-                test.result = TestResult.FAILED
+                test.result = WebSocketCheckResult.FAILED
                 test.error_message = f"Peak performance insufficient: {success_rate:.1f}% success, {avg_ops_per_sec:.1f} ops/sec, {memory_growth:.1f}MB growth"
 
         except Exception as e:
             test.error_message = f"Peak usage test failed: {str(e)}"
-            test.result = TestResult.FAILED
+            test.result = WebSocketCheckResult.FAILED
 
         test.duration = time.time() - start_time
         return test
 
-    async def test_scalability_limits_analysis(self) -> TestCase:
+    async def test_scalability_limits_analysis(self) -> WebSocketCheckCase:
         """Analyze system scalability limits and identify bottlenecks"""
-        test = TestCase(
+        test = WebSocketCheckCase(
             name="Scalability Limits Analysis",
             description="Determine system capacity limits and performance degradation points",
             success_criteria=[
@@ -577,18 +577,18 @@ class LoadTestingFramework:
 
             # Evaluate scalability
             if max_sessions >= 100 and len(degradation_points) <= 1:
-                test.result = TestResult.PASSED
+                test.result = WebSocketCheckResult.PASSED
                 if max_sessions >= 150 and len(degradation_points) == 0:
-                    test.result = TestResult.EXCELLENT
+                    test.result = WebSocketCheckResult.EXCELLENT
             elif max_sessions >= 75:
-                test.result = TestResult.WARNING
+                test.result = WebSocketCheckResult.WARNING
             else:
-                test.result = TestResult.FAILED
+                test.result = WebSocketCheckResult.FAILED
                 test.error_message = f"Insufficient scalability: max {max_sessions} sessions"
 
         except Exception as e:
             test.error_message = f"Scalability analysis failed: {str(e)}"
-            test.result = TestResult.FAILED
+            test.result = WebSocketCheckResult.FAILED
 
         test.duration = time.time() - start_time
         return test
@@ -696,10 +696,10 @@ class LoadTestingFramework:
         total_duration = time.time() - start_time
 
         # Calculate overall results
-        passed = len([t for t in tests if t.result in [TestResult.PASSED, TestResult.EXCELLENT]])
-        failed = len([t for t in tests if t.result == TestResult.FAILED])
-        warnings = len([t for t in tests if t.result == TestResult.WARNING])
-        excellent = len([t for t in tests if t.result == TestResult.EXCELLENT])
+        passed = len([t for t in tests if t.result in [WebSocketCheckResult.PASSED, WebSocketCheckResult.EXCELLENT]])
+        failed = len([t for t in tests if t.result == WebSocketCheckResult.FAILED])
+        warnings = len([t for t in tests if t.result == WebSocketCheckResult.WARNING])
+        excellent = len([t for t in tests if t.result == WebSocketCheckResult.EXCELLENT])
 
         success_rate = (passed / len(tests)) * 100 if tests else 0
 
@@ -759,7 +759,7 @@ class LoadTestingFramework:
         print("-" * 80)
 
         for test in self.test_cases:
-            icon = "🏆" if test.result == TestResult.EXCELLENT else test.result.value.split()[0]
+            icon = "🏆" if test.result == WebSocketCheckResult.EXCELLENT else test.result.value.split()[0]
             print(f"\n{test.result.value} {test.name}")
             print(f"   📝 {test.description}")
             print(f"   ⏱️  Duration: {test.duration:.2f}s")

--- a/tests/load/test_websocket_production_validation.py
+++ b/tests/load/test_websocket_production_validation.py
@@ -32,7 +32,7 @@ from urllib.parse import urlparse
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 logger = logging.getLogger(__name__)
 
-class TestResult(Enum):
+class WebSocketCheckResult(Enum):
     PASSED = "✅ PASSED"
     FAILED = "❌ FAILED"
     SKIPPED = "⏭️ SKIPPED"
@@ -51,10 +51,10 @@ class SecurityValidation:
     websocket_upgrade_secure: bool = False
 
 @dataclass
-class TestCase:
+class WebSocketCheckCase:
     name: str
     description: str
-    result: TestResult = TestResult.SKIPPED
+    result: WebSocketCheckResult = WebSocketCheckResult.SKIPPED
     duration: float = 0.0
     error_message: str = ""
     details: Dict = None
@@ -73,7 +73,7 @@ class ProductionEnvironmentValidator:
     def __init__(self, base_url: str = "http://localhost:8000", production_url: Optional[str] = None):
         self.base_url = base_url
         self.production_url = production_url or base_url
-        self.test_cases: List[TestCase] = []
+        self.test_cases: List[WebSocketCheckCase] = []
 
         # Production-like test configurations
         self.production_origins = [
@@ -100,9 +100,9 @@ class ProductionEnvironmentValidator:
             "Access-Control-Allow-Credentials"
         ]
 
-    async def test_ssl_tls_websocket_connections(self) -> TestCase:
+    async def test_ssl_tls_websocket_connections(self) -> WebSocketCheckCase:
         """Test SSL/TLS WebSocket connections (wss://) functionality"""
-        test = TestCase(
+        test = WebSocketCheckCase(
             name="SSL/TLS WebSocket Connections",
             description="Validate secure WebSocket connections and SSL certificate validation",
             success_criteria=[
@@ -192,26 +192,26 @@ class ProductionEnvironmentValidator:
             if parsed_url.scheme == "https":
                 if (test.security_validation.ssl_certificate_valid and
                     test.security_validation.websocket_upgrade_secure):
-                    test.result = TestResult.EXCELLENT
+                    test.result = WebSocketCheckResult.EXCELLENT
                 elif test.security_validation.ssl_certificate_valid:
-                    test.result = TestResult.PASSED
+                    test.result = WebSocketCheckResult.PASSED
                 else:
-                    test.result = TestResult.WARNING
+                    test.result = WebSocketCheckResult.WARNING
                     test.error_message = "SSL certificate validation issues detected"
             else:
-                test.result = TestResult.INFO
+                test.result = WebSocketCheckResult.INFO
                 test.error_message = "HTTP-only environment detected - HTTPS recommended for production"
 
         except Exception as e:
             test.error_message = f"SSL/TLS validation failed: {str(e)}"
-            test.result = TestResult.FAILED
+            test.result = WebSocketCheckResult.FAILED
 
         test.duration = time.time() - start_time
         return test
 
-    async def test_load_balancer_compatibility(self) -> TestCase:
+    async def test_load_balancer_compatibility(self) -> WebSocketCheckCase:
         """Test load balancer and proxy WebSocket support"""
-        test = TestCase(
+        test = WebSocketCheckCase(
             name="Load Balancer & Proxy Compatibility",
             description="Validate WebSocket functionality through load balancers and reverse proxies",
             success_criteria=[
@@ -299,24 +299,24 @@ class ProductionEnvironmentValidator:
             fallback_works = test.details.get("fallback_proxy_status", 0) == 200
 
             if session_works and websocket_status in [101, 426] and fallback_works:
-                test.result = TestResult.PASSED
+                test.result = WebSocketCheckResult.PASSED
             elif session_works and fallback_works:
-                test.result = TestResult.WARNING
+                test.result = WebSocketCheckResult.WARNING
                 test.error_message = "WebSocket upgrade may need proxy configuration"
             else:
-                test.result = TestResult.FAILED
+                test.result = WebSocketCheckResult.FAILED
                 test.error_message = "Load balancer compatibility issues detected"
 
         except Exception as e:
             test.error_message = f"Load balancer test failed: {str(e)}"
-            test.result = TestResult.FAILED
+            test.result = WebSocketCheckResult.FAILED
 
         test.duration = time.time() - start_time
         return test
 
-    async def test_real_world_origin_validation(self) -> TestCase:
+    async def test_real_world_origin_validation(self) -> WebSocketCheckCase:
         """Test real-world origin validation with production URLs"""
-        test = TestCase(
+        test = WebSocketCheckCase(
             name="Real-World Origin Validation",
             description="Validate CORS and origin handling with production-like URLs",
             success_criteria=[
@@ -432,25 +432,25 @@ class ProductionEnvironmentValidator:
             cors_rate = test.details["cors_compliant_origins"] / test.details["total_origins_tested"] * 100
 
             if success_rate >= 80 and cors_rate >= 60:
-                test.result = TestResult.PASSED
+                test.result = WebSocketCheckResult.PASSED
                 if success_rate >= 90 and cors_rate >= 80:
-                    test.result = TestResult.EXCELLENT
+                    test.result = WebSocketCheckResult.EXCELLENT
             elif success_rate >= 60:
-                test.result = TestResult.WARNING
+                test.result = WebSocketCheckResult.WARNING
             else:
-                test.result = TestResult.FAILED
+                test.result = WebSocketCheckResult.FAILED
                 test.error_message = f"Origin validation insufficient: {success_rate:.1f}% success rate"
 
         except Exception as e:
             test.error_message = f"Origin validation test failed: {str(e)}"
-            test.result = TestResult.FAILED
+            test.result = WebSocketCheckResult.FAILED
 
         test.duration = time.time() - start_time
         return test
 
-    async def test_production_configuration_validation(self) -> TestCase:
+    async def test_production_configuration_validation(self) -> WebSocketCheckCase:
         """Validate production configuration and deployment readiness"""
-        test = TestCase(
+        test = WebSocketCheckCase(
             name="Production Configuration Validation",
             description="Comprehensive validation of production deployment configuration",
             success_criteria=[
@@ -584,18 +584,18 @@ class ProductionEnvironmentValidator:
             endpoint_success_rate = (endpoints_accessible / total_endpoints * 100) if total_endpoints > 0 else 0
 
             if health_ok and endpoint_success_rate >= 80 and performance_ok:
-                test.result = TestResult.PASSED
+                test.result = WebSocketCheckResult.PASSED
                 if endpoint_success_rate == 100:
-                    test.result = TestResult.EXCELLENT
+                    test.result = WebSocketCheckResult.EXCELLENT
             elif health_ok and endpoint_success_rate >= 60:
-                test.result = TestResult.WARNING
+                test.result = WebSocketCheckResult.WARNING
             else:
-                test.result = TestResult.FAILED
+                test.result = WebSocketCheckResult.FAILED
                 test.error_message = f"Production configuration insufficient: {endpoint_success_rate:.1f}% endpoints accessible"
 
         except Exception as e:
             test.error_message = f"Production configuration validation failed: {str(e)}"
-            test.result = TestResult.FAILED
+            test.result = WebSocketCheckResult.FAILED
 
         test.duration = time.time() - start_time
         return test
@@ -630,11 +630,11 @@ class ProductionEnvironmentValidator:
         total_duration = time.time() - start_time
 
         # Calculate overall results
-        passed = len([t for t in tests if t.result in [TestResult.PASSED, TestResult.EXCELLENT]])
-        failed = len([t for t in tests if t.result == TestResult.FAILED])
-        warnings = len([t for t in tests if t.result == TestResult.WARNING])
-        excellent = len([t for t in tests if t.result == TestResult.EXCELLENT])
-        info = len([t for t in tests if t.result == TestResult.INFO])
+        passed = len([t for t in tests if t.result in [WebSocketCheckResult.PASSED, WebSocketCheckResult.EXCELLENT]])
+        failed = len([t for t in tests if t.result == WebSocketCheckResult.FAILED])
+        warnings = len([t for t in tests if t.result == WebSocketCheckResult.WARNING])
+        excellent = len([t for t in tests if t.result == WebSocketCheckResult.EXCELLENT])
+        info = len([t for t in tests if t.result == WebSocketCheckResult.INFO])
 
         success_rate = ((passed + info) / len(tests)) * 100 if tests else 0  # INFO counts as success for production validation
 

--- a/tests/load/test_websocket_simplified_load.py
+++ b/tests/load/test_websocket_simplified_load.py
@@ -30,7 +30,7 @@ import tracemalloc
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 logger = logging.getLogger(__name__)
 
-class TestResult(Enum):
+class WebSocketCheckResult(Enum):
     PASSED = "✅ PASSED"
     FAILED = "❌ FAILED"
     SKIPPED = "⏭️ SKIPPED"
@@ -65,10 +65,10 @@ class PerformanceMetrics:
         return statistics.quantiles(self.response_times, n=100)[98] if len(self.response_times) > 1 else 0
 
 @dataclass
-class TestCase:
+class WebSocketCheckCase:
     name: str
     description: str
-    result: TestResult = TestResult.SKIPPED
+    result: WebSocketCheckResult = WebSocketCheckResult.SKIPPED
     duration: float = 0.0
     error_message: str = ""
     details: Dict = None
@@ -86,7 +86,7 @@ class TestCase:
 class SimplifiedLoadTester:
     def __init__(self, base_url: str = "http://localhost:8000"):
         self.base_url = base_url
-        self.test_cases: List[TestCase] = []
+        self.test_cases: List[WebSocketCheckCase] = []
         self.concurrent_limit = 50
 
         # Performance thresholds
@@ -137,9 +137,9 @@ class SimplifiedLoadTester:
             logger.debug(f"Session creation failed for index {index}: {e}")
         return None
 
-    async def test_massive_concurrent_sessions(self) -> TestCase:
+    async def test_massive_concurrent_sessions(self) -> WebSocketCheckCase:
         """Test creating 200+ concurrent sessions for maximum load validation"""
-        test = TestCase(
+        test = WebSocketCheckCase(
             name="Massive Concurrent Session Creation",
             description="Validate system performance with 200+ concurrent sessions",
             success_criteria=[
@@ -210,26 +210,26 @@ class SimplifiedLoadTester:
                 if (test.metrics.success_rate >= 99.0 and
                     test.metrics.avg_response_time <= 1.0 and
                     test.metrics.throughput >= 200.0):
-                    test.result = TestResult.EXCELLENT
+                    test.result = WebSocketCheckResult.EXCELLENT
                 else:
-                    test.result = TestResult.PASSED
+                    test.result = WebSocketCheckResult.PASSED
             elif (test.metrics.success_rate >= 85.0 and
                   test.metrics.avg_response_time <= self.thresholds["avg_response_time"] * 1.5):
-                test.result = TestResult.WARNING
+                test.result = WebSocketCheckResult.WARNING
             else:
-                test.result = TestResult.FAILED
+                test.result = WebSocketCheckResult.FAILED
                 test.error_message = f"Performance below thresholds: {test.metrics.success_rate:.1f}% success, {test.metrics.avg_response_time:.2f}s avg response"
 
         except Exception as e:
             test.error_message = f"Massive concurrent test failed: {str(e)}"
-            test.result = TestResult.FAILED
+            test.result = WebSocketCheckResult.FAILED
 
         test.duration = time.time() - start_time
         return test
 
-    async def test_session_info_retrieval_load(self) -> TestCase:
+    async def test_session_info_retrieval_load(self) -> WebSocketCheckCase:
         """Test session info retrieval performance under load"""
-        test = TestCase(
+        test = WebSocketCheckCase(
             name="Session Info Retrieval Under Load",
             description="Validate session information retrieval performance with concurrent requests",
             success_criteria=[
@@ -249,7 +249,7 @@ class SimplifiedLoadTester:
 
             if len(session_ids) < session_count // 2:
                 test.error_message = f"Insufficient sessions created: {len(session_ids)}/{session_count}"
-                test.result = TestResult.FAILED
+                test.result = WebSocketCheckResult.FAILED
                 return test
 
             # Test concurrent session info retrieval
@@ -289,25 +289,25 @@ class SimplifiedLoadTester:
             # Evaluate performance
             avg_response_time = info_duration / len(session_ids)
             if (test.metrics.success_rate >= 95.0 and avg_response_time <= 1.0):
-                test.result = TestResult.PASSED
+                test.result = WebSocketCheckResult.PASSED
                 if test.metrics.success_rate >= 99.0 and avg_response_time <= 0.5:
-                    test.result = TestResult.EXCELLENT
+                    test.result = WebSocketCheckResult.EXCELLENT
             elif (test.metrics.success_rate >= 85.0 and avg_response_time <= 2.0):
-                test.result = TestResult.WARNING
+                test.result = WebSocketCheckResult.WARNING
             else:
-                test.result = TestResult.FAILED
+                test.result = WebSocketCheckResult.FAILED
                 test.error_message = f"Info retrieval performance insufficient: {test.metrics.success_rate:.1f}% success, {avg_response_time:.3f}s avg"
 
         except Exception as e:
             test.error_message = f"Session info load test failed: {str(e)}"
-            test.result = TestResult.FAILED
+            test.result = WebSocketCheckResult.FAILED
 
         test.duration = time.time() - start_time
         return test
 
-    async def test_sustained_load_stability(self) -> TestCase:
+    async def test_sustained_load_stability(self) -> WebSocketCheckCase:
         """Test system stability under sustained load for extended period"""
-        test = TestCase(
+        test = WebSocketCheckCase(
             name="Sustained Load Stability",
             description="Validate system stability under continuous load for 2 minutes",
             success_criteria=[
@@ -384,29 +384,29 @@ class SimplifiedLoadTester:
                 avg_response_time <= 1.0 and
                 memory_growth < 100 and
                 response_time_variance < 0.1):
-                test.result = TestResult.PASSED
+                test.result = WebSocketCheckResult.PASSED
                 if (operations_completed >= 200 and
                     avg_response_time <= 0.5 and
                     memory_growth < 50):
-                    test.result = TestResult.EXCELLENT
+                    test.result = WebSocketCheckResult.EXCELLENT
             elif (operations_completed >= 50 and
                   avg_response_time <= 2.0 and
                   memory_growth < 200):
-                test.result = TestResult.WARNING
+                test.result = WebSocketCheckResult.WARNING
             else:
-                test.result = TestResult.FAILED
+                test.result = WebSocketCheckResult.FAILED
                 test.error_message = f"Insufficient stability: {operations_completed} ops, {avg_response_time:.3f}s avg, {memory_growth:.1f}MB growth"
 
         except Exception as e:
             test.error_message = f"Sustained load test failed: {str(e)}"
-            test.result = TestResult.FAILED
+            test.result = WebSocketCheckResult.FAILED
 
         test.duration = time.time() - start_time
         return test
 
-    async def test_api_endpoint_stress(self) -> TestCase:
+    async def test_api_endpoint_stress(self) -> WebSocketCheckCase:
         """Stress test various API endpoints to identify bottlenecks"""
-        test = TestCase(
+        test = WebSocketCheckCase(
             name="API Endpoint Stress Testing",
             description="Identify performance limits and bottlenecks across API endpoints",
             success_criteria=[
@@ -479,18 +479,18 @@ class SimplifiedLoadTester:
             min_rps = min(ep["rps"] for ep in endpoint_results.values())
 
             if overall_success_rate >= 95.0 and min_rps >= 20.0:
-                test.result = TestResult.PASSED
+                test.result = WebSocketCheckResult.PASSED
                 if overall_success_rate >= 98.0 and min_rps >= 50.0:
-                    test.result = TestResult.EXCELLENT
+                    test.result = WebSocketCheckResult.EXCELLENT
             elif overall_success_rate >= 85.0 and min_rps >= 10.0:
-                test.result = TestResult.WARNING
+                test.result = WebSocketCheckResult.WARNING
             else:
-                test.result = TestResult.FAILED
+                test.result = WebSocketCheckResult.FAILED
                 test.error_message = f"API stress performance insufficient: {overall_success_rate:.1f}% success, {min_rps:.1f} min RPS"
 
         except Exception as e:
             test.error_message = f"API stress test failed: {str(e)}"
-            test.result = TestResult.FAILED
+            test.result = WebSocketCheckResult.FAILED
 
         test.duration = time.time() - start_time
         return test
@@ -546,10 +546,10 @@ class SimplifiedLoadTester:
         total_duration = time.time() - start_time
 
         # Calculate overall results
-        passed = len([t for t in tests if t.result in [TestResult.PASSED, TestResult.EXCELLENT]])
-        failed = len([t for t in tests if t.result == TestResult.FAILED])
-        warnings = len([t for t in tests if t.result == TestResult.WARNING])
-        excellent = len([t for t in tests if t.result == TestResult.EXCELLENT])
+        passed = len([t for t in tests if t.result in [WebSocketCheckResult.PASSED, WebSocketCheckResult.EXCELLENT]])
+        failed = len([t for t in tests if t.result == WebSocketCheckResult.FAILED])
+        warnings = len([t for t in tests if t.result == WebSocketCheckResult.WARNING])
+        excellent = len([t for t in tests if t.result == WebSocketCheckResult.EXCELLENT])
 
         success_rate = (passed / len(tests)) * 100 if tests else 0
 


### PR DESCRIPTION
## Summary
- use only primary GitHub Project work-package assignments as project-status evidence
- aggregate multiple primary cards conservatively using the least advanced status
- retain roadmap links as traceability rather than status evidence
- add regression coverage for linked and unassigned Project items

## Verification
- `apps/project-report/node_modules/.bin/vitest run plugins/project-steward/scripts/priority-report.test.mjs apps/project-report/scripts/project-status-sync.test.mjs`
- `node plugins/project-steward/scripts/priority-report.mjs --live --format markdown`

Resolves the evidence interpretation documented in #273.