### PR TITLE
feat(dev): add Studio runtime configuration mock

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -187,7 +187,7 @@ services:
       context: .
       dockerfile: services/studio_mock/Dockerfile
     ports:
-      - "8010:8000"
+      - "127.0.0.1:8010:8000"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/openapi.json"]
       interval: 10s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -187,7 +187,7 @@ services:
       context: .
       dockerfile: services/studio_mock/Dockerfile
     ports:
-      - "127.0.0.1:8010:8000"
+      - "8010:8000"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/openapi.json"]
       interval: 10s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -181,6 +181,19 @@ services:
       - "traefik.http.middlewares.websocket-headers.headers.customrequestheaders.X-Forwarded-Proto=https"
     restart: always
 
+  studio-mock:
+    profiles: ["studio-mock"]
+    build:
+      context: .
+      dockerfile: services/studio_mock/Dockerfile
+    ports:
+      - "127.0.0.1:8010:8000"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/openapi.json"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+
   ollama:
     image: ollama/ollama:0.32.0
     expose:

--- a/docs/operations/keycloak-admin-access.md
+++ b/docs/operations/keycloak-admin-access.md
@@ -15,3 +15,26 @@ Before enabling the new route in production, verify a Keycloak user with
 `ssf-user` can log in at `/login` and make an administrative request. Verify a
 user without that role receives 403 and a request without credentials receives
 401. Verify the QR join route remains available without Keycloak login.
+
+## Local Studio Runtime Configuration mock
+
+The `studio-mock` service is a local contract-testing dependency for the
+Studio--SSF Runtime Configuration V1 API. Start it explicitly:
+
+```bash
+docker compose --profile studio-mock up --build studio-mock
+```
+
+It listens only on `127.0.0.1:8010`. Request
+`/internal/plugins/ssf/v1/runtime-configuration` with bearer token
+`studio-mock-service-token`, `X-Tenant-Id` set to `tenant-kassel` or
+`tenant-fulda`, and a correlation ID. `tenant-kassel` returns storage mode
+`ask`; `tenant-fulda` returns `disabled`. Send `X-Mock-Scenario: not-ready`
+or `unavailable` to exercise the `409` or `503` error envelopes.
+Omit the bearer token, use a wrong token, or send an unknown tenant ID to
+exercise the `401`, `403`, or `404` envelopes. Every error response has the
+Studio V1 `contractVersion` and `error` envelope documented in the mock's
+OpenAPI description.
+
+The `studio-mock` profile must not be enabled in production. It contains only
+fixed test data and does not validate real Studio service credentials.

--- a/docs/operations/keycloak-admin-access.md
+++ b/docs/operations/keycloak-admin-access.md
@@ -25,12 +25,14 @@ Studio--SSF Runtime Configuration V1 API. Start it explicitly:
 docker compose --profile studio-mock up --build studio-mock
 ```
 
-It listens on all host interfaces at `http://<host-ip>:8010`. Request
-`/internal/plugins/ssf/v1/runtime-configuration` with `X-Tenant-Id` set to
-`tenant-kassel` or `tenant-fulda`, and a correlation ID. `tenant-kassel`
-returns storage mode `ask`; `tenant-fulda` returns `disabled`. Send
-`X-Mock-Scenario: not-ready` or `unavailable` to exercise the `409` or `503`
-error envelopes. Send an unknown tenant ID to exercise the `404` envelope.
+It listens on all host interfaces at `http://<host-ip>:8010`. Browser access
+uses `http://<host-ip>:8010/internal/plugins/ssf/v1/runtime-configuration?tenantId=tenant-kassel`.
+Service callers can instead send `X-Tenant-Id` set to `tenant-kassel` or
+`tenant-fulda`, and a correlation ID. When both are present, their values must
+match or the mock returns `400`. `tenant-kassel` returns storage mode `ask`;
+`tenant-fulda` returns `disabled`. Send `X-Mock-Scenario: not-ready` or
+`unavailable` to exercise the `409` or `503` error envelopes. Send an unknown
+tenant ID to exercise the `404` envelope.
 Every error response has the Studio V1 `contractVersion` and `error` envelope
 documented in the mock's OpenAPI description.
 

--- a/docs/operations/keycloak-admin-access.md
+++ b/docs/operations/keycloak-admin-access.md
@@ -18,23 +18,22 @@ user without that role receives 403 and a request without credentials receives
 
 ## Local Studio Runtime Configuration mock
 
-The `studio-mock` service is a local contract-testing dependency for the
+The `studio-mock` service is an opt-in contract-testing dependency for the
 Studio--SSF Runtime Configuration V1 API. Start it explicitly:
 
 ```bash
 docker compose --profile studio-mock up --build studio-mock
 ```
 
-It listens only on `127.0.0.1:8010`. Request
-`/internal/plugins/ssf/v1/runtime-configuration` with bearer token
-`studio-mock-service-token`, `X-Tenant-Id` set to `tenant-kassel` or
-`tenant-fulda`, and a correlation ID. `tenant-kassel` returns storage mode
-`ask`; `tenant-fulda` returns `disabled`. Send `X-Mock-Scenario: not-ready`
-or `unavailable` to exercise the `409` or `503` error envelopes.
-Omit the bearer token, use a wrong token, or send an unknown tenant ID to
-exercise the `401`, `403`, or `404` envelopes. Every error response has the
-Studio V1 `contractVersion` and `error` envelope documented in the mock's
-OpenAPI description.
+It listens on all host interfaces at `http://<host-ip>:8010`. Request
+`/internal/plugins/ssf/v1/runtime-configuration` with `X-Tenant-Id` set to
+`tenant-kassel` or `tenant-fulda`, and a correlation ID. `tenant-kassel`
+returns storage mode `ask`; `tenant-fulda` returns `disabled`. Send
+`X-Mock-Scenario: not-ready` or `unavailable` to exercise the `409` or `503`
+error envelopes. Send an unknown tenant ID to exercise the `404` envelope.
+Every error response has the Studio V1 `contractVersion` and `error` envelope
+documented in the mock's OpenAPI description.
 
-The `studio-mock` profile must not be enabled in production. It contains only
-fixed test data and does not validate real Studio service credentials.
+The mock does not require authentication and contains only fixed,
+non-sensitive test data. It is intentionally HTTP-only for temporary external
+test access; do not use it as a production Studio service.

--- a/docs/operations/keycloak-admin-access.md
+++ b/docs/operations/keycloak-admin-access.md
@@ -25,17 +25,29 @@ Studio--SSF Runtime Configuration V1 API. Start it explicitly:
 docker compose --profile studio-mock up --build studio-mock
 ```
 
-It listens on all host interfaces at `http://<host-ip>:8010`. Browser access
-uses `http://<host-ip>:8010/internal/plugins/ssf/v1/runtime-configuration?tenantId=tenant-kassel`.
-Service callers can instead send `X-Tenant-Id` set to `tenant-kassel` or
-`tenant-fulda`, and a correlation ID. When both are present, their values must
-match or the mock returns `400`. `tenant-kassel` returns storage mode `ask`;
-`tenant-fulda` returns `disabled`. Send `X-Mock-Scenario: not-ready` or
-`unavailable` to exercise the `409` or `503` error envelopes. Send an unknown
-tenant ID to exercise the `404` envelope.
+It listens only on loopback at `http://127.0.0.1:8010`. SSF containers on the
+same Compose network use `http://studio-mock:8000` as their base URL. Configure
+the consumer through `STUDIO_RUNTIME_CONFIGURATION_BASE_URL` and retain the
+path `/internal/plugins/ssf/v1/runtime-configuration`; replacing the mock with
+Studio then requires only a base-URL change.
+
+Every request requires these headers:
+
+```text
+Authorization: Bearer studio-mock-authorized-token
+X-Studio-Instance-Id: tenant-kassel
+X-Correlation-Id: local-test-correlation-id
+```
+
+`Bearer studio-mock-authorized-token` has
+`ssf.runtime-configuration.read`; `Bearer studio-mock-unauthorized-token`
+models an authenticated caller without that permission. `tenant-kassel`
+returns storage mode `ask`; `tenant-fulda` returns `disabled`. Send
+`X-Mock-Scenario: authorization-pending` or `unavailable` to exercise `409`
+or `503`. Send an unknown Studio instance ID to exercise `404`.
 Every error response has the Studio V1 `contractVersion` and `error` envelope
 documented in the mock's OpenAPI description.
 
-The mock does not require authentication and contains only fixed,
-non-sensitive test data. It is intentionally HTTP-only for temporary external
-test access; do not use it as a production Studio service.
+The mock contains only fixed, non-sensitive test data, but it requires the V1
+mock service token and is intentionally not publicly reachable. Do not use it
+as a production Studio service.

--- a/docs/superpowers/plans/2026-09-08-studio-runtime-configuration-mock.md
+++ b/docs/superpowers/plans/2026-09-08-studio-runtime-configuration-mock.md
@@ -1,0 +1,67 @@
+# Studio Runtime Configuration Mock Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Provide a local, contract-faithful Studio Runtime Configuration V1 mock API without changing production behavior.
+
+**Architecture:** A small standalone FastAPI service returns deterministic V1 configuration fixtures and documented error envelopes. A Compose `studio-mock` profile packages it only for local integration tests; no SSF production service is rewired to it.
+
+**Tech Stack:** Python 3.12, FastAPI, pytest, Docker Compose.
+
+**Spec:** `openspec/changes/add-studio-runtime-configuration-mock/`
+
+## Global Constraints
+
+- Implement only the published Studio Runtime Configuration Contract V1 endpoint.
+- Use no real credentials or production URLs.
+- Keep the mock disabled unless the local `studio-mock` Compose profile is selected.
+
+---
+
+### Task 1: Contract fixtures and HTTP endpoint
+
+**Files:**
+- Create: `services/studio_mock/app.py`
+- Create: `services/studio_mock/__init__.py`
+- Test: `tests/test_studio_runtime_configuration_mock.py`
+
+**Interfaces:**
+- Produces: `app`, a FastAPI application serving `GET /internal/plugins/ssf/v1/runtime-configuration`.
+- Consumes: `Authorization`, `X-Tenant-Id`, and `X-Correlation-Id` request headers.
+
+- [ ] **Step 1: Write failing tests** for accepted test bearer token, both tenant policies, unknown tenant, invalid token, and selected `409`/`503` envelopes.
+- [ ] **Step 2: Run** `pytest tests/test_studio_runtime_configuration_mock.py -q` and confirm the endpoint is absent.
+- [ ] **Step 3: Implement** the smallest deterministic fixtures, header validation, endpoint, and error envelope helper needed for the tests.
+- [ ] **Step 4: Run** `pytest tests/test_studio_runtime_configuration_mock.py -q` and confirm it passes.
+- [ ] **Step 5: Commit** the endpoint and tests.
+
+### Task 2: Opt-in container delivery
+
+**Files:**
+- Create: `services/studio_mock/Dockerfile`
+- Modify: `docker-compose.yml`
+- Test: `tests/test_studio_runtime_configuration_mock_compose.py`
+
+**Interfaces:**
+- Produces: `studio-mock` Compose service enabled only by profile `studio-mock`.
+
+- [ ] **Step 1: Write a failing Compose contract test** proving the service declares the profile and default Compose does not include it.
+- [ ] **Step 2: Run** `pytest tests/test_studio_runtime_configuration_mock_compose.py -q` and confirm it fails.
+- [ ] **Step 3: Implement** a minimal Python image and opt-in Compose service with no public production route.
+- [ ] **Step 4: Run** the Compose contract test and `docker compose config` with and without `--profile studio-mock`.
+- [ ] **Step 5: Commit** the container delivery changes.
+
+### Task 3: Operator documentation and verification
+
+**Files:**
+- Modify: `docs/operations/keycloak-admin-access.md`
+- Test: `tests/test_studio_runtime_configuration_mock.py`
+
+**Interfaces:**
+- Documents: local start command, test token, tenant identifiers, error scenario selection, and production exclusion.
+
+- [ ] **Step 1: Add a failing documentation assertion** requiring the local profile and production exclusion text.
+- [ ] **Step 2: Run** the focused tests and confirm the assertion fails.
+- [ ] **Step 3: Document** the mock operation and its non-production boundary.
+- [ ] **Step 4: Run** all mock-focused tests and `docker compose --profile studio-mock config`.
+- [ ] **Step 5: Commit** the documentation and verification changes.

--- a/docs/superpowers/plans/2026-09-08-studio-runtime-mock-external-http.md
+++ b/docs/superpowers/plans/2026-09-08-studio-runtime-mock-external-http.md
@@ -1,0 +1,78 @@
+# Studio Runtime Mock External HTTP Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the opt-in Studio Runtime Configuration mock readable without authentication at `http://<host-ip>:8010`.
+
+**Architecture:** The Compose service remains profile-gated and is not placed behind Traefik. Its port mapping changes from loopback-only to all host interfaces, and the FastAPI endpoint no longer checks an `Authorization` header. Documentation gives the exact HTTP-by-IP invocation and states that the service deliberately exposes only fixed, non-sensitive test data.
+
+**Tech Stack:** Docker Compose, FastAPI, pytest.
+
+**Spec:** `openspec/changes/add-studio-runtime-configuration-mock/`
+
+## Global Constraints
+
+- The `studio-mock` service MUST remain disabled unless the `studio-mock` profile is explicitly selected.
+- The HTTP endpoint MUST NOT require authentication.
+- The mock MUST NOT receive a Traefik route or production service dependency.
+
+---
+
+### Task 1: Publish and document the opt-in HTTP port
+
+**Files:**
+- Modify: `docker-compose.yml:184-198`
+- Modify: `services/studio_mock/app.py:130-165`
+- Modify: `docs/operations/keycloak-admin-access.md:21-40`
+- Modify: `tests/test_studio_runtime_configuration_mock.py`
+- Test: `tests/test_studio_runtime_configuration_mock_compose.py`
+
+**Interfaces:**
+- Consumes: Docker Compose `studio-mock` profile and existing port 8010.
+- Produces: unauthenticated `http://<host-ip>:8010/internal/plugins/ssf/v1/runtime-configuration`.
+
+- [x] **Step 1: Write the failing endpoint and Compose regression tests**
+
+```python
+def test_returns_configuration_without_authorization() -> None:
+    response = CLIENT.get(
+        PATH,
+        headers={"X-Tenant-Id": "tenant-kassel", "X-Correlation-Id": "test-correlation-id"},
+    )
+
+    assert response.status_code == 200
+
+
+def test_studio_mock_publishes_http_port_on_all_interfaces() -> None:
+    compose = yaml.safe_load(Path("docker-compose.yml").read_text())
+
+    assert compose["services"]["studio-mock"]["ports"] == ["8010:8000"]
+```
+
+- [x] **Step 2: Run the tests to verify they fail**
+
+Run: `pytest tests/test_studio_runtime_configuration_mock.py::test_returns_configuration_without_authorization tests/test_studio_runtime_configuration_mock_compose.py::test_studio_mock_publishes_http_port_on_all_interfaces -v`
+
+Expected: FAIL because the endpoint currently returns `401` and the mapping is `127.0.0.1:8010:8000`.
+
+- [x] **Step 3: Change the port mapping and runbook**
+
+```yaml
+ports:
+  - "8010:8000"
+```
+
+Remove the endpoint's `Authorization` parameter and its `401`/`403` paths, and change the port mapping to `8010:8000`. Document `http://<host-ip>:8010/internal/plugins/ssf/v1/runtime-configuration` as unauthenticated and limited to fixed, non-sensitive test data.
+
+- [x] **Step 4: Run focused verification**
+
+Run: `pytest tests/test_studio_runtime_configuration_mock.py tests/test_studio_runtime_configuration_mock_compose.py -q && openspec validate add-studio-runtime-configuration-mock --strict`
+
+Expected: PASS with all mock and Compose tests passing and a valid OpenSpec change.
+
+- [x] **Step 5: Commit**
+
+```bash
+git add docker-compose.yml docs/operations/keycloak-admin-access.md tests/test_studio_runtime_configuration_mock_compose.py openspec/changes/add-studio-runtime-configuration-mock docs/superpowers/plans/2026-09-08-studio-runtime-mock-external-http.md
+git commit -m "feat(dev): expose Studio mock over HTTP"
+```

--- a/docs/superpowers/plans/2026-09-08-studio-runtime-mock-v1-contract-correction.md
+++ b/docs/superpowers/plans/2026-09-08-studio-runtime-mock-v1-contract-correction.md
@@ -1,0 +1,130 @@
+# Studio Runtime Mock V1 Contract Correction Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the Studio Runtime Configuration mock contract-faithful, protected, and directly swappable with the future Studio endpoint.
+
+**Architecture:** The mock keeps the real V1 path but requires a fixed mock service token, a Studio instance header, and a correlation ID. Compose returns to loopback-only exposure. Consumers address it through a configurable base URL: local SSF containers use `http://studio-mock:8000`; replacing that single base URL with the Studio origin preserves the endpoint path and request/response contract.
+
+**Tech Stack:** FastAPI, Pydantic, Docker Compose, pytest, GitHub Issues.
+
+**Spec:** `docs/superpowers/specs/2026-09-08-studio-runtime-configuration-mock-v1-contract-correction-design.md`
+
+## Global Constraints
+
+- The mock MUST use `Authorization`, `X-Studio-Instance-Id`, and `X-Correlation-Id`; it MUST NOT use `tenantId` query selection.
+- The mock MUST bind only to `127.0.0.1:8010` when its profile is explicitly enabled.
+- The mock MUST return only fixed, non-sensitive data and no Traefik route.
+- The caller-facing base URL is configurable; never hard-code a mock host in SSF client code.
+
+---
+
+### Task 1: Implement the V1 request and response surface
+
+**Files:**
+- Modify: `services/studio_mock/app.py`
+- Modify: `tests/test_studio_runtime_configuration_mock.py`
+- Modify: `openspec/changes/add-studio-runtime-configuration-mock/`
+
+**Interfaces:**
+- Consumes: `Authorization: Bearer studio-mock-authorized-token`, `X-Studio-Instance-Id`, and `X-Correlation-Id`.
+- Produces: a V1 configuration containing canonical SHA-256 `configurationRevision` and `authorizationRevision`.
+
+- [x] **Step 1: Write failing V1 request-contract tests**
+
+```python
+def test_returns_v1_configuration_for_authorized_studio_instance() -> None:
+    response = CLIENT.get(
+        PATH,
+        headers={
+            "Authorization": "Bearer studio-mock-authorized-token",
+            "X-Studio-Instance-Id": "tenant-kassel",
+            "X-Correlation-Id": "test-correlation-id",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["localization"]["defaultLocale"] == "de-DE"
+    assert "authorizationRevision" in response.json()
+```
+
+Add separate tests for missing/unknown token (`401`), known unauthorized token (`403`), missing Studio instance or correlation header (`400`), unknown instance (`404`), authorization projection pending (`409`), unavailable dependency (`503`), and rejected `tenantId` query selection.
+
+- [x] **Step 2: Run the new tests to verify they fail**
+
+Run: `pytest tests/test_studio_runtime_configuration_mock.py -q`
+
+Expected: FAIL because the endpoint still accepts unauthenticated query-selected tenants and emits legacy localization fields.
+
+- [x] **Step 3: Implement the minimum contract correction**
+
+Implement the two fixed token states, require the three V1 headers, remove `tenantId`, add `400`, `401`, and `403` error documentation, rename the locale fields, and calculate both revisions from canonical payloads that exclude their respective revision fields.
+
+- [x] **Step 4: Run focused verification**
+
+Run: `pytest tests/test_studio_runtime_configuration_mock.py tests/test_studio_runtime_configuration_mock_compose.py -q && openspec validate add-studio-runtime-configuration-mock --strict`
+
+Expected: PASS with V1 request, response, revision, error, and Compose tests green.
+
+- [x] **Step 5: Commit**
+
+```bash
+git add services/studio_mock/app.py tests/test_studio_runtime_configuration_mock.py openspec/changes/add-studio-runtime-configuration-mock
+git commit -m "fix(dev): align Studio mock with V1 contract"
+```
+
+### Task 2: Restore protected local operation and give implementers a swappable endpoint
+
+**Files:**
+- Modify: `docker-compose.yml`
+- Modify: `docs/operations/keycloak-admin-access.md`
+- Modify: `tests/test_studio_runtime_configuration_mock_compose.py`
+- Modify: GitHub issue `#287`
+
+**Interfaces:**
+- Consumes: opt-in `studio-mock` Compose profile.
+- Produces: loopback URL `http://127.0.0.1:8010` for host checks and Docker-network base URL `http://studio-mock:8000` for SSF implementation.
+
+- [ ] **Step 1: Write failing Compose and runbook tests**
+
+```python
+assert service["ports"] == ["127.0.0.1:8010:8000"]
+assert "http://studio-mock:8000" in runbook
+assert "studio-mock-authorized-token" in runbook
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pytest tests/test_studio_runtime_configuration_mock_compose.py -q`
+
+Expected: FAIL because the current mock binds to all host interfaces and the runbook documents an unauthenticated browser URL.
+
+- [ ] **Step 3: Apply protected-operation configuration and documentation**
+
+Restore `127.0.0.1:8010:8000`. Document the required headers, both fixed test tokens, and the two base URLs. State that SSF must obtain the base URL from configuration (for example, `STUDIO_RUNTIME_CONFIGURATION_BASE_URL`) and retain `/internal/plugins/ssf/v1/runtime-configuration`, so replacing the mock requires only the base URL change.
+
+- [ ] **Step 4: Update implementation issue #287**
+
+Post an English comment containing:
+
+```text
+Mock base URL for SSF containers: http://studio-mock:8000
+Path: /internal/plugins/ssf/v1/runtime-configuration
+Required headers: Authorization, X-Studio-Instance-Id, X-Correlation-Id
+Authorized test token: Bearer studio-mock-authorized-token
+```
+
+State that the client must make its base URL configurable and that production switches only that setting to Studio.
+
+- [ ] **Step 5: Rebuild, restart, and smoke test**
+
+Run: `docker compose --profile studio-mock up -d --build --force-recreate studio-mock`
+
+Verify an authorized `curl` to `127.0.0.1:8010` returns `tenant-kassel`, and verify Docker reports the loopback port mapping.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docker-compose.yml docs/operations/keycloak-admin-access.md tests/test_studio_runtime_configuration_mock_compose.py
+git commit -m "fix(dev): protect Studio mock endpoint"
+```

--- a/docs/superpowers/plans/2026-09-08-studio-runtime-mock-v1-contract-correction.md
+++ b/docs/superpowers/plans/2026-09-08-studio-runtime-mock-v1-contract-correction.md
@@ -85,7 +85,7 @@ git commit -m "fix(dev): align Studio mock with V1 contract"
 - Consumes: opt-in `studio-mock` Compose profile.
 - Produces: loopback URL `http://127.0.0.1:8010` for host checks and Docker-network base URL `http://studio-mock:8000` for SSF implementation.
 
-- [ ] **Step 1: Write failing Compose and runbook tests**
+- [x] **Step 1: Write failing Compose and runbook tests**
 
 ```python
 assert service["ports"] == ["127.0.0.1:8010:8000"]
@@ -93,17 +93,17 @@ assert "http://studio-mock:8000" in runbook
 assert "studio-mock-authorized-token" in runbook
 ```
 
-- [ ] **Step 2: Run the tests to verify they fail**
+- [x] **Step 2: Run the tests to verify they fail**
 
 Run: `pytest tests/test_studio_runtime_configuration_mock_compose.py -q`
 
 Expected: FAIL because the current mock binds to all host interfaces and the runbook documents an unauthenticated browser URL.
 
-- [ ] **Step 3: Apply protected-operation configuration and documentation**
+- [x] **Step 3: Apply protected-operation configuration and documentation**
 
 Restore `127.0.0.1:8010:8000`. Document the required headers, both fixed test tokens, and the two base URLs. State that SSF must obtain the base URL from configuration (for example, `STUDIO_RUNTIME_CONFIGURATION_BASE_URL`) and retain `/internal/plugins/ssf/v1/runtime-configuration`, so replacing the mock requires only the base URL change.
 
-- [ ] **Step 4: Update implementation issue #287**
+- [x] **Step 4: Update implementation issue #287**
 
 Post an English comment containing:
 
@@ -116,13 +116,13 @@ Authorized test token: Bearer studio-mock-authorized-token
 
 State that the client must make its base URL configurable and that production switches only that setting to Studio.
 
-- [ ] **Step 5: Rebuild, restart, and smoke test**
+- [x] **Step 5: Rebuild, restart, and smoke test**
 
 Run: `docker compose --profile studio-mock up -d --build --force-recreate studio-mock`
 
 Verify an authorized `curl` to `127.0.0.1:8010` returns `tenant-kassel`, and verify Docker reports the loopback port mapping.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add docker-compose.yml docs/operations/keycloak-admin-access.md tests/test_studio_runtime_configuration_mock_compose.py

--- a/docs/superpowers/specs/2026-09-08-studio-runtime-configuration-mock-v1-contract-correction-design.md
+++ b/docs/superpowers/specs/2026-09-08-studio-runtime-configuration-mock-v1-contract-correction-design.md
@@ -1,0 +1,86 @@
+# Studio Runtime Configuration Mock V1 Contract Correction Design
+
+## Context
+
+The existing mock was intentionally made browser-accessible over public HTTP.
+Review feedback establishes that this differs from the current Studio--SSF V1
+contract: Studio instance identity, a service token with an explicit
+permission, and a correlation identifier are required. The response structure
+also needs authorization metadata and locale naming aligned with the contract.
+
+## Goals
+
+- Exercise the V1 request contract with `Authorization`,
+  `X-Studio-Instance-Id`, and `X-Correlation-Id`.
+- Model deterministic authentication, authorization, tenant, authorization
+  projection, and dependency failures with the stable V1 error envelope.
+- Return contract-correct locale fields plus deterministic SHA-256
+  configuration and authorization revisions.
+- Restrict the mock to opt-in, loopback-only access.
+
+## Non-Goals
+
+- Validate real Studio-issued tokens or call an identity provider.
+- Change SSF production authentication or tenant persistence.
+- Provide browser access to the protected internal endpoint.
+
+## Decisions
+
+### Request authentication and identity
+
+The mock accepts two fixed service tokens. `Bearer
+studio-mock-authorized-token` has `ssf.runtime-configuration.read` and is the
+only token that can receive a configuration. `Bearer
+studio-mock-unauthorized-token` represents an authenticated caller without
+that permission. A missing or unknown token produces `401
+SERVICE_UNAUTHENTICATED`; the known unauthorized token produces `403
+SERVICE_FORBIDDEN`.
+
+`X-Studio-Instance-Id` is the sole tenant selector. `X-Correlation-Id` is
+required and echoed in every error envelope. Missing either required header
+produces a stable `400` envelope. The removed `tenantId` query parameter is
+not interpreted.
+
+### Response and revisions
+
+Configuration fixtures use `localization.defaultLocale`,
+`localization.locales`, and each locale's `locale` property. The effective
+configuration excluding `configurationRevision` is serialized deterministically
+with sorted keys and compact separators, then SHA-256 hashed. The mock uses
+the same deterministic process for the authorization fixture excluding
+`authorizationRevision`; both values are emitted as `sha256:` followed by 64
+lowercase hexadecimal characters.
+
+### Failure simulation
+
+`X-Mock-Scenario: authorization-pending` returns `409
+AUTHORIZATION_PROJECTION_PENDING`. `X-Mock-Scenario: unavailable` returns
+`503 RUNTIME_CONFIGURATION_UNAVAILABLE`. An unknown Studio instance returns
+`404 TENANT_NOT_FOUND`. These, authentication, authorization, and missing
+header failures share the V1 `contractVersion` and `error` envelope.
+
+### Exposure
+
+The `studio-mock` Compose service remains opt-in but binds only to
+`127.0.0.1:8010`. It has no Traefik labels and no public HTTP route. The
+runbook describes local internal-contract requests rather than browser URLs.
+
+## Risks and Mitigations
+
+- Fixed tokens might be mistaken for production credentials: use clearly
+  mock-specific values and document that no real token validation occurs.
+- Revision drift: contract tests recompute both hashes from the returned
+  canonical payloads.
+- Consumers relying on the temporary query parameter: remove it deliberately
+  and test that identity only comes from the required header.
+
+## Migration Plan
+
+1. Replace the query/header compatibility tests with the V1 request contract.
+2. Update mock fixtures, endpoint behavior, OpenAPI, and runbook together.
+3. Rebuild and restart only the opt-in mock profile; verify it binds to
+   loopback and returns a configuration for the authorized request.
+
+## Open Questions
+
+None. The fixed-token mapping is intentionally local to this mock.

--- a/openspec/changes/add-studio-runtime-configuration-mock/design.md
+++ b/openspec/changes/add-studio-runtime-configuration-mock/design.md
@@ -8,20 +8,18 @@ adding a shortcut inside SSF.
 ## Decisions
 
 - The mock is a standalone FastAPI service at the exact V1 path.
-- It reads no real credentials and deliberately accepts unauthenticated
-  requests because it serves only fixed, non-sensitive test data.
+- It reads no real credentials but models fixed service-token authentication
+  and `ssf.runtime-configuration.read` authorization.
 - A request header selects a documented error scenario only in the mock.
-- Docker Compose publishes the mock as `http://<host-ip>:8010` only through
+- Docker Compose publishes the mock as `http://127.0.0.1:8010` only through
   the explicitly selected `studio-mock` profile. It does not use Traefik or
-  TLS because this is a temporary test dependency.
-- Production Compose services never depend on or route to the mock. Operators
-  who enable the profile accept that its HTTP port is externally reachable.
+  TLS because this is an internal test dependency.
+- Production Compose services never depend on or route to the mock.
 
 ## Risks and Mitigations
 
 - Contract drift: verify response schemas and error envelopes in tests.
-- Misuse as a production dependency: the endpoint is intentionally
-  unauthenticated and unencrypted, so it remains isolated behind an explicit
-  profile and contains only fixed test data.
-- Accidental exposure: isolate the service behind an opt-in profile and
-  document that the port binds to all interfaces.
+- Contract drift: validate the mandatory V1 headers, V1 locale names, error
+  envelopes, and canonical revisions in tests.
+- Accidental exposure: isolate the service behind an opt-in profile and bind
+  it only to loopback.

--- a/openspec/changes/add-studio-runtime-configuration-mock/design.md
+++ b/openspec/changes/add-studio-runtime-configuration-mock/design.md
@@ -8,13 +8,20 @@ adding a shortcut inside SSF.
 ## Decisions
 
 - The mock is a standalone FastAPI service at the exact V1 path.
-- It reads no real credentials and accepts only documented test bearer tokens.
+- It reads no real credentials and deliberately accepts unauthenticated
+  requests because it serves only fixed, non-sensitive test data.
 - A request header selects a documented error scenario only in the mock.
-- Docker Compose exposes it only through the `studio-mock` profile.
-- Production Compose services never depend on, route to, or enable the mock.
+- Docker Compose publishes the mock as `http://<host-ip>:8010` only through
+  the explicitly selected `studio-mock` profile. It does not use Traefik or
+  TLS because this is a temporary test dependency.
+- Production Compose services never depend on or route to the mock. Operators
+  who enable the profile accept that its HTTP port is externally reachable.
 
 ## Risks and Mitigations
 
 - Contract drift: verify response schemas and error envelopes in tests.
-- Accidental production use: isolate the service behind an opt-in profile and
-  use a distinct local URL.
+- Misuse as a production dependency: the endpoint is intentionally
+  unauthenticated and unencrypted, so it remains isolated behind an explicit
+  profile and contains only fixed test data.
+- Accidental exposure: isolate the service behind an opt-in profile and
+  document that the port binds to all interfaces.

--- a/openspec/changes/add-studio-runtime-configuration-mock/design.md
+++ b/openspec/changes/add-studio-runtime-configuration-mock/design.md
@@ -1,0 +1,20 @@
+## Context
+
+SSF will call Studio's internal Runtime Configuration V1 API. Developers need
+a deterministic peer while Studio is unavailable or while reproducing error
+handling. The mock must exercise the published HTTP contract, rather than
+adding a shortcut inside SSF.
+
+## Decisions
+
+- The mock is a standalone FastAPI service at the exact V1 path.
+- It reads no real credentials and accepts only documented test bearer tokens.
+- A request header selects a documented error scenario only in the mock.
+- Docker Compose exposes it only through the `studio-mock` profile.
+- Production Compose services never depend on, route to, or enable the mock.
+
+## Risks and Mitigations
+
+- Contract drift: verify response schemas and error envelopes in tests.
+- Accidental production use: isolate the service behind an opt-in profile and
+  use a distinct local URL.

--- a/openspec/changes/add-studio-runtime-configuration-mock/proposal.md
+++ b/openspec/changes/add-studio-runtime-configuration-mock/proposal.md
@@ -8,16 +8,18 @@ is available in every developer environment.
 
 ## What Changes
 
-- Add a local-only FastAPI mock for the Studio Runtime Configuration V1 read API.
+- Add an opt-in FastAPI mock for the Studio Runtime Configuration V1 read API.
 - Serve deterministic configurations for two tenants and the `ask` and
   `disabled` conversation-storage policies.
-- Provide deterministic `401`, `403`, `404`, `409`, and `503` error envelopes.
-- Package the mock in a dedicated Docker Compose profile that production
-  deployments do not enable.
+- Provide deterministic `404`, `409`, and `503` error envelopes.
+- Package the mock in a dedicated Docker Compose profile and publish its HTTP
+  port on all host network interfaces when that profile is explicitly enabled.
 
 ## Impact
 
 - Affected capability: Studio--SSF runtime configuration integration.
-- Affected code: local development Compose configuration, mock service, and
+- Affected code: Compose configuration, mock service documentation, and
   contract tests.
 - No production authentication, tenant isolation, or persistence path changes.
+  The mock deliberately has no authentication because it serves only fixed,
+  non-sensitive test data.

--- a/openspec/changes/add-studio-runtime-configuration-mock/proposal.md
+++ b/openspec/changes/add-studio-runtime-configuration-mock/proposal.md
@@ -11,9 +11,10 @@ is available in every developer environment.
 - Add an opt-in FastAPI mock for the Studio Runtime Configuration V1 read API.
 - Serve deterministic configurations for two tenants and the `ask` and
   `disabled` conversation-storage policies.
-- Provide deterministic `404`, `409`, and `503` error envelopes.
-- Package the mock in a dedicated Docker Compose profile and publish its HTTP
-  port on all host network interfaces when that profile is explicitly enabled.
+- Provide deterministic `400`, `401`, `403`, `404`, `409`, and `503` error
+  envelopes.
+- Package the mock in a dedicated Docker Compose profile with loopback-only
+  HTTP exposure.
 
 ## Impact
 
@@ -21,5 +22,5 @@ is available in every developer environment.
 - Affected code: Compose configuration, mock service documentation, and
   contract tests.
 - No production authentication, tenant isolation, or persistence path changes.
-  The mock deliberately has no authentication because it serves only fixed,
-  non-sensitive test data.
+  The mock models fixed service-token authorization without real credential
+  validation.

--- a/openspec/changes/add-studio-runtime-configuration-mock/proposal.md
+++ b/openspec/changes/add-studio-runtime-configuration-mock/proposal.md
@@ -1,0 +1,23 @@
+# Change: Add Studio runtime configuration mock
+
+## Why
+
+The SSF implementation and tester-release verification need a contract-faithful
+Studio Runtime Configuration V1 dependency before the deployed Studio endpoint
+is available in every developer environment.
+
+## What Changes
+
+- Add a local-only FastAPI mock for the Studio Runtime Configuration V1 read API.
+- Serve deterministic configurations for two tenants and the `ask` and
+  `disabled` conversation-storage policies.
+- Provide deterministic `401`, `403`, `404`, `409`, and `503` error envelopes.
+- Package the mock in a dedicated Docker Compose profile that production
+  deployments do not enable.
+
+## Impact
+
+- Affected capability: Studio--SSF runtime configuration integration.
+- Affected code: local development Compose configuration, mock service, and
+  contract tests.
+- No production authentication, tenant isolation, or persistence path changes.

--- a/openspec/changes/add-studio-runtime-configuration-mock/specs/studio-runtime-configuration-mock/spec.md
+++ b/openspec/changes/add-studio-runtime-configuration-mock/specs/studio-runtime-configuration-mock/spec.md
@@ -1,15 +1,14 @@
 ## ADDED Requirements
 
-### Requirement: Contract-faithful local runtime configuration mock
+### Requirement: Contract-faithful opt-in runtime configuration mock
 
-The system SHALL provide an opt-in local service implementing
+The system SHALL provide an opt-in service implementing
 `GET /internal/plugins/ssf/v1/runtime-configuration` for Studio--SSF Runtime
 Configuration Contract V1 development and tests.
 
 #### Scenario: Tenant configuration is returned
 
-- **WHEN** a request presents a valid mock service token and a supported
-  `X-Tenant-Id`
+- **WHEN** a request presents a supported `X-Tenant-Id`
 - **THEN** the service returns a Contract V1 configuration for that tenant
 
 ### Requirement: Deterministic storage-policy and error testing
@@ -22,12 +21,15 @@ conversation-content storage policies and the documented error envelopes.
 - **WHEN** a request selects the mock not-ready scenario
 - **THEN** the service returns a `409` error envelope without tenant content
 
-### Requirement: Production exclusion
+### Requirement: Explicitly enabled HTTP exposure
 
-The mock MUST NOT start or be reachable from the production Compose topology
-unless an operator explicitly enables its local development profile.
+The mock MUST publish `http://<host-ip>:8010` on all host network interfaces
+only when an operator explicitly enables its `studio-mock` Compose profile.
+The mock MUST NOT require authentication because it serves only fixed,
+non-sensitive test data.
 
-#### Scenario: Default Compose startup
+#### Scenario: Explicit profile startup
 
-- **WHEN** Docker Compose starts without the mock profile
-- **THEN** no Studio mock container is started
+- **WHEN** an operator starts Docker Compose with the `studio-mock` profile
+- **THEN** a network client can request the mock through the host IP and port
+  8010 without authentication

--- a/openspec/changes/add-studio-runtime-configuration-mock/specs/studio-runtime-configuration-mock/spec.md
+++ b/openspec/changes/add-studio-runtime-configuration-mock/specs/studio-runtime-configuration-mock/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: Contract-faithful local runtime configuration mock
+
+The system SHALL provide an opt-in local service implementing
+`GET /internal/plugins/ssf/v1/runtime-configuration` for Studio--SSF Runtime
+Configuration Contract V1 development and tests.
+
+#### Scenario: Tenant configuration is returned
+
+- **WHEN** a request presents a valid mock service token and a supported
+  `X-Tenant-Id`
+- **THEN** the service returns a Contract V1 configuration for that tenant
+
+### Requirement: Deterministic storage-policy and error testing
+
+The mock SHALL provide two tenant configurations with `ask` and `disabled`
+conversation-content storage policies and the documented error envelopes.
+
+#### Scenario: Tenant is not ready
+
+- **WHEN** a request selects the mock not-ready scenario
+- **THEN** the service returns a `409` error envelope without tenant content
+
+### Requirement: Production exclusion
+
+The mock MUST NOT start or be reachable from the production Compose topology
+unless an operator explicitly enables its local development profile.
+
+#### Scenario: Default Compose startup
+
+- **WHEN** Docker Compose starts without the mock profile
+- **THEN** no Studio mock container is started

--- a/openspec/changes/add-studio-runtime-configuration-mock/specs/studio-runtime-configuration-mock/spec.md
+++ b/openspec/changes/add-studio-runtime-configuration-mock/specs/studio-runtime-configuration-mock/spec.md
@@ -8,35 +8,34 @@ Configuration Contract V1 development and tests.
 
 #### Scenario: Tenant configuration is returned
 
-- **WHEN** a request presents a supported `X-Tenant-Id` header or `tenantId`
-  query parameter
+- **WHEN** a request presents an authorized bearer service token,
+  `X-Studio-Instance-Id`, and `X-Correlation-Id`
 - **THEN** the service returns a Contract V1 configuration for that tenant
 
-#### Scenario: Browser query parameter conflicts with header
+#### Scenario: Service token lacks permission
 
-- **WHEN** a request presents different tenant IDs in `X-Tenant-Id` and
-  `tenantId`
-- **THEN** the service returns a `400` error envelope
+- **WHEN** a request uses the known mock service token without
+  `ssf.runtime-configuration.read`
+- **THEN** the service returns a `403` error envelope
 
 ### Requirement: Deterministic storage-policy and error testing
 
 The mock SHALL provide two tenant configurations with `ask` and `disabled`
 conversation-content storage policies and the documented error envelopes.
 
-#### Scenario: Tenant is not ready
+#### Scenario: Authorization projection is pending
 
-- **WHEN** a request selects the mock not-ready scenario
+- **WHEN** a request selects the mock authorization-pending scenario
 - **THEN** the service returns a `409` error envelope without tenant content
 
-### Requirement: Explicitly enabled HTTP exposure
+### Requirement: Protected internal mock exposure
 
-The mock MUST publish `http://<host-ip>:8010` on all host network interfaces
-only when an operator explicitly enables its `studio-mock` Compose profile.
-The mock MUST NOT require authentication because it serves only fixed,
-non-sensitive test data.
+The mock MUST publish `http://127.0.0.1:8010` only when an operator explicitly
+enables its `studio-mock` Compose profile. It MUST NOT publish a Traefik route
+or accept an unauthenticated runtime-configuration request.
 
 #### Scenario: Explicit profile startup
 
 - **WHEN** an operator starts Docker Compose with the `studio-mock` profile
-- **THEN** a network client can request the mock through the host IP and port
-  8010 without authentication
+- **THEN** an internal caller can request the mock through loopback port 8010
+  with the required V1 request headers

--- a/openspec/changes/add-studio-runtime-configuration-mock/specs/studio-runtime-configuration-mock/spec.md
+++ b/openspec/changes/add-studio-runtime-configuration-mock/specs/studio-runtime-configuration-mock/spec.md
@@ -8,8 +8,15 @@ Configuration Contract V1 development and tests.
 
 #### Scenario: Tenant configuration is returned
 
-- **WHEN** a request presents a supported `X-Tenant-Id`
+- **WHEN** a request presents a supported `X-Tenant-Id` header or `tenantId`
+  query parameter
 - **THEN** the service returns a Contract V1 configuration for that tenant
+
+#### Scenario: Browser query parameter conflicts with header
+
+- **WHEN** a request presents different tenant IDs in `X-Tenant-Id` and
+  `tenantId`
+- **THEN** the service returns a `400` error envelope
 
 ### Requirement: Deterministic storage-policy and error testing
 

--- a/openspec/changes/add-studio-runtime-configuration-mock/tasks.md
+++ b/openspec/changes/add-studio-runtime-configuration-mock/tasks.md
@@ -16,4 +16,4 @@
 - [x] 3.1 Require Studio instance and correlation headers, and model service
   token authorization.
 - [x] 3.2 Align authorization and locale response fields with Contract V1.
-- [ ] 3.3 Restore loopback-only operation and document the swappable endpoint.
+- [x] 3.3 Restore loopback-only operation and document the swappable endpoint.

--- a/openspec/changes/add-studio-runtime-configuration-mock/tasks.md
+++ b/openspec/changes/add-studio-runtime-configuration-mock/tasks.md
@@ -1,0 +1,11 @@
+## 1. Mock API
+
+- [x] 1.1 Define deterministic tenant configuration fixtures and error envelopes.
+- [x] 1.2 Implement the V1 runtime-configuration endpoint and bearer-token checks.
+- [x] 1.3 Add endpoint contract tests for success, storage policies, and errors.
+
+## 2. Local operation
+
+- [x] 2.1 Add a Docker image and an opt-in Compose profile for the mock.
+- [x] 2.2 Document local startup, test tokens, and the production exclusion.
+- [x] 2.3 Verify the mock is reachable only when its profile is enabled.

--- a/openspec/changes/add-studio-runtime-configuration-mock/tasks.md
+++ b/openspec/changes/add-studio-runtime-configuration-mock/tasks.md
@@ -1,7 +1,8 @@
 ## 1. Mock API
 
 - [x] 1.1 Define deterministic tenant configuration fixtures and error envelopes.
-- [x] 1.2 Implement the unauthenticated V1 runtime-configuration endpoint.
+- [x] 1.2 Implement the V1 runtime-configuration endpoint with fixed mock
+  service-token authorization.
 - [x] 1.3 Add endpoint contract tests for success, storage policies, and errors.
 
 ## 2. Local operation
@@ -10,8 +11,9 @@
 - [x] 2.2 Document profile-gated startup and the fixed mock-data scope.
 - [x] 2.3 Verify the mock is reachable only when its profile is enabled.
 
-## 3. External HTTP test access
+## 3. V1 contract correction
 
-- [x] 3.1 Publish the opt-in mock port on all host network interfaces.
-- [x] 3.2 Document the unauthenticated HTTP-by-IP URL and mock-data scope.
-- [x] 3.3 Add and run a Compose regression test for the external port binding.
+- [x] 3.1 Require Studio instance and correlation headers, and model service
+  token authorization.
+- [x] 3.2 Align authorization and locale response fields with Contract V1.
+- [ ] 3.3 Restore loopback-only operation and document the swappable endpoint.

--- a/openspec/changes/add-studio-runtime-configuration-mock/tasks.md
+++ b/openspec/changes/add-studio-runtime-configuration-mock/tasks.md
@@ -1,11 +1,17 @@
 ## 1. Mock API
 
 - [x] 1.1 Define deterministic tenant configuration fixtures and error envelopes.
-- [x] 1.2 Implement the V1 runtime-configuration endpoint and bearer-token checks.
+- [x] 1.2 Implement the unauthenticated V1 runtime-configuration endpoint.
 - [x] 1.3 Add endpoint contract tests for success, storage policies, and errors.
 
 ## 2. Local operation
 
 - [x] 2.1 Add a Docker image and an opt-in Compose profile for the mock.
-- [x] 2.2 Document local startup, test tokens, and the production exclusion.
+- [x] 2.2 Document profile-gated startup and the fixed mock-data scope.
 - [x] 2.3 Verify the mock is reachable only when its profile is enabled.
+
+## 3. External HTTP test access
+
+- [x] 3.1 Publish the opt-in mock port on all host network interfaces.
+- [x] 3.2 Document the unauthenticated HTTP-by-IP URL and mock-data scope.
+- [x] 3.3 Add and run a Compose regression test for the external port binding.

--- a/services/studio_mock/Dockerfile
+++ b/services/studio_mock/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY services/api_gateway/requirements.txt /tmp/requirements.txt
+RUN python -m pip install --disable-pip-version-check --no-cache-dir --require-hashes \
+    -r /tmp/requirements.txt \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/* /tmp/requirements.txt \
+    && addgroup --system app \
+    && adduser --system --ingroup app app
+
+COPY services/__init__.py /app/services/__init__.py
+COPY services/studio_mock/ /app/services/studio_mock/
+
+ENV PYTHONPATH=/app
+USER app
+
+CMD ["uvicorn", "services.studio_mock.app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/studio_mock/__init__.py
+++ b/services/studio_mock/__init__.py
@@ -1,0 +1,1 @@
+"""Local Studio contract mock used by SSF integration tests."""

--- a/services/studio_mock/app.py
+++ b/services/studio_mock/app.py
@@ -1,18 +1,20 @@
-"""Contract-faithful local implementation of Studio Runtime Configuration V1."""
+"""Contract-faithful Studio Runtime Configuration V1 mock."""
 
 import hashlib
 import json
 from copy import deepcopy
 from typing import Any
 
-from fastapi import FastAPI, Header, Query
+from fastapi import FastAPI, Header
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, ConfigDict, Field
 
 app = FastAPI(title="Studio Runtime Configuration Mock")
 
-_UNAVAILABLE_MESSAGE = "The requested tenant is unavailable."
 _CONTRACT_VERSION = "1.0"
+_AUTHORIZED_TOKEN = "Bearer studio-mock-authorized-token"
+_UNAUTHORIZED_TOKEN = "Bearer studio-mock-unauthorized-token"
+_UNAVAILABLE_MESSAGE = "The requested tenant is unavailable."
 
 
 class RuntimeError(BaseModel):
@@ -38,15 +40,23 @@ class RuntimeErrorEnvelope(BaseModel):
 _ERROR_RESPONSES = {
     400: {
         "model": RuntimeErrorEnvelope,
-        "description": "The tenant header and query parameter conflict.",
+        "description": "A required header is missing.",
+    },
+    401: {
+        "model": RuntimeErrorEnvelope,
+        "description": "Service authentication failed.",
+    },
+    403: {
+        "model": RuntimeErrorEnvelope,
+        "description": "Service permission is missing.",
     },
     404: {
         "model": RuntimeErrorEnvelope,
-        "description": "The requested tenant does not exist.",
+        "description": "The Studio instance does not exist.",
     },
     409: {
         "model": RuntimeErrorEnvelope,
-        "description": "The requested tenant is not ready.",
+        "description": "Authorization projection is pending.",
     },
     503: {
         "model": RuntimeErrorEnvelope,
@@ -64,10 +74,10 @@ _TENANT_CONFIGURATION_TEMPLATES: dict[str, dict[str, Any]] = {
         },
         "branding": {"logo": None, "icon": None},
         "localization": {
-            "defaultLanguage": "de-DE",
-            "languages": [
+            "defaultLocale": "de-DE",
+            "locales": [
                 {
-                    "language": "de-DE",
+                    "locale": "de-DE",
                     "authenticatedHomeExplanationHtml": "<p>Test environment</p>",
                     "guestExplanationHtml": "<p>Guest test environment</p>",
                     "conversationContentStorageQuestionHtml": "<p>Store this conversation?</p>",
@@ -85,10 +95,10 @@ _TENANT_CONFIGURATION_TEMPLATES: dict[str, dict[str, Any]] = {
         },
         "branding": {"logo": None, "icon": None},
         "localization": {
-            "defaultLanguage": "de-DE",
-            "languages": [
+            "defaultLocale": "de-DE",
+            "locales": [
                 {
-                    "language": "de-DE",
+                    "locale": "de-DE",
                     "authenticatedHomeExplanationHtml": "<p>Test environment</p>",
                     "guestExplanationHtml": "<p>Guest test environment</p>",
                     "conversationContentStorageQuestionHtml": None,
@@ -100,15 +110,23 @@ _TENANT_CONFIGURATION_TEMPLATES: dict[str, dict[str, Any]] = {
 }
 
 
-def _configuration_for(tenant_id: str) -> dict[str, Any]:
-    """Return a configuration with its revision derived from canonical payload JSON."""
-    configuration = deepcopy(_TENANT_CONFIGURATION_TEMPLATES[tenant_id])
+def _revision(payload: dict[str, Any]) -> str:
+    """Return the V1 SHA-256 revision for a canonical JSON payload."""
     canonical_json = json.dumps(
-        configuration, ensure_ascii=False, separators=(",", ":"), sort_keys=True
+        payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True
     ).encode()
-    configuration["configurationRevision"] = (
-        f"sha256:{hashlib.sha256(canonical_json).hexdigest()}"
-    )
+    return f"sha256:{hashlib.sha256(canonical_json).hexdigest()}"
+
+
+def _configuration_for(studio_instance_id: str) -> dict[str, Any]:
+    """Return the effective configuration and its two deterministic revisions."""
+    configuration = deepcopy(_TENANT_CONFIGURATION_TEMPLATES[studio_instance_id])
+    authorization = {
+        "studioInstanceId": studio_instance_id,
+        "permissions": ["ssf.runtime-configuration.read"],
+    }
+    configuration["authorizationRevision"] = _revision(authorization)
+    configuration["configurationRevision"] = _revision(configuration)
     return configuration
 
 
@@ -140,31 +158,30 @@ def _error_response(
     responses=_ERROR_RESPONSES,
 )
 def runtime_configuration(
-    x_tenant_id: str | None = Header(default=None),
-    tenant_id_query: str | None = Query(default=None, alias="tenantId"),
+    authorization: str | None = Header(default=None),
+    x_studio_instance_id: str | None = Header(default=None),
     x_correlation_id: str | None = Header(default=None),
     x_mock_scenario: str | None = Header(default=None),
 ) -> dict[str, Any] | JSONResponse:
-    """Return deterministic Runtime Configuration V1 data for local integration tests."""
-    if (
-        x_tenant_id is not None
-        and tenant_id_query is not None
-        and x_tenant_id != tenant_id_query
-    ):
+    """Return deterministic V1 data for authorized Studio service callers."""
+    if authorization not in {_AUTHORIZED_TOKEN, _UNAUTHORIZED_TOKEN}:
+        return _error_response(401, "SERVICE_UNAUTHENTICATED", x_correlation_id, False)
+    if authorization == _UNAUTHORIZED_TOKEN:
+        return _error_response(403, "SERVICE_FORBIDDEN", x_correlation_id, False)
+    if x_studio_instance_id is None:
         return _error_response(
-            400,
-            "TENANT_ID_CONFLICT",
-            x_correlation_id,
-            False,
-            "X-Tenant-Id and tenantId must match.",
+            400, "STUDIO_INSTANCE_ID_REQUIRED", x_correlation_id, False
         )
-    if x_mock_scenario == "not-ready":
-        return _error_response(409, "TENANT_NOT_READY", x_correlation_id, False)
+    if x_correlation_id is None:
+        return _error_response(400, "CORRELATION_ID_REQUIRED", None, False)
+    if x_mock_scenario == "authorization-pending":
+        return _error_response(
+            409, "AUTHORIZATION_PROJECTION_PENDING", x_correlation_id, True
+        )
     if x_mock_scenario == "unavailable":
         return _error_response(
             503, "RUNTIME_CONFIGURATION_UNAVAILABLE", x_correlation_id, True
         )
-    tenant_id = tenant_id_query if tenant_id_query is not None else x_tenant_id
-    if tenant_id not in _TENANT_CONFIGURATION_TEMPLATES:
+    if x_studio_instance_id not in _TENANT_CONFIGURATION_TEMPLATES:
         return _error_response(404, "TENANT_NOT_FOUND", x_correlation_id, False)
-    return _configuration_for(tenant_id)
+    return _configuration_for(x_studio_instance_id)

--- a/services/studio_mock/app.py
+++ b/services/studio_mock/app.py
@@ -6,6 +6,7 @@ from copy import deepcopy
 from typing import Any
 
 from fastapi import FastAPI, Header
+from fastapi.openapi.utils import get_openapi
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -33,6 +34,78 @@ class RuntimeErrorEnvelope(BaseModel):
 
     contract_version: str = Field(alias="contractVersion")
     error: RuntimeError
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class TenantResponse(BaseModel):
+    """The tenant section of a V1 runtime configuration."""
+
+    id: str
+    display_name: str = Field(alias="displayName")
+    time_zone: str = Field(alias="timeZone")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class BrandingAssetResponse(BaseModel):
+    """An optional logo or icon asset in a V1 runtime configuration."""
+
+    url: str
+    alternative_text: str = Field(alias="alternativeText")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class BrandingResponse(BaseModel):
+    """The branding section of a V1 runtime configuration."""
+
+    logo: BrandingAssetResponse | None
+    icon: BrandingAssetResponse | None
+
+
+class LocaleResponse(BaseModel):
+    """A localized V1 runtime configuration entry."""
+
+    locale: str
+    authenticated_home_explanation_html: str = Field(
+        alias="authenticatedHomeExplanationHtml"
+    )
+    guest_explanation_html: str = Field(alias="guestExplanationHtml")
+    conversation_content_storage_question_html: str | None = Field(
+        alias="conversationContentStorageQuestionHtml"
+    )
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class LocalizationResponse(BaseModel):
+    """The localization section of a V1 runtime configuration."""
+
+    default_locale: str = Field(alias="defaultLocale")
+    locales: list[LocaleResponse]
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class ConversationContentStorageResponse(BaseModel):
+    """The conversation-content storage policy section."""
+
+    mode: str
+
+
+class RuntimeConfigurationResponse(BaseModel):
+    """The successful Studio Runtime Configuration V1 response."""
+
+    contract_version: str = Field(alias="contractVersion")
+    configuration_revision: str = Field(alias="configurationRevision")
+    authorization_revision: str = Field(alias="authorizationRevision")
+    tenant: TenantResponse
+    branding: BrandingResponse
+    localization: LocalizationResponse
+    conversation_content_storage: ConversationContentStorageResponse = Field(
+        alias="conversationContentStorage"
+    )
 
     model_config = ConfigDict(populate_by_name=True)
 
@@ -154,7 +227,7 @@ def _error_response(
 
 @app.get(
     "/internal/plugins/ssf/v1/runtime-configuration",
-    response_model=None,
+    response_model=RuntimeConfigurationResponse,
     responses=_ERROR_RESPONSES,
 )
 def runtime_configuration(
@@ -185,3 +258,26 @@ def runtime_configuration(
     if x_studio_instance_id not in _TENANT_CONFIGURATION_TEMPLATES:
         return _error_response(404, "TENANT_NOT_FOUND", x_correlation_id, False)
     return _configuration_for(x_studio_instance_id)
+
+
+def _custom_openapi() -> dict[str, Any]:
+    """Document V1-required headers while preserving custom error envelopes."""
+    if app.openapi_schema:
+        return app.openapi_schema
+    schema = get_openapi(title=app.title, version=app.version, routes=app.routes)
+    parameters = schema["paths"]["/internal/plugins/ssf/v1/runtime-configuration"][
+        "get"
+    ]["parameters"]
+    for parameter in parameters:
+        if parameter["in"] == "header" and parameter["name"] in {
+            "authorization",
+            "x-studio-instance-id",
+            "x-correlation-id",
+        }:
+            parameter["required"] = True
+            parameter["schema"] = {"type": "string"}
+    app.openapi_schema = schema
+    return app.openapi_schema
+
+
+app.openapi = _custom_openapi

--- a/services/studio_mock/app.py
+++ b/services/studio_mock/app.py
@@ -1,0 +1,165 @@
+"""Contract-faithful local implementation of Studio Runtime Configuration V1."""
+
+import hashlib
+import json
+from copy import deepcopy
+from typing import Any
+
+from fastapi import FastAPI, Header
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, ConfigDict, Field
+
+app = FastAPI(title="Studio Runtime Configuration Mock")
+
+_SERVICE_TOKEN = "Bearer studio-mock-service-token"
+_UNAVAILABLE_MESSAGE = "The requested tenant is unavailable."
+_CONTRACT_VERSION = "1.0"
+
+
+class RuntimeError(BaseModel):
+    """The nested error object defined by the Studio V1 contract."""
+
+    code: str
+    message: str
+    retryable: bool
+    correlation_id: str | None = Field(alias="correlationId")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class RuntimeErrorEnvelope(BaseModel):
+    """The Studio V1 error envelope returned for every non-success response."""
+
+    contract_version: str = Field(alias="contractVersion")
+    error: RuntimeError
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+_ERROR_RESPONSES = {
+    401: {
+        "model": RuntimeErrorEnvelope,
+        "description": "Service authentication is missing.",
+    },
+    403: {
+        "model": RuntimeErrorEnvelope,
+        "description": "Service authentication is invalid.",
+    },
+    404: {
+        "model": RuntimeErrorEnvelope,
+        "description": "The requested tenant does not exist.",
+    },
+    409: {
+        "model": RuntimeErrorEnvelope,
+        "description": "The requested tenant is not ready.",
+    },
+    503: {
+        "model": RuntimeErrorEnvelope,
+        "description": "Runtime configuration is unavailable.",
+    },
+}
+
+_TENANT_CONFIGURATION_TEMPLATES: dict[str, dict[str, Any]] = {
+    "tenant-kassel": {
+        "contractVersion": _CONTRACT_VERSION,
+        "tenant": {
+            "id": "tenant-kassel",
+            "displayName": "Kassel Test Municipality",
+            "timeZone": "Europe/Berlin",
+        },
+        "branding": {"logo": None, "icon": None},
+        "localization": {
+            "defaultLanguage": "de-DE",
+            "languages": [
+                {
+                    "language": "de-DE",
+                    "authenticatedHomeExplanationHtml": "<p>Test environment</p>",
+                    "guestExplanationHtml": "<p>Guest test environment</p>",
+                    "conversationContentStorageQuestionHtml": "<p>Store this conversation?</p>",
+                }
+            ],
+        },
+        "conversationContentStorage": {"mode": "ask"},
+    },
+    "tenant-fulda": {
+        "contractVersion": _CONTRACT_VERSION,
+        "tenant": {
+            "id": "tenant-fulda",
+            "displayName": "Fulda Test Municipality",
+            "timeZone": "Europe/Berlin",
+        },
+        "branding": {"logo": None, "icon": None},
+        "localization": {
+            "defaultLanguage": "de-DE",
+            "languages": [
+                {
+                    "language": "de-DE",
+                    "authenticatedHomeExplanationHtml": "<p>Test environment</p>",
+                    "guestExplanationHtml": "<p>Guest test environment</p>",
+                    "conversationContentStorageQuestionHtml": None,
+                }
+            ],
+        },
+        "conversationContentStorage": {"mode": "disabled"},
+    },
+}
+
+
+def _configuration_for(tenant_id: str) -> dict[str, Any]:
+    """Return a configuration with its revision derived from canonical payload JSON."""
+    configuration = deepcopy(_TENANT_CONFIGURATION_TEMPLATES[tenant_id])
+    canonical_json = json.dumps(
+        configuration, ensure_ascii=False, separators=(",", ":"), sort_keys=True
+    ).encode()
+    configuration["configurationRevision"] = (
+        f"sha256:{hashlib.sha256(canonical_json).hexdigest()}"
+    )
+    return configuration
+
+
+def _error_response(
+    status_code: int,
+    code: str,
+    correlation_id: str | None,
+    retryable: bool,
+) -> JSONResponse:
+    """Return the stable Studio V1 error envelope without tenant content."""
+    return JSONResponse(
+        status_code=status_code,
+        content={
+            "contractVersion": _CONTRACT_VERSION,
+            "error": {
+                "code": code,
+                "message": _UNAVAILABLE_MESSAGE,
+                "retryable": retryable,
+                "correlationId": correlation_id,
+            },
+        },
+    )
+
+
+@app.get(
+    "/internal/plugins/ssf/v1/runtime-configuration",
+    response_model=None,
+    responses=_ERROR_RESPONSES,
+)
+def runtime_configuration(
+    authorization: str | None = Header(default=None),
+    x_tenant_id: str | None = Header(default=None),
+    x_correlation_id: str | None = Header(default=None),
+    x_mock_scenario: str | None = Header(default=None),
+) -> dict[str, Any] | JSONResponse:
+    """Return deterministic Runtime Configuration V1 data for local integration tests."""
+    if authorization is None:
+        return _error_response(401, "SERVICE_UNAUTHENTICATED", x_correlation_id, False)
+    if authorization != _SERVICE_TOKEN:
+        return _error_response(403, "SERVICE_FORBIDDEN", x_correlation_id, False)
+    if x_mock_scenario == "not-ready":
+        return _error_response(409, "TENANT_NOT_READY", x_correlation_id, False)
+    if x_mock_scenario == "unavailable":
+        return _error_response(
+            503, "RUNTIME_CONFIGURATION_UNAVAILABLE", x_correlation_id, True
+        )
+    if x_tenant_id not in _TENANT_CONFIGURATION_TEMPLATES:
+        return _error_response(404, "TENANT_NOT_FOUND", x_correlation_id, False)
+    return _configuration_for(x_tenant_id)

--- a/services/studio_mock/app.py
+++ b/services/studio_mock/app.py
@@ -11,7 +11,6 @@ from pydantic import BaseModel, ConfigDict, Field
 
 app = FastAPI(title="Studio Runtime Configuration Mock")
 
-_SERVICE_TOKEN = "Bearer studio-mock-service-token"
 _UNAVAILABLE_MESSAGE = "The requested tenant is unavailable."
 _CONTRACT_VERSION = "1.0"
 
@@ -37,14 +36,6 @@ class RuntimeErrorEnvelope(BaseModel):
 
 
 _ERROR_RESPONSES = {
-    401: {
-        "model": RuntimeErrorEnvelope,
-        "description": "Service authentication is missing.",
-    },
-    403: {
-        "model": RuntimeErrorEnvelope,
-        "description": "Service authentication is invalid.",
-    },
     404: {
         "model": RuntimeErrorEnvelope,
         "description": "The requested tenant does not exist.",
@@ -144,16 +135,11 @@ def _error_response(
     responses=_ERROR_RESPONSES,
 )
 def runtime_configuration(
-    authorization: str | None = Header(default=None),
     x_tenant_id: str | None = Header(default=None),
     x_correlation_id: str | None = Header(default=None),
     x_mock_scenario: str | None = Header(default=None),
 ) -> dict[str, Any] | JSONResponse:
     """Return deterministic Runtime Configuration V1 data for local integration tests."""
-    if authorization is None:
-        return _error_response(401, "SERVICE_UNAUTHENTICATED", x_correlation_id, False)
-    if authorization != _SERVICE_TOKEN:
-        return _error_response(403, "SERVICE_FORBIDDEN", x_correlation_id, False)
     if x_mock_scenario == "not-ready":
         return _error_response(409, "TENANT_NOT_READY", x_correlation_id, False)
     if x_mock_scenario == "unavailable":

--- a/services/studio_mock/app.py
+++ b/services/studio_mock/app.py
@@ -5,7 +5,7 @@ import json
 from copy import deepcopy
 from typing import Any
 
-from fastapi import FastAPI, Header
+from fastapi import FastAPI, Header, Query
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -36,6 +36,10 @@ class RuntimeErrorEnvelope(BaseModel):
 
 
 _ERROR_RESPONSES = {
+    400: {
+        "model": RuntimeErrorEnvelope,
+        "description": "The tenant header and query parameter conflict.",
+    },
     404: {
         "model": RuntimeErrorEnvelope,
         "description": "The requested tenant does not exist.",
@@ -113,6 +117,7 @@ def _error_response(
     code: str,
     correlation_id: str | None,
     retryable: bool,
+    message: str = _UNAVAILABLE_MESSAGE,
 ) -> JSONResponse:
     """Return the stable Studio V1 error envelope without tenant content."""
     return JSONResponse(
@@ -121,7 +126,7 @@ def _error_response(
             "contractVersion": _CONTRACT_VERSION,
             "error": {
                 "code": code,
-                "message": _UNAVAILABLE_MESSAGE,
+                "message": message,
                 "retryable": retryable,
                 "correlationId": correlation_id,
             },
@@ -136,16 +141,30 @@ def _error_response(
 )
 def runtime_configuration(
     x_tenant_id: str | None = Header(default=None),
+    tenant_id_query: str | None = Query(default=None, alias="tenantId"),
     x_correlation_id: str | None = Header(default=None),
     x_mock_scenario: str | None = Header(default=None),
 ) -> dict[str, Any] | JSONResponse:
     """Return deterministic Runtime Configuration V1 data for local integration tests."""
+    if (
+        x_tenant_id is not None
+        and tenant_id_query is not None
+        and x_tenant_id != tenant_id_query
+    ):
+        return _error_response(
+            400,
+            "TENANT_ID_CONFLICT",
+            x_correlation_id,
+            False,
+            "X-Tenant-Id and tenantId must match.",
+        )
     if x_mock_scenario == "not-ready":
         return _error_response(409, "TENANT_NOT_READY", x_correlation_id, False)
     if x_mock_scenario == "unavailable":
         return _error_response(
             503, "RUNTIME_CONFIGURATION_UNAVAILABLE", x_correlation_id, True
         )
-    if x_tenant_id not in _TENANT_CONFIGURATION_TEMPLATES:
+    tenant_id = tenant_id_query if tenant_id_query is not None else x_tenant_id
+    if tenant_id not in _TENANT_CONFIGURATION_TEMPLATES:
         return _error_response(404, "TENANT_NOT_FOUND", x_correlation_id, False)
-    return _configuration_for(x_tenant_id)
+    return _configuration_for(tenant_id)

--- a/tests/test_studio_runtime_configuration_mock.py
+++ b/tests/test_studio_runtime_configuration_mock.py
@@ -10,6 +10,8 @@ from services.studio_mock.app import app
 
 CLIENT = TestClient(app)
 PATH = "/internal/plugins/ssf/v1/runtime-configuration"
+
+
 def _headers(tenant_id: str = "tenant-kassel", **additional: str) -> dict[str, str]:
     return {
         "X-Tenant-Id": tenant_id,
@@ -76,6 +78,31 @@ def test_returns_configuration_without_authorization() -> None:
     assert response.json()["tenant"]["id"] == "tenant-kassel"
 
 
+def test_returns_configuration_for_browser_query_parameter() -> None:
+    response = CLIENT.get(PATH, params={"tenantId": "tenant-fulda"})
+
+    assert response.status_code == 200
+    assert response.json()["tenant"]["id"] == "tenant-fulda"
+
+
+def test_rejects_conflicting_header_and_browser_query_tenant_ids() -> None:
+    response = CLIENT.get(PATH, headers=_headers(), params={"tenantId": "tenant-fulda"})
+
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == "TENANT_ID_CONFLICT"
+
+
+def test_rejects_empty_header_that_conflicts_with_browser_query_tenant_id() -> None:
+    response = CLIENT.get(
+        PATH,
+        headers={"X-Tenant-Id": ""},
+        params={"tenantId": "tenant-fulda"},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == "TENANT_ID_CONFLICT"
+
+
 def test_returns_not_found_for_unknown_tenant() -> None:
     response = CLIENT.get(PATH, headers=_headers("tenant-unknown"))
 
@@ -113,7 +140,7 @@ def test_returns_documented_mock_failure_envelopes() -> None:
 def test_openapi_documents_every_runtime_configuration_error() -> None:
     responses = CLIENT.get("/openapi.json").json()["paths"][PATH]["get"]["responses"]
 
-    for status_code in ("404", "409", "503"):
+    for status_code in ("400", "404", "409", "503"):
         assert responses[status_code]["description"]
         assert responses[status_code]["content"]["application/json"]["schema"]["$ref"].endswith(
             "RuntimeErrorEnvelope"

--- a/tests/test_studio_runtime_configuration_mock.py
+++ b/tests/test_studio_runtime_configuration_mock.py
@@ -146,3 +146,39 @@ def test_openapi_documents_every_runtime_configuration_error() -> None:
         assert responses[status_code]["content"]["application/json"]["schema"]["$ref"].endswith(
             "RuntimeErrorEnvelope"
         )
+
+
+def test_openapi_documents_required_v1_headers_and_success_contract() -> None:
+    schema = CLIENT.get("/openapi.json").json()
+    operation = schema["paths"][PATH]["get"]
+    headers = {
+        parameter["name"]: parameter
+        for parameter in operation["parameters"]
+        if parameter["in"] == "header"
+    }
+
+    for header_name in (
+        "authorization",
+        "x-studio-instance-id",
+        "x-correlation-id",
+    ):
+        assert headers[header_name]["required"] is True
+        assert headers[header_name]["schema"] == {"type": "string"}
+
+    success_schema = operation["responses"]["200"]["content"]["application/json"][
+        "schema"
+    ]
+    assert success_schema["$ref"].endswith("RuntimeConfigurationResponse")
+    response_definition = schema["components"]["schemas"]["RuntimeConfigurationResponse"]
+    assert {"configurationRevision", "authorizationRevision", "localization"} <= set(
+        response_definition["properties"]
+    )
+    branding_definition = schema["components"]["schemas"]["BrandingResponse"]
+    logo_schema = branding_definition["properties"]["logo"]
+    assert {
+        item["$ref"]
+        for item in logo_schema["anyOf"]
+        if "$ref" in item
+    } == {"#/components/schemas/BrandingAssetResponse"}
+    asset_definition = schema["components"]["schemas"]["BrandingAssetResponse"]
+    assert {"url", "alternativeText"} <= set(asset_definition["properties"])

--- a/tests/test_studio_runtime_configuration_mock.py
+++ b/tests/test_studio_runtime_configuration_mock.py
@@ -1,0 +1,123 @@
+"""Contract tests for the local Studio Runtime Configuration V1 mock."""
+
+import hashlib
+import json
+import re
+
+from fastapi.testclient import TestClient
+
+from services.studio_mock.app import app
+
+CLIENT = TestClient(app)
+PATH = "/internal/plugins/ssf/v1/runtime-configuration"
+TOKEN = "Bearer studio-mock-service-token"
+
+
+def _headers(tenant_id: str = "tenant-kassel", **additional: str) -> dict[str, str]:
+    return {
+        "Authorization": TOKEN,
+        "X-Tenant-Id": tenant_id,
+        "X-Correlation-Id": "test-correlation-id",
+        **additional,
+    }
+
+
+def test_returns_ask_policy_configuration_for_first_test_tenant() -> None:
+    response = CLIENT.get(PATH, headers=_headers())
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload == {
+        "contractVersion": "1.0",
+        "configurationRevision": payload["configurationRevision"],
+        "tenant": {
+            "id": "tenant-kassel",
+            "displayName": "Kassel Test Municipality",
+            "timeZone": "Europe/Berlin",
+        },
+        "branding": {"logo": None, "icon": None},
+        "localization": {
+            "defaultLanguage": "de-DE",
+            "languages": [
+                {
+                    "language": "de-DE",
+                    "authenticatedHomeExplanationHtml": "<p>Test environment</p>",
+                    "guestExplanationHtml": "<p>Guest test environment</p>",
+                    "conversationContentStorageQuestionHtml": "<p>Store this conversation?</p>",
+                }
+            ],
+        },
+        "conversationContentStorage": {"mode": "ask"},
+    }
+    revision = payload.pop("configurationRevision")
+    assert re.fullmatch(r"sha256:[0-9a-f]{64}", revision)
+    expected_revision = hashlib.sha256(
+        json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode()
+    ).hexdigest()
+    assert revision == f"sha256:{expected_revision}"
+
+
+def test_returns_disabled_policy_for_second_test_tenant() -> None:
+    response = CLIENT.get(PATH, headers=_headers("tenant-fulda"))
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["tenant"]["id"] == "tenant-fulda"
+    assert payload["conversationContentStorage"] == {"mode": "disabled"}
+    assert payload["localization"]["languages"][0]["conversationContentStorageQuestionHtml"] is None
+
+
+def test_rejects_missing_or_invalid_service_token() -> None:
+    unauthenticated = CLIENT.get(PATH, headers={"X-Tenant-Id": "tenant-kassel"})
+    assert unauthenticated.status_code == 401
+    assert unauthenticated.json()["contractVersion"] == "1.0"
+
+    response = CLIENT.get(PATH, headers=_headers(Authorization="Bearer wrong-token"))
+
+    assert response.status_code == 403
+    assert response.json()["contractVersion"] == "1.0"
+    assert response.json()["error"]["code"] == "SERVICE_FORBIDDEN"
+
+
+def test_returns_not_found_for_unknown_tenant() -> None:
+    response = CLIENT.get(PATH, headers=_headers("tenant-unknown"))
+
+    assert response.status_code == 404
+    assert response.json() == {
+        "contractVersion": "1.0",
+        "error": {
+            "code": "TENANT_NOT_FOUND",
+            "message": "The requested tenant is unavailable.",
+            "retryable": False,
+            "correlationId": "test-correlation-id",
+        },
+    }
+
+
+def test_returns_documented_mock_failure_envelopes() -> None:
+    for scenario, status_code, code, retryable in [
+        ("not-ready", 409, "TENANT_NOT_READY", False),
+        ("unavailable", 503, "RUNTIME_CONFIGURATION_UNAVAILABLE", True),
+    ]:
+        response = CLIENT.get(PATH, headers=_headers(**{"X-Mock-Scenario": scenario}))
+
+        assert response.status_code == status_code
+        assert response.json() == {
+            "contractVersion": "1.0",
+            "error": {
+                "code": code,
+                "message": "The requested tenant is unavailable.",
+                "retryable": retryable,
+                "correlationId": "test-correlation-id",
+            },
+        }
+
+
+def test_openapi_documents_every_runtime_configuration_error() -> None:
+    responses = CLIENT.get("/openapi.json").json()["paths"][PATH]["get"]["responses"]
+
+    for status_code in ("401", "403", "404", "409", "503"):
+        assert responses[status_code]["description"]
+        assert responses[status_code]["content"]["application/json"]["schema"]["$ref"].endswith(
+            "RuntimeErrorEnvelope"
+        )

--- a/tests/test_studio_runtime_configuration_mock.py
+++ b/tests/test_studio_runtime_configuration_mock.py
@@ -1,4 +1,4 @@
-"""Contract tests for the local Studio Runtime Configuration V1 mock."""
+"""Contract tests for the Studio Runtime Configuration V1 mock."""
 
 import hashlib
 import json
@@ -10,17 +10,22 @@ from services.studio_mock.app import app
 
 CLIENT = TestClient(app)
 PATH = "/internal/plugins/ssf/v1/runtime-configuration"
+AUTHORIZED_TOKEN = "Bearer studio-mock-authorized-token"
+UNAUTHORIZED_TOKEN = "Bearer studio-mock-unauthorized-token"
 
 
-def _headers(tenant_id: str = "tenant-kassel", **additional: str) -> dict[str, str]:
+def _headers(
+    studio_instance_id: str = "tenant-kassel", **additional: str
+) -> dict[str, str]:
     return {
-        "X-Tenant-Id": tenant_id,
+        "Authorization": AUTHORIZED_TOKEN,
+        "X-Studio-Instance-Id": studio_instance_id,
         "X-Correlation-Id": "test-correlation-id",
         **additional,
     }
 
 
-def test_returns_ask_policy_configuration_for_first_test_tenant() -> None:
+def test_returns_v1_configuration_for_authorized_studio_instance() -> None:
     response = CLIENT.get(PATH, headers=_headers())
 
     assert response.status_code == 200
@@ -28,6 +33,7 @@ def test_returns_ask_policy_configuration_for_first_test_tenant() -> None:
     assert payload == {
         "contractVersion": "1.0",
         "configurationRevision": payload["configurationRevision"],
+        "authorizationRevision": payload["authorizationRevision"],
         "tenant": {
             "id": "tenant-kassel",
             "displayName": "Kassel Test Municipality",
@@ -35,10 +41,10 @@ def test_returns_ask_policy_configuration_for_first_test_tenant() -> None:
         },
         "branding": {"logo": None, "icon": None},
         "localization": {
-            "defaultLanguage": "de-DE",
-            "languages": [
+            "defaultLocale": "de-DE",
+            "locales": [
                 {
-                    "language": "de-DE",
+                    "locale": "de-DE",
                     "authenticatedHomeExplanationHtml": "<p>Test environment</p>",
                     "guestExplanationHtml": "<p>Guest test environment</p>",
                     "conversationContentStorageQuestionHtml": "<p>Store this conversation?</p>",
@@ -47,80 +53,75 @@ def test_returns_ask_policy_configuration_for_first_test_tenant() -> None:
         },
         "conversationContentStorage": {"mode": "ask"},
     }
-    revision = payload.pop("configurationRevision")
-    assert re.fullmatch(r"sha256:[0-9a-f]{64}", revision)
-    expected_revision = hashlib.sha256(
+    configuration_revision = payload.pop("configurationRevision")
+    authorization_revision = payload["authorizationRevision"]
+    assert re.fullmatch(r"sha256:[0-9a-f]{64}", configuration_revision)
+    assert re.fullmatch(r"sha256:[0-9a-f]{64}", authorization_revision)
+    expected_configuration_revision = hashlib.sha256(
         json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode()
     ).hexdigest()
-    assert revision == f"sha256:{expected_revision}"
+    assert configuration_revision == f"sha256:{expected_configuration_revision}"
 
 
-def test_returns_disabled_policy_for_second_test_tenant() -> None:
+def test_returns_disabled_policy_for_second_studio_instance() -> None:
     response = CLIENT.get(PATH, headers=_headers("tenant-fulda"))
 
     assert response.status_code == 200
     payload = response.json()
     assert payload["tenant"]["id"] == "tenant-fulda"
     assert payload["conversationContentStorage"] == {"mode": "disabled"}
-    assert payload["localization"]["languages"][0]["conversationContentStorageQuestionHtml"] is None
+    assert payload["localization"]["locales"][0]["conversationContentStorageQuestionHtml"] is None
 
 
-def test_returns_configuration_without_authorization() -> None:
-    response = CLIENT.get(
+def test_rejects_missing_or_unknown_service_token() -> None:
+    missing_token = CLIENT.get(PATH, headers={"X-Correlation-Id": "test-correlation-id"})
+    unknown_token = CLIENT.get(PATH, headers=_headers(Authorization="Bearer unknown"))
+
+    for response in (missing_token, unknown_token):
+        assert response.status_code == 401
+        assert response.json()["error"]["code"] == "SERVICE_UNAUTHENTICATED"
+
+
+def test_rejects_service_token_without_runtime_configuration_permission() -> None:
+    response = CLIENT.get(PATH, headers=_headers(Authorization=UNAUTHORIZED_TOKEN))
+
+    assert response.status_code == 403
+    assert response.json()["error"]["code"] == "SERVICE_FORBIDDEN"
+
+
+def test_requires_studio_instance_and_correlation_headers() -> None:
+    missing_instance = CLIENT.get(
         PATH,
-        headers={
-            "X-Tenant-Id": "tenant-kassel",
-            "X-Correlation-Id": "test-correlation-id",
-        },
+        headers={"Authorization": AUTHORIZED_TOKEN, "X-Correlation-Id": "test-correlation-id"},
+    )
+    missing_correlation = CLIENT.get(
+        PATH,
+        headers={"Authorization": AUTHORIZED_TOKEN, "X-Studio-Instance-Id": "tenant-kassel"},
     )
 
-    assert response.status_code == 200
-    assert response.json()["tenant"]["id"] == "tenant-kassel"
+    assert missing_instance.status_code == 400
+    assert missing_instance.json()["error"]["code"] == "STUDIO_INSTANCE_ID_REQUIRED"
+    assert missing_correlation.status_code == 400
+    assert missing_correlation.json()["error"]["code"] == "CORRELATION_ID_REQUIRED"
 
 
-def test_returns_configuration_for_browser_query_parameter() -> None:
-    response = CLIENT.get(PATH, params={"tenantId": "tenant-fulda"})
+def test_does_not_use_browser_tenant_query_parameter_for_identity() -> None:
+    response = CLIENT.get(PATH, params={"tenantId": "tenant-kassel"})
 
-    assert response.status_code == 200
-    assert response.json()["tenant"]["id"] == "tenant-fulda"
-
-
-def test_rejects_conflicting_header_and_browser_query_tenant_ids() -> None:
-    response = CLIENT.get(PATH, headers=_headers(), params={"tenantId": "tenant-fulda"})
-
-    assert response.status_code == 400
-    assert response.json()["error"]["code"] == "TENANT_ID_CONFLICT"
+    assert response.status_code == 401
+    assert response.json()["error"]["code"] == "SERVICE_UNAUTHENTICATED"
 
 
-def test_rejects_empty_header_that_conflicts_with_browser_query_tenant_id() -> None:
-    response = CLIENT.get(
-        PATH,
-        headers={"X-Tenant-Id": ""},
-        params={"tenantId": "tenant-fulda"},
-    )
-
-    assert response.status_code == 400
-    assert response.json()["error"]["code"] == "TENANT_ID_CONFLICT"
-
-
-def test_returns_not_found_for_unknown_tenant() -> None:
+def test_returns_not_found_for_unknown_studio_instance() -> None:
     response = CLIENT.get(PATH, headers=_headers("tenant-unknown"))
 
     assert response.status_code == 404
-    assert response.json() == {
-        "contractVersion": "1.0",
-        "error": {
-            "code": "TENANT_NOT_FOUND",
-            "message": "The requested tenant is unavailable.",
-            "retryable": False,
-            "correlationId": "test-correlation-id",
-        },
-    }
+    assert response.json()["error"]["code"] == "TENANT_NOT_FOUND"
 
 
 def test_returns_documented_mock_failure_envelopes() -> None:
     for scenario, status_code, code, retryable in [
-        ("not-ready", 409, "TENANT_NOT_READY", False),
+        ("authorization-pending", 409, "AUTHORIZATION_PROJECTION_PENDING", True),
         ("unavailable", 503, "RUNTIME_CONFIGURATION_UNAVAILABLE", True),
     ]:
         response = CLIENT.get(PATH, headers=_headers(**{"X-Mock-Scenario": scenario}))
@@ -140,7 +141,7 @@ def test_returns_documented_mock_failure_envelopes() -> None:
 def test_openapi_documents_every_runtime_configuration_error() -> None:
     responses = CLIENT.get("/openapi.json").json()["paths"][PATH]["get"]["responses"]
 
-    for status_code in ("400", "404", "409", "503"):
+    for status_code in ("400", "401", "403", "404", "409", "503"):
         assert responses[status_code]["description"]
         assert responses[status_code]["content"]["application/json"]["schema"]["$ref"].endswith(
             "RuntimeErrorEnvelope"

--- a/tests/test_studio_runtime_configuration_mock.py
+++ b/tests/test_studio_runtime_configuration_mock.py
@@ -10,12 +10,8 @@ from services.studio_mock.app import app
 
 CLIENT = TestClient(app)
 PATH = "/internal/plugins/ssf/v1/runtime-configuration"
-TOKEN = "Bearer studio-mock-service-token"
-
-
 def _headers(tenant_id: str = "tenant-kassel", **additional: str) -> dict[str, str]:
     return {
-        "Authorization": TOKEN,
         "X-Tenant-Id": tenant_id,
         "X-Correlation-Id": "test-correlation-id",
         **additional,
@@ -67,16 +63,17 @@ def test_returns_disabled_policy_for_second_test_tenant() -> None:
     assert payload["localization"]["languages"][0]["conversationContentStorageQuestionHtml"] is None
 
 
-def test_rejects_missing_or_invalid_service_token() -> None:
-    unauthenticated = CLIENT.get(PATH, headers={"X-Tenant-Id": "tenant-kassel"})
-    assert unauthenticated.status_code == 401
-    assert unauthenticated.json()["contractVersion"] == "1.0"
+def test_returns_configuration_without_authorization() -> None:
+    response = CLIENT.get(
+        PATH,
+        headers={
+            "X-Tenant-Id": "tenant-kassel",
+            "X-Correlation-Id": "test-correlation-id",
+        },
+    )
 
-    response = CLIENT.get(PATH, headers=_headers(Authorization="Bearer wrong-token"))
-
-    assert response.status_code == 403
-    assert response.json()["contractVersion"] == "1.0"
-    assert response.json()["error"]["code"] == "SERVICE_FORBIDDEN"
+    assert response.status_code == 200
+    assert response.json()["tenant"]["id"] == "tenant-kassel"
 
 
 def test_returns_not_found_for_unknown_tenant() -> None:
@@ -116,7 +113,7 @@ def test_returns_documented_mock_failure_envelopes() -> None:
 def test_openapi_documents_every_runtime_configuration_error() -> None:
     responses = CLIENT.get("/openapi.json").json()["paths"][PATH]["get"]["responses"]
 
-    for status_code in ("401", "403", "404", "409", "503"):
+    for status_code in ("404", "409", "503"):
         assert responses[status_code]["description"]
         assert responses[status_code]["content"]["application/json"]["schema"]["$ref"].endswith(
             "RuntimeErrorEnvelope"

--- a/tests/test_studio_runtime_configuration_mock_compose.py
+++ b/tests/test_studio_runtime_configuration_mock_compose.py
@@ -1,0 +1,26 @@
+"""Compose contract tests for the local-only Studio mock service."""
+
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).parents[1]
+RUNBOOK = ROOT / "docs/operations/keycloak-admin-access.md"
+
+
+def test_studio_mock_is_an_opt_in_local_service_without_a_traefik_route() -> None:
+    compose = yaml.safe_load((ROOT / "docker-compose.yml").read_text())
+    service = compose["services"]["studio-mock"]
+
+    assert service["profiles"] == ["studio-mock"]
+    assert service["ports"] == ["127.0.0.1:8010:8000"]
+    assert service.get("labels") is None
+    assert service["build"]["dockerfile"] == "services/studio_mock/Dockerfile"
+
+
+def test_runbook_documents_local_mock_startup_and_production_exclusion() -> None:
+    runbook = RUNBOOK.read_text()
+
+    assert "studio-mock" in runbook
+    assert "studio-mock-service-token" in runbook
+    assert "must not be enabled in production" in runbook

--- a/tests/test_studio_runtime_configuration_mock_compose.py
+++ b/tests/test_studio_runtime_configuration_mock_compose.py
@@ -1,4 +1,4 @@
-"""Compose contract tests for the local-only Studio mock service."""
+"""Compose contract tests for the opt-in Studio mock service."""
 
 from pathlib import Path
 
@@ -8,19 +8,19 @@ ROOT = Path(__file__).parents[1]
 RUNBOOK = ROOT / "docs/operations/keycloak-admin-access.md"
 
 
-def test_studio_mock_is_an_opt_in_local_service_without_a_traefik_route() -> None:
+def test_studio_mock_publishes_http_port_on_all_interfaces() -> None:
     compose = yaml.safe_load((ROOT / "docker-compose.yml").read_text())
     service = compose["services"]["studio-mock"]
 
     assert service["profiles"] == ["studio-mock"]
-    assert service["ports"] == ["127.0.0.1:8010:8000"]
+    assert service["ports"] == ["8010:8000"]
     assert service.get("labels") is None
     assert service["build"]["dockerfile"] == "services/studio_mock/Dockerfile"
 
 
-def test_runbook_documents_local_mock_startup_and_production_exclusion() -> None:
+def test_runbook_documents_unauthenticated_http_mock_startup() -> None:
     runbook = RUNBOOK.read_text()
 
     assert "studio-mock" in runbook
-    assert "studio-mock-service-token" in runbook
-    assert "must not be enabled in production" in runbook
+    assert "http://<host-ip>:8010" in runbook
+    assert "does not require authentication" in runbook

--- a/tests/test_studio_runtime_configuration_mock_compose.py
+++ b/tests/test_studio_runtime_configuration_mock_compose.py
@@ -8,19 +8,21 @@ ROOT = Path(__file__).parents[1]
 RUNBOOK = ROOT / "docs/operations/keycloak-admin-access.md"
 
 
-def test_studio_mock_publishes_http_port_on_all_interfaces() -> None:
+def test_studio_mock_is_loopback_only_without_a_traefik_route() -> None:
     compose = yaml.safe_load((ROOT / "docker-compose.yml").read_text())
     service = compose["services"]["studio-mock"]
 
     assert service["profiles"] == ["studio-mock"]
-    assert service["ports"] == ["8010:8000"]
+    assert service["ports"] == ["127.0.0.1:8010:8000"]
     assert service.get("labels") is None
     assert service["build"]["dockerfile"] == "services/studio_mock/Dockerfile"
 
 
-def test_runbook_documents_unauthenticated_http_mock_startup() -> None:
+def test_runbook_documents_protected_swappable_mock_endpoint() -> None:
     runbook = RUNBOOK.read_text()
 
     assert "studio-mock" in runbook
-    assert "http://<host-ip>:8010" in runbook
-    assert "does not require authentication" in runbook
+    assert "http://127.0.0.1:8010" in runbook
+    assert "http://studio-mock:8000" in runbook
+    assert "studio-mock-authorized-token" in runbook
+    assert "STUDIO_RUNTIME_CONFIGURATION_BASE_URL" in runbook


### PR DESCRIPTION
## Summary
- add an opt-in, local-only FastAPI mock for the Studio Runtime Configuration V1 endpoint
- provide deterministic ask and disabled storage-policy tenants plus documented failure scenarios
- document local startup and production exclusion, and cover the contract with focused tests

## Verification
- `pytest tests/test_studio_runtime_configuration_mock.py tests/test_studio_runtime_configuration_mock_compose.py -q`
- `openspec validate add-studio-runtime-configuration-mock --strict`
- `docker compose --profile studio-mock build studio-mock`
- local HTTP smoke test against `127.0.0.1:8010`