### PR TITLE
fix: close the model-service ports and make delivery telemetry and service-down alerts real

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -318,10 +318,13 @@ docker compose up
 # For direct access from the host, use an SSH tunnel that binds both the
 # Docker bridge (serving the socat containers) and loopback (serving the
 # native-gateway workflow):
+# The tunnel targets the containers on port 8000, not the GPU host's own
+# 8001-8003 -- those are what #221 closed. Read the container addresses first
+# (sudo docker inspect on the GPU host), the way the ollama tunnel does:
 #   ssh -N \
-#     -L 172.17.0.1:8001:localhost:8001 -L 127.0.0.1:8001:localhost:8001 \
-#     -L 172.17.0.1:8002:localhost:8002 -L 127.0.0.1:8002:localhost:8002 \
-#     -L 172.17.0.1:8003:localhost:8003 -L 127.0.0.1:8003:localhost:8003 \
+#     -L 172.17.0.1:8001:<asr-ip>:8000 -L 127.0.0.1:8001:<asr-ip>:8000 \
+#     -L 172.17.0.1:8002:<translation-ip>:8000 -L 127.0.0.1:8002:<translation-ip>:8000 \
+#     -L 172.17.0.1:8003:<tts-ip>:8000 -L 127.0.0.1:8003:<tts-ip>:8000 \
 #     <user>@<gpu-host>
 # <gpu-host> is the GPU server running the model containers; its address comes
 # from the deployment inventory, not from this repository.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -310,7 +310,21 @@ ssf-backend/
 # Start services in development mode
 docker compose up
 
-# Run specific service locally (for debugging)
+# Run specific service locally (for debugging). This binds a host port for a
+# process you started yourself; the asr, translation and tts containers do not
+# publish 8001-8003 any more (#221) and are reachable only inside the compose
+# network, as http://asr:8000 and so on:
+#   docker compose exec api_gateway curl http://asr:8000/health
+# For direct access from the host, use an SSH tunnel that binds both the
+# Docker bridge (serving the socat containers) and loopback (serving the
+# native-gateway workflow):
+#   ssh -N \
+#     -L 172.17.0.1:8001:localhost:8001 -L 127.0.0.1:8001:localhost:8001 \
+#     -L 172.17.0.1:8002:localhost:8002 -L 127.0.0.1:8002:localhost:8002 \
+#     -L 172.17.0.1:8003:localhost:8003 -L 127.0.0.1:8003:localhost:8003 \
+#     <user>@<gpu-host>
+# <gpu-host> is the GPU server running the model containers; its address comes
+# from the deployment inventory, not from this repository.
 source .venv/bin/activate
 uvicorn services/asr/app:app --port 8001 --reload
 

--- a/README.en.md
+++ b/README.en.md
@@ -37,14 +37,33 @@ The dependency sources are `requirements*.in` and `services/*/requirements.in`. 
 
 ## Services
 
-| Service | Development port | Responsibility |
+| Service | Reachable at | Responsibility |
 | --- | --- | --- |
-| API Gateway | 8000 | REST/WebSocket entry point and pipeline orchestration |
-| ASR | 8001 | Audio transcription |
-| Translation | 8002 | M2M100 text translation |
-| TTS | 8003 | Speech synthesis |
+| API Gateway | `localhost:8000` | REST/WebSocket entry point and pipeline orchestration |
+| ASR | `http://asr:8000`, internal | Audio transcription |
+| Translation | `http://translation:8000`, internal | M2M100 text translation |
+| TTS | `http://tts:8000`, internal | Speech synthesis |
 | Redis | internal | Session and message persistence |
 | Ollama | internal | Optional translation refinement |
+
+Since #221 the three model services are not published on the host at all: they
+listen on port 8000 inside the compose network and nothing maps them to
+`localhost:8001-8003` any more. Reach them with
+`docker compose exec api_gateway curl http://asr:8000/health`, or, for direct
+access from the host, through an SSH tunnel that binds both the Docker bridge
+(serving the socat containers) and loopback (serving the native-gateway
+workflow):
+
+```bash
+ssh -N \
+  -L 172.17.0.1:8001:localhost:8001 -L 127.0.0.1:8001:localhost:8001 \
+  -L 172.17.0.1:8002:localhost:8002 -L 127.0.0.1:8002:localhost:8002 \
+  -L 172.17.0.1:8003:localhost:8003 -L 127.0.0.1:8003:localhost:8003 \
+  <user>@<gpu-host>
+```
+
+`<gpu-host>` is the GPU server that runs the model containers; its address
+comes from the deployment inventory, not from this repository.
 
 The gateway is the public integration boundary. Clients should use the session and messaging endpoints under `/api/*`; `/pipeline` and `/upload` remain low-level/legacy endpoints.
 

--- a/README.en.md
+++ b/README.en.md
@@ -54,11 +54,23 @@ access from the host, through an SSH tunnel that binds both the Docker bridge
 (serving the socat containers) and loopback (serving the native-gateway
 workflow):
 
+The tunnel must target the containers, not the GPU host's own ports -- those
+are what this change closed. Take the same route the `ollama` tunnel does:
+read the container addresses on the GPU host, then forward to them on 8000.
+
 ```bash
+# 1. Container addresses (they change on every recreate)
+ssh <user>@<gpu-host> \
+  'for s in asr translation tts; do sudo docker inspect \
+     -f "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}" \
+     $(sudo docker ps -qf name=$s | head -1); done'
+
+# 2. Forward to those addresses on port 8000, binding both the Docker bridge
+#    (serving the socat containers) and loopback (serving the native gateway)
 ssh -N \
-  -L 172.17.0.1:8001:localhost:8001 -L 127.0.0.1:8001:localhost:8001 \
-  -L 172.17.0.1:8002:localhost:8002 -L 127.0.0.1:8002:localhost:8002 \
-  -L 172.17.0.1:8003:localhost:8003 -L 127.0.0.1:8003:localhost:8003 \
+  -L 172.17.0.1:8001:<asr-ip>:8000 -L 127.0.0.1:8001:<asr-ip>:8000 \
+  -L 172.17.0.1:8002:<translation-ip>:8000 -L 127.0.0.1:8002:<translation-ip>:8000 \
+  -L 172.17.0.1:8003:<tts-ip>:8000 -L 127.0.0.1:8003:<tts-ip>:8000 \
   <user>@<gpu-host>
 ```
 

--- a/README.md
+++ b/README.md
@@ -112,11 +112,24 @@ Der aktuelle Haupt-Workflow fuer Admin/Customer-Kommunikation ist sessionbasiert
 > `localhost` gleichzeitig bindet (die Bridge bedient die socat-Container,
 > `localhost` den nativen Gateway-Workflow):
 >
+> Der Tunnel muss auf die Container zeigen, nicht auf die Host-Ports des
+> GPU-Servers -- die schliesst genau diese Aenderung. Gleicher Weg wie beim
+> `ollama`-Tunnel: Container-Adressen auf dem GPU-Server auslesen, dann auf
+> Port 8000 weiterleiten.
+>
 > ```bash
+> # 1. Container-Adressen (aendern sich bei jedem Recreate)
+> ssh <user>@<gpu-host> \
+>   'for s in asr translation tts; do sudo docker inspect \
+>      -f "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}" \
+>      $(sudo docker ps -qf name=$s | head -1); done'
+>
+> # 2. Auf diese Adressen weiterleiten, Port 8000; gebunden an Docker-Bridge
+> #    (fuer die socat-Container) und loopback (fuer das native Gateway)
 > ssh -N \
->   -L 172.17.0.1:8001:localhost:8001 -L 127.0.0.1:8001:localhost:8001 \
->   -L 172.17.0.1:8002:localhost:8002 -L 127.0.0.1:8002:localhost:8002 \
->   -L 172.17.0.1:8003:localhost:8003 -L 127.0.0.1:8003:localhost:8003 \
+>   -L 172.17.0.1:8001:<asr-ip>:8000 -L 127.0.0.1:8001:<asr-ip>:8000 \
+>   -L 172.17.0.1:8002:<translation-ip>:8000 -L 127.0.0.1:8002:<translation-ip>:8000 \
+>   -L 172.17.0.1:8003:<tts-ip>:8000 -L 127.0.0.1:8003:<tts-ip>:8000 \
 >   <user>@<gpu-host>
 > ```
 >
@@ -134,7 +147,7 @@ Der aktuelle Haupt-Workflow fuer Admin/Customer-Kommunikation ist sessionbasiert
 - **Beispiel:**
    ```bash
    docker compose exec api_gateway \
-          curl -F "file=@sample.wav" http://asr:8000/transcribe
+          curl -F "file=@examples/audio/sample.wav" http://asr:8000/transcribe
    ```
 
 ### 2. Translation Service

--- a/README.md
+++ b/README.md
@@ -100,38 +100,61 @@ Der aktuelle Haupt-Workflow fuer Admin/Customer-Kommunikation ist sessionbasiert
       ┌────▼────┐    ┌─────▼─────┐   ┌────▼────┐   ┌────▼────┐
       │   ASR   │    │Translation│   │   TTS   │   │ Ollama  │
       │(Whisper)│    │  (M2M100) │   │(Coqui)  │   │(Refiner)│
-      │Port:8001│    │ Port:8002 │   │Port:8003│   │Port:11434│
+      │Port:8000│    │ Port:8000 │   │Port:8000│   │Port:11434│
       └─────────┘    └───────────┘   └─────────┘   └─────────┘
 ```
 
+> **Hinweis zur Erreichbarkeit (#221):** ASR, Translation und TTS lauschen
+> containerintern auf Port 8000 und werden **nicht** mehr auf dem Host
+> veröffentlicht. Im Compose-Netz erreicht man sie als `http://asr:8000`,
+> `http://translation:8000` und `http://tts:8000`; vom Host aus nur über
+> `docker compose exec` oder einen SSH-Tunnel, der die Docker-Bridge und
+> `localhost` gleichzeitig bindet (die Bridge bedient die socat-Container,
+> `localhost` den nativen Gateway-Workflow):
+>
+> ```bash
+> ssh -N \
+>   -L 172.17.0.1:8001:localhost:8001 -L 127.0.0.1:8001:localhost:8001 \
+>   -L 172.17.0.1:8002:localhost:8002 -L 127.0.0.1:8002:localhost:8002 \
+>   -L 172.17.0.1:8003:localhost:8003 -L 127.0.0.1:8003:localhost:8003 \
+>   <user>@<gpu-host>
+> ```
+>
+> `<gpu-host>` ist der GPU-Server mit den Modell-Containern; die Adresse steht
+> in der Deployment-Dokumentation, nicht in diesem Repository.
+>
+> Beispiele, die die Container über `localhost:8001-8003` ansprechen,
+> funktionieren nicht mehr.
+
 ### 1. ASR Service (Speech-to-Text)
-- **Port:** 8001
+- **Port:** 8000, nur im Compose-Netz (`http://asr:8000`)
 - **Funktion:** Automatische Spracherkennung für verschiedene Sprachen und Audioformate
 - **Modelle:** Whisper, Wav2Vec, etc. (lokal geladen)
 - **Endpunkte:** `/transcribe` (POST), `/health` (GET), `/metrics` (GET), `/supported-languages` (GET)
 - **Beispiel:**
    ```bash
-   curl -F "file=@sample.wav" http://localhost:8001/transcribe
+   docker compose exec api_gateway \
+          curl -F "file=@sample.wav" http://asr:8000/transcribe
    ```
 
 ### 2. Translation Service
-- **Port:** 8002
+- **Port:** 8000, nur im Compose-Netz (`http://translation:8000`)
 - **Funktion:** KI-basierte Übersetzung mit Facebooks m2m100_1.2B-Modell
 - **Endpunkte:** `/translate` (POST), `/languages` (GET), `/health` (GET), `/metrics` (GET)
 - **Beispiel:**
    ```bash
-   curl -X POST http://localhost:8002/translate \
+   docker compose exec api_gateway curl -X POST http://translation:8000/translate \
           -H "Content-Type: application/json" \
           -d '{"text": "Hallo Welt", "source_lang": "de", "target_lang": "en"}'
    ```
 
 ### 3. TTS Service (Text-to-Speech)
-- **Port:** 8003
+- **Port:** 8000, nur im Compose-Netz (`http://tts:8000`)
 - **Funktion:** Sprachsynthese für viele Sprachen mit Coqui-TTS und HuggingFace MMS-TTS
 - **Endpunkte:** `/synthesize` (POST), `/health` (GET), `/metrics` (GET), `/supported-languages` (GET)
 - **Beispiel:**
    ```bash
-   curl -X POST http://localhost:8003/synthesize \
+   docker compose exec api_gateway curl -X POST http://tts:8000/synthesize \
           -H "Content-Type: application/json" \
           -d '{"text": "Hello world", "lang": "en"}' --output out.wav
    ```
@@ -234,7 +257,8 @@ pip install -r requirements-dev.txt
 # Run tests
 pytest
 
-# Start individual services
+# Einzelne Services direkt auf dem Host starten (ohne Container; die Container
+# selbst veröffentlichen diese Ports seit #221 nicht mehr)
 uvicorn services/asr/app:app --port 8001 --reload
 uvicorn services/translation/app:app --port 8002 --reload
 uvicorn services/tts/app:app --port 8003 --reload
@@ -448,10 +472,10 @@ Eine ausführliche Dokumentation zu den in den Services verwendeten KI-Modellen,
 # Alle Services prüfen
 curl http://localhost:8000/health
 
-# Einzelne Services
-curl http://localhost:8001/health  # ASR
-curl http://localhost:8002/health  # Translation
-curl http://localhost:8003/health  # TTS
+# Einzelne Modell-Dienste (nur im Compose-Netz erreichbar, siehe #221)
+docker compose exec api_gateway curl http://asr:8000/health          # ASR
+docker compose exec api_gateway curl http://translation:8000/health  # Translation
+docker compose exec api_gateway curl http://tts:8000/health          # TTS
 ```
 
 ## 🐛 Troubleshooting

--- a/deploy/production/docker-compose.production.yml
+++ b/deploy/production/docker-compose.production.yml
@@ -23,8 +23,8 @@ services:
     restart: unless-stopped
     pull_policy: never
   asr:
-    ports:
-    - 8001:8000
+    expose:
+    - '8000'
     volumes:
     - ../../models:/models
     deploy:
@@ -39,8 +39,8 @@ services:
     restart: unless-stopped
     pull_policy: never
   translation:
-    ports:
-    - 8002:8000
+    expose:
+    - '8000'
     volumes:
     - ../../models:/models
     deploy:
@@ -55,8 +55,8 @@ services:
     restart: unless-stopped
     pull_policy: never
   tts:
-    ports:
-    - 8003:8000
+    expose:
+    - '8000'
     volumes:
     - ../../models:/models
     deploy:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,8 +25,11 @@ services:
     build:
       context: .
       dockerfile: services/asr/Dockerfile
-    ports:
-      - "8001:8000"
+    # #221: no host port. The gateway reaches this as http://asr:8000 over the
+    # compose network; publishing 8001 handed unauthenticated GPU capacity to
+    # anyone who could route to the host.
+    expose:
+      - "8000"
     volumes:
       - ./models:/models
     deploy:
@@ -41,8 +44,8 @@ services:
     build:
       context: .
       dockerfile: services/translation/Dockerfile
-    ports:
-      - "8002:8000"
+    expose:
+      - "8000"
     environment:
       # Inference Admission Control — inference runs off the event loop, so
       # /health and /metrics stay responsive; these bound how many beam searches
@@ -63,8 +66,8 @@ services:
     build:
       context: .
       dockerfile: services/tts/Dockerfile
-    ports:
-      - "8003:8000"
+    expose:
+      - "8000"
     volumes:
       - ./models:/models
     deploy:

--- a/docs/operations/runbooks/service-down-alerts.md
+++ b/docs/operations/runbooks/service-down-alerts.md
@@ -25,19 +25,31 @@ Keep both. They detect different failures, and neither subsumes the other.
 **A rule change is not live until Prometheus is restarted.** Neither compose
 file gives the `prometheus` service a `command:`, so `--web.enable-lifecycle` is
 off and there is no `POST /-/reload` endpoint. `alert_rules.yml` is a bind
-mount, so `docker compose up -d` sees no change to the service definition and
+mount, so `production_compose up -d` sees no change to the service definition and
 does not recreate the container. Editing the file alone leaves the old rules
 loaded and the new ones silent — the exact failure #220 exists to eliminate.
 
+**Every command in this runbook must name the production stack.** A bare
+`docker compose` from the repository root reads `docker-compose.yml` plus any
+local `docker-compose.override.yml`, under a project name derived from the
+directory — a *different* stack from the one production runs. Source the
+helper the deployment scripts use and go through `production_compose`:
+
 ```bash
-docker compose restart prometheus
+source scripts/lib/production-common.sh
+
+production_compose restart prometheus
 
 # Confirm the four scrape rules are loaded (expect: 4)
-docker compose exec api_gateway \
+production_compose exec api_gateway \
   curl -s http://prometheus:9090/api/v1/rules | grep -o ScrapeDown | wc -l
 ```
 
-Two details in that command are load-bearing. Prometheus is declared
+`production_compose` is `docker compose --project-name ssf-backend --env-file
+.env --file deploy/production/docker-compose.production.yml`; spell that out
+in full if you would rather not source the helper.
+
+Two details in the query are load-bearing. Prometheus is declared
 `expose: "9090"` and publishes no host port, so `curl localhost:9090` from the
 host is refused — the query has to run inside the compose network. And the
 rules API returns one single-line JSON body, so `grep -c` counts that one line
@@ -73,11 +85,15 @@ baselining that KPIs Q4 (delivery SLO breach rate) and R10 (SLO compliance) need
 
 ## Response
 
-1. `docker compose ps` — is the container running?
-2. `docker compose logs --tail=200 <service>` — model load failure, OOM, CUDA error?
+Source `scripts/lib/production-common.sh` first; every step below goes through
+`production_compose`, not a bare `docker compose` (see above).
+
+1. `production_compose ps` — is the container running?
+2. `production_compose logs --tail=200 <service>` — model load failure, OOM,
+   CUDA error?
 3. `nvidia-smi` — is the GPU visible and does it have free memory?
-4. `docker compose restart <service>`, then confirm the alert clears within one
-   scrape interval plus the `for` duration.
+4. `production_compose restart <service>`, then confirm the alert clears within
+   one scrape interval plus the `for` duration.
 5. If it recurs, capture the logs before restarting again and open an issue.
 
 ## Verification

--- a/docs/operations/runbooks/service-down-alerts.md
+++ b/docs/operations/runbooks/service-down-alerts.md
@@ -1,0 +1,90 @@
+# Runbook: service-down and capacity alerts
+
+## What each alert means
+
+| Alert | Fires when | Meaning |
+| --- | --- | --- |
+| `ASRScrapeDown` / `TranslationScrapeDown` / `TTSScrapeDown` | Prometheus cannot scrape the service for 2 minutes | The container is gone, wedged, or unroutable. The stage fails for every message. |
+| `ASRServiceDown` / `TranslationServiceDown` / `TTSServiceDown` | The service answers but reports `<svc>_health_status == 0` for 2 minutes | The process is alive and self-reporting unhealthy — usually the model failed to load or the GPU is unavailable. |
+| `APIGatewayScrapeDown` | Gateway unscrapeable for 1 minute | Total outage. |
+| `GPUMemoryPressure` | `DCGM_FI_DEV_FB_USED / DCGM_FI_DEV_FB_TOTAL > 0.95` for 5 minutes | See the threshold note below. |
+| `TranslationLatencyHigh` | p95 `translation_request_latency_seconds` > 3s for 5 minutes | See the threshold note below. |
+
+## Why the scrape alerts exist alongside the health alerts
+
+The `*ServiceDown` rules match `<svc>_health_status == 0`, a metric the service
+exports about itself. When the container stops, that series **disappears** — it
+does not go to zero — so the expression matches nothing and the alert stays
+silent through the exact outage it was written for. `up{job="..."} == 0` is
+produced by Prometheus, not by the target, so it survives the target's death.
+
+Keep both. They detect different failures, and neither subsumes the other.
+
+## Applying a change to `alert_rules.yml`
+
+**A rule change is not live until Prometheus is restarted.** Neither compose
+file gives the `prometheus` service a `command:`, so `--web.enable-lifecycle` is
+off and there is no `POST /-/reload` endpoint. `alert_rules.yml` is a bind
+mount, so `docker compose up -d` sees no change to the service definition and
+does not recreate the container. Editing the file alone leaves the old rules
+loaded and the new ones silent — the exact failure #220 exists to eliminate.
+
+```bash
+docker compose restart prometheus
+
+# Confirm the four scrape rules are loaded (expect: 4)
+curl -s localhost:9090/api/v1/rules | grep -c ScrapeDown
+```
+
+If that count is 0, the container is still running the previous rule file. If
+it is anything other than 4, the file was edited without updating
+`tests/test_service_down_alerting.py`, which asserts all four exist.
+
+Enabling `--web.enable-lifecycle` would allow a reload without a restart, but it
+also exposes a mutating endpoint on the Prometheus port; that is a deployment
+decision for the operator, not a default.
+
+## Threshold rationale
+
+**Scrape alerts — `for: 2m` (gateway `1m`).** The scrape interval is 15s, so 2
+minutes is eight consecutive failures: long enough to ride out a restart or a
+single missed scrape, short enough that an operator hears about a dead model
+service before more than a couple of conversations fail. The gateway gets 1
+minute because its failure is a total outage.
+
+**`GPUMemoryPressure` at 0.95 and `TranslationLatencyHigh` at 3s are inherited
+values, not measured ones.** No baseline exists to justify either. #220 requires
+recalibration "from observed baselines", and the catalogue
+(`docs/operations/conversation-quality-kpis.en.md:279`) prescribes a two-to-four
+week window. That window has not run yet.
+
+Until it has, both stay as-is and are treated as unproven. Do not tune them from
+a single incident. The observation window is tracked as part of the same
+baselining that KPIs Q4 (delivery SLO breach rate) and R10 (SLO compliance) need
+— one exercise, two consumers.
+
+## Response
+
+1. `docker compose ps` — is the container running?
+2. `docker compose logs --tail=200 <service>` — model load failure, OOM, CUDA error?
+3. `nvidia-smi` — is the GPU visible and does it have free memory?
+4. `docker compose restart <service>`, then confirm the alert clears within one
+   scrape interval plus the `for` duration.
+5. If it recurs, capture the logs before restarting again and open an issue.
+
+## Verification
+
+These rules were verified on 2026-09-07 against Prometheus v3.13.1 with a 15s
+scrape interval: the asr, translation and tts containers were each stopped and
+observed across two rounds — translation first, then asr and tts together —
+with the corresponding `*ScrapeDown` alert reaching state `firing` each time,
+and each cleared after its container was restarted. With
+`translation` stopped, `up{job="translation"}` read 0 while
+`translation_health_status` was absent from the series entirely — confirming
+directly that `TranslationServiceDown` had nothing to match, which is why both
+rule kinds are kept. `APIGatewayScrapeDown` was not exercised this way — the
+gateway is the shared local API and stopping it was not worth the disruption —
+but its rule was confirmed loaded with `for: 1m` against an existing job. See
+the issue-#220 thread for the full record. Re-verify after any change to
+`monitoring/prometheus.yml` job names — an `up{job="asr"}` alert on a job that
+no longer exists under that name is inert and silent.

--- a/docs/operations/runbooks/service-down-alerts.md
+++ b/docs/operations/runbooks/service-down-alerts.md
@@ -33,8 +33,16 @@ loaded and the new ones silent — the exact failure #220 exists to eliminate.
 docker compose restart prometheus
 
 # Confirm the four scrape rules are loaded (expect: 4)
-curl -s localhost:9090/api/v1/rules | grep -c ScrapeDown
+docker compose exec api_gateway \
+  curl -s http://prometheus:9090/api/v1/rules | grep -o ScrapeDown | wc -l
 ```
+
+Two details in that command are load-bearing. Prometheus is declared
+`expose: "9090"` and publishes no host port, so `curl localhost:9090` from the
+host is refused — the query has to run inside the compose network. And the
+rules API returns one single-line JSON body, so `grep -c` counts that one line
+and reports `1` no matter how many rules matched; `grep -o | wc -l` counts the
+matches. Both mistakes read as "the rules did not load" when they did.
 
 If that count is 0, the container is still running the previous rule file. If
 it is anything other than 4, the file was edited without updating

--- a/monitoring/alert_rules.yml
+++ b/monitoring/alert_rules.yml
@@ -83,6 +83,63 @@ groups:
 
   - name: ssf-service-health
     rules:
+      # #220: the *ServiceDown rules below match a metric scraped from the
+      # service itself, so a stopped container makes the series vanish rather
+      # than go to zero and the expression matches nothing. These fire on the
+      # scrape failing, which is the signal that survives the target's death.
+      - alert: ASRScrapeDown
+        expr: up{job="asr"} == 0
+        for: 2m
+        labels:
+          severity: critical
+          service: asr
+        annotations:
+          summary: "ASR service is not answering Prometheus"
+          description: >-
+            Prometheus has failed to scrape asr:8000 for 2 minutes. Speech
+            recognition is unavailable; every audio message will fail at the ASR
+            stage.
+          runbook_url: "https://github.com/smart-village-solutions/smart-speech-flow/blob/main/docs/operations/runbooks/service-down-alerts.md"
+
+      - alert: TranslationScrapeDown
+        expr: up{job="translation"} == 0
+        for: 2m
+        labels:
+          severity: critical
+          service: translation
+        annotations:
+          summary: "Translation service is not answering Prometheus"
+          description: >-
+            Prometheus has failed to scrape translation:8000 for 2 minutes. No
+            message in either direction can be translated.
+          runbook_url: "https://github.com/smart-village-solutions/smart-speech-flow/blob/main/docs/operations/runbooks/service-down-alerts.md"
+
+      - alert: TTSScrapeDown
+        expr: up{job="tts"} == 0
+        for: 2m
+        labels:
+          severity: critical
+          service: tts
+        annotations:
+          summary: "TTS service is not answering Prometheus"
+          description: >-
+            Prometheus has failed to scrape tts:8000 for 2 minutes. Text
+            translation may still succeed; spoken output will not.
+          runbook_url: "https://github.com/smart-village-solutions/smart-speech-flow/blob/main/docs/operations/runbooks/service-down-alerts.md"
+
+      - alert: APIGatewayScrapeDown
+        expr: up{job="api_gateway"} == 0
+        for: 1m
+        labels:
+          severity: critical
+          service: api_gateway
+        annotations:
+          summary: "API gateway is not answering Prometheus"
+          description: >-
+            Prometheus has failed to scrape api_gateway:8000 for 1 minute. The
+            whole product is down, including the WebSocket transport.
+          runbook_url: "https://github.com/smart-village-solutions/smart-speech-flow/blob/main/docs/operations/runbooks/service-down-alerts.md"
+
       - alert: ASRServiceDown
         expr: asr_health_status == 0
         for: 2m
@@ -155,15 +212,24 @@ groups:
           summary: High number of active WebSocket connections
           description: "Currently {{ $value }} active WebSocket connections. Monitor system resources and connection patterns."
 
+      # server_disconnect is excluded alongside client_disconnect: a session
+      # ending on purpose (new_session_created, manual_termination,
+      # manual_admin_termination) is routine traffic, not a failure, and
+      # terminate_all_active_sessions runs on every new session.
+      # session_expired is excluded too: a session ageing out on its own is
+      # normal lifecycle, not a connection failure. Abnormal causes --
+      # connection_error, heartbeat_timeout, rate_limit_exceeded,
+      # authentication_failed, protocol_error, origin_not_allowed -- still
+      # match.
       - alert: WebSocketConnectionFailures
-        expr: rate(websocket_disconnects_total{disconnect_reason!="client_disconnect"}[5m]) > 0.1
+        expr: rate(websocket_disconnects_total{disconnect_reason!~"client_disconnect|server_disconnect|session_expired"}[5m]) > 0.1
         for: 1m
         labels:
           severity: critical
           component: websocket
         annotations:
           summary: High WebSocket connection failure rate
-          description: "WebSocket disconnect rate of {{ $value }}/sec for non-client disconnects. Check network connectivity and server health."
+          description: "WebSocket disconnect rate of {{ $value }}/sec for disconnects that were neither a clean client exit, a deliberate server-side termination, nor an ordinary session expiry. Check network connectivity and server health."
 
       - alert: WebSocketHeartbeatLatencyHigh
         expr: histogram_quantile(0.95, sum(rate(websocket_heartbeat_latency_seconds_bucket[5m])) by (le)) > 1.0
@@ -215,7 +281,7 @@ groups:
         annotations:
           summary: High WebSocket broadcast failure rate (>1%)
           description: "Broadcast failure rate is {{ $value | humanizePercentage }}. Check WebSocketManager health and connection state."
-          runbook_url: "https://docs.smart-village.solutions/runbooks/websocket-broadcast-failures"
+          runbook_url: "https://github.com/smart-village-solutions/smart-speech-flow/blob/main/docs/operations/runbooks/websocket-broadcast-failures.md"
 
       - alert: WebSocketBroadcastMessagesNotDelivered
         expr: rate(websocket_broadcast_messages_failed_total[5m]) > 0.05

--- a/monitoring/alert_rules.yml
+++ b/monitoring/alert_rules.yml
@@ -222,14 +222,18 @@ groups:
       # authentication_failed, protocol_error, origin_not_allowed -- still
       # match.
       - alert: WebSocketConnectionFailures
-        expr: rate(websocket_disconnects_total{disconnect_reason!~"client_disconnect|server_disconnect|session_expired"}[5m]) > 0.1
+        # origin_not_allowed is excluded because WebSocketOriginBlocked below
+        # owns it at 0.01/s -- ten times more sensitive than this rule, so the
+        # warning always fires first. Counting it here as well pages critical
+        # for a CORS misconfiguration and says less than the rule built for it.
+        expr: rate(websocket_disconnects_total{disconnect_reason!~"client_disconnect|server_disconnect|session_expired|origin_not_allowed"}[5m]) > 0.1
         for: 1m
         labels:
           severity: critical
           component: websocket
         annotations:
           summary: High WebSocket connection failure rate
-          description: "WebSocket disconnect rate of {{ $value }}/sec for disconnects that were neither a clean client exit, a deliberate server-side termination, nor an ordinary session expiry. Check network connectivity and server health."
+          description: "WebSocket disconnect rate of {{ $value }}/sec for disconnects that were neither a clean client exit, a deliberate server-side termination, an ordinary session expiry, nor a blocked origin (see WebSocketOriginBlocked). Check network connectivity and server health."
 
       - alert: WebSocketHeartbeatLatencyHigh
         expr: histogram_quantile(0.95, sum(rate(websocket_heartbeat_latency_seconds_bucket[5m])) by (le)) > 1.0

--- a/services/api_gateway/app.py
+++ b/services/api_gateway/app.py
@@ -414,6 +414,13 @@ from .websocket_monitor import initialize_websocket_monitor
 
 websocket_monitor = initialize_websocket_monitor(registry)
 
+# The fallback manager is a module-level singleton built before this registry
+# exists; without this its drop counter would sit on prometheus_client's global
+# default registry, which /metrics does not serve.
+from .websocket_fallback import fallback_manager
+
+fallback_manager.bind_metrics_registry(registry)
+
 
 # === CORS Middleware ===
 # Enhanced CORS Configuration for WebSocket Support

--- a/services/api_gateway/websocket.py
+++ b/services/api_gateway/websocket.py
@@ -94,6 +94,40 @@ async def validate_websocket_origin(origin: Optional[str]) -> bool:
     return bool(re.match(production_pattern, origin))
 
 
+# RFC 6455 close codes, mapped onto the wire reasons DisconnectReason.from_wire
+# understands. A WebSocketDisconnect carries the code, and treating them all as
+# a clean client exit is what hid network and server failures from the
+# unexpected-disconnect KPI and WebSocketConnectionFailures.
+_CLOSE_CODE_REASONS = {
+    1000: "client_disconnect",  # normal closure
+    1001: "client_disconnect",  # going away: tab closed, navigation
+    1005: "client_disconnect",  # close frame carried no code
+    1002: "protocol_error",
+    1003: "protocol_error",  # unsupported data
+    1007: "protocol_error",  # invalid payload
+    1008: "protocol_error",  # policy violation
+    1009: "protocol_error",  # message too big
+    1010: "protocol_error",  # mandatory extension missing
+    1006: "connection_error",  # abnormal closure: no close frame at all
+    1011: "connection_error",  # internal server error
+    1012: "connection_error",  # service restart
+    1013: "connection_error",  # try again later
+    1014: "connection_error",  # bad gateway
+    1015: "connection_error",  # TLS handshake failure
+}
+
+
+def disconnect_reason_for_close_code(code: Optional[int]) -> str:
+    """Classify a WebSocket close code into a disconnect reason.
+
+    An unrecognised code is a connection error, not a clean exit -- the same
+    rule DisconnectReason.from_wire applies to unrecognised wire reasons.
+    """
+    if code is None:
+        return "connection_error"
+    return _CLOSE_CODE_REASONS.get(code, "connection_error")
+
+
 class ConnectionState(str, Enum):
     CONNECTING = "connecting"
     CONNECTED = "connected"
@@ -1514,9 +1548,10 @@ async def websocket_endpoint(
         return
 
     connection_id = None
-    # Only a clean break out of the receive loop keeps this. Every other exit
-    # is an abnormal termination, and reporting it as a clean client exit is
-    # what kept the unexpected-disconnect rate reading near zero.
+    # A close frame replaces this with the reason its code classifies to, and
+    # every non-close exit path sets connection_error. Reporting an abnormal
+    # termination as a clean client exit is what kept the unexpected-disconnect
+    # rate reading near zero.
     exit_reason = "client_disconnect"
 
     try:
@@ -1536,8 +1571,14 @@ async def websocket_endpoint(
                 data = await websocket.receive_json()
                 await manager.handle_websocket_message(connection_id, data)
 
-            except WebSocketDisconnect:
-                logger.info(f"🔌 WebSocket-Disconnect: {connection_id}")
+            except WebSocketDisconnect as disconnect:
+                exit_reason = disconnect_reason_for_close_code(disconnect.code)
+                logger.info(
+                    "🔌 WebSocket-Disconnect: %s (code %s, reason %s)",
+                    sanitize_log_value(str(connection_id)),
+                    disconnect.code,
+                    exit_reason,
+                )
                 break
 
             except Exception:

--- a/services/api_gateway/websocket.py
+++ b/services/api_gateway/websocket.py
@@ -363,6 +363,24 @@ class WebSocketManager:
         """
         return f"{session_id}_{client_type.value}_{uuid4().hex[:12]}"
 
+    def _registered_connection_id(
+        self, connection: "WebSocketConnection"
+    ) -> Optional[str]:
+        """The id this connection is registered under, or None if it is not.
+
+        Callers that hold a connection object and need its id must ask the map
+        that broadcast_to_session iterates. Rebuilding the id from the
+        connection's own fields worked only while it ended in a timestamp the
+        caller could recompute, and silently stopped matching anything once ids
+        became unique -- which included the sender in its own broadcast.
+        """
+        for connection_id, candidate in self.session_connections.get(
+            connection.session_id, {}
+        ).items():
+            if candidate is connection:
+                return connection_id
+        return None
+
     async def connect_websocket(
         self,
         websocket: WebSocket,
@@ -957,7 +975,7 @@ class WebSocketManager:
         await self.broadcast_to_session(
             connection.session_id,
             forward_message,
-            exclude_connection=f"{connection.session_id}_{connection.client_type.value}_{int(connection.connected_at.timestamp())}",
+            exclude_connection=self._registered_connection_id(connection),
         )
 
     async def _handle_typing_indicator(
@@ -977,7 +995,7 @@ class WebSocketManager:
         await self.broadcast_to_session(
             connection.session_id,
             typing_message,
-            exclude_connection=f"{connection.session_id}_{connection.client_type.value}_{int(connection.connected_at.timestamp())}",
+            exclude_connection=self._registered_connection_id(connection),
         )
 
     async def _send_connection_ack(self, connection: WebSocketConnection):

--- a/services/api_gateway/websocket.py
+++ b/services/api_gateway/websocket.py
@@ -14,11 +14,11 @@ import hashlib
 import logging
 import os
 import re
-import time
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from enum import Enum
 from typing import Annotated, Any, Dict, List, Optional, Set
+from uuid import uuid4
 
 from fastapi import (
     APIRouter,
@@ -351,6 +351,18 @@ class WebSocketManager:
             self.heartbeat_task = None
         logger.info("💓 Heartbeat-System gestoppt")
 
+    @staticmethod
+    def _build_connection_id(session_id: str, client_type: ClientType) -> str:
+        """A connection id must be unique, not merely descriptive.
+
+        The previous form ended in `int(time.time())`, so two sockets opened for
+        one session inside the same second collided — and the monitor keys its
+        active-connection map by this value, so the loser's metrics silently
+        became the winner's. Reconnect storms are when that happens and when the
+        connection KPIs matter most.
+        """
+        return f"{session_id}_{client_type.value}_{uuid4().hex[:12]}"
+
     async def connect_websocket(
         self,
         websocket: WebSocket,
@@ -365,7 +377,7 @@ class WebSocketManager:
         await websocket.accept()
 
         # Connection-ID generieren
-        connection_id = f"{session_id}_{client_type.value}_{int(time.time())}"
+        connection_id = self._build_connection_id(session_id, client_type)
 
         # 📱 Mobile-Detection aus client_info
         is_mobile = False
@@ -467,7 +479,9 @@ class WebSocketManager:
 
         finally:
             # Connection-Cleanup
-            await self._cleanup_connection(connection_id)
+            await self._cleanup_connection(
+                connection_id, DisconnectReason.from_wire(reason)
+            )
 
             # Anderen Clients mitteilen
             await self._broadcast_client_left(
@@ -787,7 +801,7 @@ class WebSocketManager:
         """
         Polling-Fallback für Client aktivieren
         """
-        polling_id = f"poll_{session_id}_{client_type.value}_{int(time.time())}"
+        polling_id = f"poll_{session_id}_{client_type.value}_{uuid4().hex[:12]}"
         self.polling_clients.add(polling_id)
         self.connection_stats["polling_fallbacks"] += 1
 
@@ -897,7 +911,9 @@ class WebSocketManager:
 
         # Tote Verbindungen cleanup
         for connection_id in dead_connections:
-            await self._cleanup_connection(connection_id)
+            await self._cleanup_connection(
+                connection_id, DisconnectReason.CONNECTION_ERROR
+            )
 
     async def _check_heartbeat_timeouts(self):
         """
@@ -1030,9 +1046,22 @@ class WebSocketManager:
                     break
 
             if connection_id:
-                await self._cleanup_connection(connection_id)
+                # The termination message already carries the real cause
+                # (session_timeout, new_session_created). Recording every one
+                # of them as CONNECTION_ERROR would feed routine session ends
+                # into a critical alert.
+                await self._cleanup_connection(
+                    connection_id,
+                    DisconnectReason.from_wire(
+                        termination_message.get("reason", "session_ended")
+                    ),
+                )
 
-    async def _cleanup_connection(self, connection_id: str):
+    async def _cleanup_connection(
+        self,
+        connection_id: str,
+        reason: DisconnectReason = DisconnectReason.CLIENT_DISCONNECT,
+    ):
         """
         Connection-Cleanup nach Disconnect
         """
@@ -1061,7 +1090,7 @@ class WebSocketManager:
         # 📊 Monitoring: Connection closed
         get_websocket_monitor().connection_closed(
             connection_id=connection_id,
-            reason=DisconnectReason.CLIENT_DISCONNECT,  # Default reason
+            reason=reason,
         )
 
         self._update_active_connections_count()
@@ -1075,11 +1104,13 @@ class WebSocketManager:
         """
         try:
             # Prepare error details for evaluation
+            # No connection_id: the only one available here was rebuilt from
+            # the old timestamp format, so it named no real connection, and
+            # nothing downstream of evaluate_websocket_failure reads it.
             error_details = {
                 "message": str(error),
                 "type": type(error).__name__,
                 "context": error_context,
-                "connection_id": f"{connection.session_id}_{connection.client_type.value}_{int(time.time())}",
             }
 
             # Extract additional error information
@@ -1437,6 +1468,9 @@ async def websocket_endpoint(
     """
     # 1. CORS Origin Validation (before WebSocket accept)
     if not await validate_websocket_origin(origin):
+        get_websocket_monitor().record_rejected_connection(
+            DisconnectReason.ORIGIN_NOT_ALLOWED
+        )
         await websocket.close(code=1008, reason="Origin not allowed")
         logger.warning(
             "❌ WebSocket connection rejected - invalid origin: %s",
@@ -1462,6 +1496,10 @@ async def websocket_endpoint(
         return
 
     connection_id = None
+    # Only a clean break out of the receive loop keeps this. Every other exit
+    # is an abnormal termination, and reporting it as a clean client exit is
+    # what kept the unexpected-disconnect rate reading near zero.
+    exit_reason = "client_disconnect"
 
     try:
         # 4. WebSocket-Verbindung herstellen mit origin logging
@@ -1495,15 +1533,17 @@ async def websocket_endpoint(
                 try:
                     await websocket.send_json(error_message)
                 except Exception:
+                    exit_reason = "connection_error"
                     break
 
     except Exception:
+        exit_reason = "connection_error"
         logger.exception("WebSocket connection failed")
 
     finally:
         # Cleanup bei Disconnect
         if connection_id:
-            await manager.disconnect_websocket(connection_id, "client_disconnect")
+            await manager.disconnect_websocket(connection_id, exit_reason)
 
 
 @router.get("/api/websocket/stats")

--- a/services/api_gateway/websocket_fallback.py
+++ b/services/api_gateway/websocket_fallback.py
@@ -737,12 +737,15 @@ class WebSocketFallbackManager:
         the live queue, and a caller minting entries in a loop reclaims its own
         rather than growing the map.
         """
+        candidates = (
+            self.polling_clients.get(polling_id)
+            for polling_id in self.session_polling_clients.get(session_id, set())
+        )
         peers = sorted(
             (
                 client
-                for polling_id in self.session_polling_clients.get(session_id, set())
-                if (client := self.polling_clients.get(polling_id)) is not None
-                and client.client_type == client_type
+                for client in candidates
+                if client is not None and client.client_type == client_type
             ),
             key=lambda client: client.created_at,
         )

--- a/services/api_gateway/websocket_fallback.py
+++ b/services/api_gateway/websocket_fallback.py
@@ -6,14 +6,79 @@ failure detection, CORS error handling, and seamless user experience.
 
 import asyncio
 import logging
-import time
 from collections import defaultdict, deque
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from enum import Enum
 from typing import Any, Callable, Dict, List, Optional, Set
+from uuid import uuid4
+
+from prometheus_client import CollectorRegistry, Counter
+
+from .log_safety import sanitize_log_value
+from .session_manager import ClientType
 
 logger = logging.getLogger(__name__)
+
+# The bound stays: an unbounded per-client queue is a memory risk. What changes
+# is that crossing it is counted and reported rather than silently discarded.
+POLLING_QUEUE_MAX_MESSAGES = 100
+
+_DROPPED_COUNTER_NAME = "websocket_polling_messages_dropped_total"
+
+
+def _dropped_counter(registry: CollectorRegistry) -> Counter:
+    """Register the drop counter once per registry, reusing it on repeat calls.
+
+    The counter must live on the gateway's own registry: routes/metrics.py
+    serves app.state.prometheus_registry, so a series left on
+    prometheus_client's global default is counted in-process and never
+    scraped. prometheus_client raises on a second registration of the same
+    name and the test suite reloads services.api_gateway.app, so registration
+    is attempted through the public API first and every fallback ends in a
+    counter rather than an exception.
+    """
+    try:
+        return Counter(
+            _DROPPED_COUNTER_NAME,
+            "Messages discarded because a polling client's queue was full",
+            ["client_type"],
+            registry=registry,
+        )
+    except ValueError:
+        pass  # already registered on this registry, or the name is taken
+
+    # _names_to_collectors is private and may be renamed by a library bump, so
+    # reuse is best-effort and never the only path out of here.
+    existing = getattr(registry, "_names_to_collectors", {}).get(_DROPPED_COUNTER_NAME)
+    if isinstance(existing, Counter):
+        return existing
+
+    logger.warning(
+        "%s is not available on the gateway registry; polling drops will not "
+        "be scraped",
+        _DROPPED_COUNTER_NAME,
+    )
+    return Counter(
+        _DROPPED_COUNTER_NAME,
+        "Messages discarded because a polling client's queue was full",
+        ["client_type"],
+        registry=CollectorRegistry(),
+    )
+
+
+def _known_client_type(value: Any) -> str:
+    """Clamp a client type to the enum before it becomes a Prometheus label.
+
+    `client_type` reaches this module straight from the body of
+    POST /api/websocket/polling/activate, which declares it as a bare `str`.
+    An unbounded label value is a cardinality attack, so anything outside
+    ClientType is folded into "unknown".
+    """
+    try:
+        return ClientType(value).value
+    except ValueError:
+        return "unknown"
 
 
 def utc_now() -> datetime:
@@ -127,7 +192,21 @@ class WebSocketFallbackManager:
         # Notification callbacks
         self.notification_callbacks: List[Callable] = []
 
+        # Defaults to a registry of its own so that importing this module never
+        # touches prometheus_client's global default, which /metrics does not
+        # serve. app.py rebinds it to the gateway registry.
+        self.messages_dropped = _dropped_counter(CollectorRegistry())
+
         logger.info("🔄 WebSocket Fallback Manager initialized")
+
+    def bind_metrics_registry(self, registry: CollectorRegistry) -> None:
+        """Move the drop counter onto the registry /metrics actually serves.
+
+        This module is imported before app.py has built that registry and
+        cannot import app.py back, so the wiring is a call from app.py rather
+        than a constructor argument.
+        """
+        self.messages_dropped = _dropped_counter(registry)
 
     def evaluate_websocket_failure(
         self,
@@ -252,8 +331,11 @@ class WebSocketFallbackManager:
     ) -> str:
         """Activate polling fallback for a client"""
 
-        # Generate unique polling ID
-        polling_id = f"poll_{session_id}_{client_type}_{int(time.time())}"
+        # A polling id must be unique, not merely descriptive: it keys
+        # self.polling_clients, so two activations for one session and client
+        # type inside the same second used to overwrite each other and discard
+        # the loser's entire message queue.
+        polling_id = f"poll_{session_id}_{client_type}_{uuid4().hex[:12]}"
 
         # Create polling client
         polling_client = PollingClient(
@@ -300,7 +382,16 @@ class WebSocketFallbackManager:
     def send_message_to_polling_client(
         self, polling_id: str, message: Dict[str, Any]
     ) -> bool:
-        """Send message to polling client's queue"""
+        """Queue a message for a polling client.
+
+        Returns True when nothing was lost. False does **not** mean the message
+        passed in was rejected: it was appended, and a *different, older*
+        message was evicted to keep the queue within
+        POLLING_QUEUE_MAX_MESSAGES. Retrying on False therefore duplicates the
+        newest message and evicts one more. False is a signal to report or
+        alert on, not to resend. (An unknown polling id also returns False,
+        and there the message was not queued at all.)
+        """
         client = self.polling_clients.get(polling_id)
         if not client:
             return False
@@ -316,9 +407,18 @@ class WebSocketFallbackManager:
 
         client.message_queue.append(message_with_meta)
 
-        # Limit queue size to prevent memory issues
-        if len(client.message_queue) > 100:
-            client.message_queue.popleft()
+        if len(client.message_queue) > POLLING_QUEUE_MAX_MESSAGES:
+            dropped = client.message_queue.popleft()
+            self.messages_dropped.labels(
+                client_type=_known_client_type(client.client_type)
+            ).inc()
+            logger.warning(
+                "Polling queue full (%d); dropped the oldest queued message of "
+                "type %s. The recipient will never see it.",
+                POLLING_QUEUE_MAX_MESSAGES,
+                sanitize_log_value(dropped.get("type", "unknown")),
+            )
+            return False
 
         return True
 

--- a/services/api_gateway/websocket_fallback.py
+++ b/services/api_gateway/websocket_fallback.py
@@ -24,6 +24,15 @@ logger = logging.getLogger(__name__)
 # is that crossing it is counted and reported rather than silently discarded.
 POLLING_QUEUE_MAX_MESSAGES = 100
 
+# /api/websocket/polling/activate has no authentication -- it validates only
+# that the session exists. Unique polling ids removed the accidental bound that
+# id collisions used to provide, so an unauthenticated caller could mint one
+# PollingClient (and its queue) per request until periodic_cleanup reaped them
+# 30 minutes later. A client legitimately re-activates during a reconnect race,
+# so the cap is not 1; beyond it the oldest entry for the same session and
+# client type is reclaimed.
+POLLING_MAX_CLIENTS_PER_SESSION_CLIENT_TYPE = 3
+
 _DROPPED_COUNTER_NAME = "websocket_polling_messages_dropped_total"
 
 
@@ -148,6 +157,10 @@ class PollingClient:
     fallback_reason: FallbackReason = FallbackReason.MANUAL_FALLBACK
     retry_count: int = 0
     websocket_retry_after: Optional[datetime] = None
+    # Drops since this client last polled. A wedged client saturates its queue
+    # and then drops every subsequent message, so this bounds the log to one
+    # line per saturation episode instead of one per lost message.
+    dropped_since_last_poll: int = 0
 
 
 @dataclass
@@ -352,6 +365,8 @@ class WebSocketFallbackManager:
         self.polling_clients[polling_id] = polling_client
         self.session_polling_clients[session_id].add(polling_id)
 
+        self._enforce_polling_client_cap(session_id, client_type)
+
         # Update statistics
         self.fallback_stats["total_fallbacks"] += 1
         self.fallback_stats["active_polling_clients"] = len(self.polling_clients)
@@ -412,12 +427,25 @@ class WebSocketFallbackManager:
             self.messages_dropped.labels(
                 client_type=_known_client_type(client.client_type)
             ).inc()
-            logger.warning(
-                "Polling queue full (%d); dropped the oldest queued message of "
-                "type %s. The recipient will never see it.",
-                POLLING_QUEUE_MAX_MESSAGES,
-                sanitize_log_value(dropped.get("type", "unknown")),
-            )
+            client.dropped_since_last_poll += 1
+            dropped_type = sanitize_log_value(dropped.get("type", "unknown"))
+            if client.dropped_since_last_poll == 1:
+                logger.warning(
+                    "Polling queue full (%d); dropped the oldest queued message "
+                    "of type %s. The recipient will never see it. Further drops "
+                    "for this client log at debug until it polls again; "
+                    "%s carries the true count.",
+                    POLLING_QUEUE_MAX_MESSAGES,
+                    dropped_type,
+                    _DROPPED_COUNTER_NAME,
+                )
+            else:
+                logger.debug(
+                    "Polling queue still full; dropped message of type %s "
+                    "(%d since last poll)",
+                    dropped_type,
+                    client.dropped_since_last_poll,
+                )
             return False
 
         return True
@@ -430,6 +458,14 @@ class WebSocketFallbackManager:
 
         # Update last poll time
         client.last_poll = utc_now()
+
+        if client.dropped_since_last_poll:
+            logger.warning(
+                "Polling client drained after overflow: %d message(s) lost while "
+                "its queue was full",
+                client.dropped_since_last_poll,
+            )
+            client.dropped_since_last_poll = 0
 
         # Get all queued messages
         messages = list(client.message_queue)
@@ -692,6 +728,37 @@ class WebSocketFallbackManager:
             reason,
             "Connection using compatibility mode. All features remain available.",
         )
+
+    def _enforce_polling_client_cap(self, session_id: str, client_type: str) -> int:
+        """Reclaim the oldest entries past the per-session-and-type cap.
+
+        Returns how many were reclaimed. Oldest-first, so the activation that
+        just happened is the one kept: a client repairing its connection gets
+        the live queue, and a caller minting entries in a loop reclaims its own
+        rather than growing the map.
+        """
+        peers = sorted(
+            (
+                client
+                for polling_id in self.session_polling_clients.get(session_id, set())
+                if (client := self.polling_clients.get(polling_id)) is not None
+                and client.client_type == client_type
+            ),
+            key=lambda client: client.created_at,
+        )
+
+        reclaimed = 0
+        for client in peers[:-POLLING_MAX_CLIENTS_PER_SESSION_CLIENT_TYPE]:
+            queued = len(client.message_queue)
+            if self._cleanup_polling_client(client.polling_id):
+                reclaimed += 1
+                logger.warning(
+                    "♻️ Polling client reclaimed at cap: session=%s type=%s queued=%d",
+                    sanitize_log_value(session_id),
+                    sanitize_log_value(_known_client_type(client_type)),
+                    queued,
+                )
+        return reclaimed
 
     def _cleanup_polling_client(self, polling_id: str) -> bool:
         """Remove polling client and cleanup resources"""

--- a/services/api_gateway/websocket_monitor.py
+++ b/services/api_gateway/websocket_monitor.py
@@ -32,7 +32,12 @@ class ConnectionState(Enum):
 
 
 class DisconnectReason(Enum):
-    """WebSocket disconnect reasons"""
+    """WebSocket disconnect reasons.
+
+    The values are the Prometheus label written to `websocket_disconnects_total`
+    and matched by the WebSocketConnectionFailures and WebSocketOriginBlocked
+    rules in monitoring/alert_rules.yml. Renaming one breaks an alert silently.
+    """
 
     CLIENT_DISCONNECT = "client_disconnect"
     SERVER_DISCONNECT = "server_disconnect"
@@ -42,6 +47,36 @@ class DisconnectReason(Enum):
     RATE_LIMIT_EXCEEDED = "rate_limit_exceeded"
     AUTHENTICATION_FAILED = "authentication_failed"
     PROTOCOL_ERROR = "protocol_error"
+    ORIGIN_NOT_ALLOWED = "origin_not_allowed"
+
+    @classmethod
+    def from_wire(cls, value: str) -> "DisconnectReason":
+        """Map the free-text reason the socket layer passes around.
+
+        Unknown values become PROTOCOL_ERROR, never CLIENT_DISCONNECT: an
+        unrecognised cause is not evidence of a clean client exit, and folding
+        it into the clean bucket is exactly the defect this replaces.
+        """
+        try:
+            return cls(value)
+        except ValueError:
+            return _WIRE_ALIASES.get(value, cls.PROTOCOL_ERROR)
+
+
+_WIRE_ALIASES = {
+    "no_connections": DisconnectReason.SERVER_DISCONNECT,
+    "session_timeout": DisconnectReason.SESSION_EXPIRED,
+    "new_session_created": DisconnectReason.SERVER_DISCONNECT,
+    "battery_optimization": DisconnectReason.SERVER_DISCONNECT,
+    # handle_session_termination's default reason. A deliberate server-side
+    # termination is not a fault, so it must not land in PROTOCOL_ERROR.
+    "session_ended": DisconnectReason.SERVER_DISCONNECT,
+    # An operator (or the operator-facing admin UI) ending a session on
+    # purpose is a deliberate server-side termination, not a protocol
+    # violation -- it must not land in PROTOCOL_ERROR either.
+    "manual_termination": DisconnectReason.SERVER_DISCONNECT,
+    "manual_admin_termination": DisconnectReason.SERVER_DISCONNECT,
+}
 
 
 @dataclass
@@ -307,6 +342,17 @@ class WebSocketMonitor:
             f"(duration: {metrics.connection_duration:.2f}s, reason: {reason.value})"
         )
         return metrics
+
+    def record_rejected_connection(self, reason: DisconnectReason) -> None:
+        """Count a socket refused before it was ever registered.
+
+        `connection_closed` cannot serve these: there is no ConnectionMetrics to
+        pop, so it logs "non-existent connection" and returns None. The
+        WebSocketOriginBlocked alert needs the counter incremented anyway.
+        """
+        self.disconnects_total.labels(
+            client_type="unknown", disconnect_reason=reason.value
+        ).inc()
 
     def message_sent(
         self, connection_id: str, message_data: str, message_type: str = "unknown"

--- a/services/api_gateway/websocket_monitor.py
+++ b/services/api_gateway/websocket_monitor.py
@@ -76,6 +76,16 @@ _WIRE_ALIASES = {
     # violation -- it must not land in PROTOCOL_ERROR either.
     "manual_termination": DisconnectReason.SERVER_DISCONNECT,
     "manual_admin_termination": DisconnectReason.SERVER_DISCONNECT,
+    # terminate_all_active_sessions' default, and a member of the closed
+    # SessionTerminationReason enum. Maintenance is a deliberate server-side
+    # action; without this an operator's cleanup pages critical.
+    "system_cleanup": DisconnectReason.SERVER_DISCONNECT,
+    # _get_termination_message's inactivity reason -- the same event as
+    # session_timeout, spelled differently by the caller.
+    "timeout": DisconnectReason.SESSION_EXPIRED,
+    # _get_termination_message's fault reason. It still pages, but it is a
+    # connection error, not evidence the client broke the protocol.
+    "error": DisconnectReason.CONNECTION_ERROR,
 }
 
 

--- a/services/api_gateway/websocket_polling_routes.py
+++ b/services/api_gateway/websocket_polling_routes.py
@@ -5,6 +5,7 @@ due to CORS, network, or compatibility issues.
 """
 
 import asyncio
+import logging
 from datetime import datetime, timezone
 from typing import Annotated, Any, Dict, Optional
 
@@ -14,6 +15,8 @@ from pydantic import BaseModel
 
 from .session_manager import ClientType, session_manager
 from .websocket_fallback import FallbackReason, fallback_manager
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/websocket/polling", tags=["WebSocket Polling Fallback"])
 POLLING_ROUTE_RESPONSES = {
@@ -237,18 +240,42 @@ async def send_message_via_polling(polling_id: str, message: PollingMessage):
         session_fallback_status = fallback_manager.get_session_fallback_status(
             message.session_id
         )
+        recipients = 0
+        overflowed = 0
         for client_info in session_fallback_status["polling_clients"]:
             if client_info["polling_id"] != polling_id:  # Don't send to sender
-                fallback_manager.send_message_to_polling_client(
+                recipients += 1
+                queued = fallback_manager.send_message_to_polling_client(
                     polling_id=client_info["polling_id"], message=broadcast_message
                 )
+                if not queued:
+                    overflowed += 1
+
+        # A False from send_message_to_polling_client does not mean this
+        # message was rejected -- it was queued, and a different, older message
+        # was evicted from a full recipient queue. Retrying would duplicate
+        # this message and evict one more, so the caller is told not to.
+        if overflowed:
+            logger.warning(
+                "Polling send overflowed %d of %d recipient queue(s)",
+                overflowed,
+                recipients,
+            )
 
         return JSONResponse(
             status_code=200,
             content={
-                "status": "success",
-                "message": "Message sent successfully",
+                "status": "partial_overflow" if overflowed else "success",
+                "message": (
+                    "Message queued, but a full recipient queue evicted an older "
+                    "message"
+                    if overflowed
+                    else "Message sent successfully"
+                ),
                 "broadcast_count": 1,
+                "polling_recipients": recipients,
+                "polling_overflow_recipients": overflowed,
+                "retryable": False,
                 "timestamp": utc_now_iso(),
             },
         )

--- a/services/asr/README.en.md
+++ b/services/asr/README.en.md
@@ -15,7 +15,7 @@ This standalone FastAPI microservice provides automatic speech recognition (ASR)
 # Since #221 the service is not published on the host; inside the compose
 # network it listens on asr:8000.
 docker compose exec api_gateway \
-  curl -F "file=@sample.wav" -F "lang=de" http://asr:8000/transcribe
+  curl -F "file=@examples/audio/sample.wav" -F "lang=de" http://asr:8000/transcribe
 ```
 
 ### Output

--- a/services/asr/README.en.md
+++ b/services/asr/README.en.md
@@ -12,7 +12,10 @@ This standalone FastAPI microservice provides automatic speech recognition (ASR)
 - `lang`: optional language code, for example `de`, `en`, or `ar`
 
 ```bash
-curl -F "file=@sample.wav" -F "lang=de" http://localhost:8001/transcribe
+# Since #221 the service is not published on the host; inside the compose
+# network it listens on asr:8000.
+docker compose exec api_gateway \
+  curl -F "file=@sample.wav" -F "lang=de" http://asr:8000/transcribe
 ```
 
 ### Output

--- a/services/asr/README.md
+++ b/services/asr/README.md
@@ -8,7 +8,10 @@
 
 Beispiel:
 ```bash
-curl -F "file=@sample.wav" -F "lang=de" http://localhost:8001/transcribe
+# Der Dienst wird seit #221 nicht mehr auf dem Host veröffentlicht; im
+# Compose-Netz lauscht er auf asr:8000.
+docker compose exec api_gateway \
+  curl -F "file=@sample.wav" -F "lang=de" http://asr:8000/transcribe
 ```
 
 ### Output

--- a/services/asr/README.md
+++ b/services/asr/README.md
@@ -11,7 +11,7 @@ Beispiel:
 # Der Dienst wird seit #221 nicht mehr auf dem Host veröffentlicht; im
 # Compose-Netz lauscht er auf asr:8000.
 docker compose exec api_gateway \
-  curl -F "file=@sample.wav" -F "lang=de" http://asr:8000/transcribe
+  curl -F "file=@examples/audio/sample.wav" -F "lang=de" http://asr:8000/transcribe
 ```
 
 ### Output

--- a/tests/test_ai_service_port_exposure.py
+++ b/tests/test_ai_service_port_exposure.py
@@ -1,0 +1,47 @@
+"""#221: the model services must not be reachable without authentication.
+
+Both compose files are asserted, because production runs the pinned file in
+`deploy/production/` and a fix applied to only one of them leaves the hole open
+in the environment that matters.
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPOSE_FILES = (
+    ROOT / "docker-compose.yml",
+    ROOT / "deploy" / "production" / "docker-compose.production.yml",
+)
+AI_SERVICES = ("asr", "translation", "tts")
+
+
+def _service(compose_path: Path, name: str) -> dict:
+    services = yaml.safe_load(compose_path.read_text())["services"]
+    assert name in services, f"{name} missing from {compose_path.name}"
+    return services[name]
+
+
+@pytest.mark.parametrize("compose_path", COMPOSE_FILES, ids=lambda p: p.name)
+@pytest.mark.parametrize("name", AI_SERVICES)
+def test_ai_service_publishes_no_host_port(compose_path: Path, name: str):
+    """A `ports` entry binds 0.0.0.0 by default, which is the whole defect."""
+    service = _service(compose_path, name)
+    assert "ports" not in service, (
+        f"{name} in {compose_path.name} publishes {service.get('ports')} to the host; "
+        "use `expose` so the port stays on the compose network"
+    )
+
+
+@pytest.mark.parametrize("compose_path", COMPOSE_FILES, ids=lambda p: p.name)
+@pytest.mark.parametrize("name", AI_SERVICES)
+def test_ai_service_still_reachable_inside_the_network(compose_path: Path, name: str):
+    """Removing `ports` must not also remove container-to-container access."""
+    service = _service(compose_path, name)
+    exposed = [str(port) for port in service.get("expose", [])]
+    assert "8000" in exposed, (
+        f"{name} in {compose_path.name} exposes {exposed}; the gateway calls it "
+        "on port 8000 over the compose network"
+    )

--- a/tests/test_polling_send_reports_overflow.py
+++ b/tests/test_polling_send_reports_overflow.py
@@ -1,0 +1,117 @@
+"""The send route must not report clean success over a dropped message.
+
+send_message_to_polling_client returns False when a recipient's queue was full
+and an older message was evicted to make room. The route discarded that result
+and answered 200 "Message sent successfully" regardless, so the signal this
+branch added stopped at the function boundary and never reached the caller --
+the branch's own thesis, one layer up.
+
+False does not mean the new message was rejected: it was queued, and a
+*different, older* message was lost. So the response reports partial delivery,
+and a caller must not retry.
+"""
+
+import json
+
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from services.api_gateway import websocket_polling_routes as polling_routes
+
+
+@pytest.fixture
+def send_route(monkeypatch):
+    """Two recipients besides the sender; the test decides what each returns."""
+    outcomes: dict[str, bool] = {}
+
+    websocket_manager = Mock()
+    websocket_manager.broadcast_to_session = AsyncMock()
+
+    monkeypatch.setattr(
+        polling_routes.fallback_manager,
+        "get_polling_client_status",
+        lambda polling_id: {"session_id": "SESSION123"},
+    )
+    monkeypatch.setattr(
+        polling_routes.fallback_manager,
+        "get_session_fallback_status",
+        lambda session_id: {
+            "polling_clients": [
+                {"polling_id": "sender"},
+                {"polling_id": "receiver-a"},
+                {"polling_id": "receiver-b"},
+            ]
+        },
+    )
+    monkeypatch.setattr(
+        polling_routes.fallback_manager,
+        "send_message_to_polling_client",
+        lambda polling_id, message: outcomes.get(polling_id, True),
+    )
+
+    from services.api_gateway import websocket
+
+    monkeypatch.setattr(websocket, "websocket_manager", websocket_manager)
+
+    async def call():
+        message = polling_routes.PollingMessage(
+            type="message",
+            content={"text": "hello"},
+            session_id="SESSION123",
+            client_type="customer",
+            timestamp="2026-07-20T12:00:00+00:00",
+        )
+        response = await polling_routes.send_message_via_polling("sender", message)
+        return response.status_code, json.loads(response.body)
+
+    return outcomes, call
+
+
+class TestCleanDelivery:
+    async def test_every_recipient_queued_reports_success(self, send_route):
+        _, call = send_route
+
+        status_code, body = await call()
+
+        assert status_code == 200
+        assert body["status"] == "success"
+        assert body["polling_recipients"] == 2
+        assert body["polling_overflow_recipients"] == 0
+
+
+class TestOverflowIsReported:
+    async def test_a_dropped_message_is_not_reported_as_clean_success(
+        self, send_route
+    ):
+        outcomes, call = send_route
+        outcomes["receiver-b"] = False
+
+        status_code, body = await call()
+
+        assert body["status"] != "success", (
+            "a recipient lost a queued message and the caller was told the "
+            "send succeeded"
+        )
+        assert body["polling_overflow_recipients"] == 1
+        assert body["polling_recipients"] == 2
+        # The message was accepted and queued; only an older one was evicted.
+        assert status_code == 200
+
+    async def test_the_caller_is_told_not_to_retry(self, send_route):
+        """Retrying duplicates the newest message and evicts one more."""
+        outcomes, call = send_route
+        outcomes["receiver-a"] = False
+
+        _, body = await call()
+
+        assert body["retryable"] is False
+
+    async def test_every_overflowing_recipient_is_counted(self, send_route):
+        outcomes, call = send_route
+        outcomes["receiver-a"] = False
+        outcomes["receiver-b"] = False
+
+        _, body = await call()
+
+        assert body["polling_overflow_recipients"] == 2

--- a/tests/test_runbooks_target_production.py
+++ b/tests/test_runbooks_target_production.py
@@ -1,0 +1,91 @@
+"""A runbook command must name the stack it is meant to act on.
+
+Runbooks are followed during an incident, on the production host. A bare
+`docker compose` there reads `docker-compose.yml` plus whatever
+`docker-compose.override.yml` the operator happens to have, under a project
+name derived from the current directory -- a different stack from the one
+production runs, which is
+`docker compose --project-name ssf-backend --env-file .env
+ --file deploy/production/docker-compose.production.yml`, wrapped as
+`production_compose` in scripts/lib/production-common.sh.
+
+This guard exists because following the precedent in this directory produced
+the bug: `production_compose` has been available since 2026-08-30 and no
+runbook used it, so a new runbook written by matching its neighbours was
+wrong by construction. A reviewer caught it; nothing in the repository would
+have.
+
+KNOWN_BARE_COMPOSE is a ratchet, not an exemption. Each entry records the
+number of bare invocations a runbook had when this guard was written. The
+count may only go down: fixing lines requires lowering the number, and adding
+one fails. A runbook not listed here gets no allowance at all.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+RUNBOOKS = Path(__file__).resolve().parents[1] / "docs" / "operations" / "runbooks"
+
+# A command line, not prose: the invocation starts the line. Prose references
+# such as "`docker compose` reads the dev file" are explanatory and fine.
+BARE_COMPOSE = re.compile(r"^\s*(sudo\s+)?docker[- ]compose\s", re.MULTILINE)
+
+KNOWN_BARE_COMPOSE = {
+    "clickhouse-operations.md": 20,
+    "keycloak-operations.md": 4,
+    "websocket-broadcast-failures.md": 6,
+}
+
+
+def _runbooks():
+    return sorted(RUNBOOKS.glob("*.md"))
+
+
+def _bare_count(path: Path) -> int:
+    return len(BARE_COMPOSE.findall(path.read_text(encoding="utf-8")))
+
+
+def test_the_runbook_directory_exists():
+    """A rename that empties the glob would make every test below vacuous."""
+    assert _runbooks(), f"no runbooks found under {RUNBOOKS}"
+
+
+@pytest.mark.parametrize("path", _runbooks(), ids=lambda p: p.name)
+def test_a_runbook_does_not_grow_bare_compose_commands(path: Path):
+    allowed = KNOWN_BARE_COMPOSE.get(path.name, 0)
+    found = _bare_count(path)
+
+    assert found <= allowed, (
+        f"{path.name} has {found} bare `docker compose` command(s), "
+        f"{allowed} allowed. On the production host these act on the "
+        "development stack. Use `production_compose` from "
+        "scripts/lib/production-common.sh, or spell out --project-name, "
+        "--env-file and --file."
+    )
+
+
+@pytest.mark.parametrize("name", sorted(KNOWN_BARE_COMPOSE), ids=str)
+def test_the_ratchet_is_tightened_when_a_runbook_is_fixed(name: str):
+    """Recorded debt that has been paid must be recorded as paid, or the
+    allowance silently becomes room for a new bare command."""
+    path = RUNBOOKS / name
+    if not path.exists():
+        pytest.fail(f"{name} is recorded in KNOWN_BARE_COMPOSE but does not exist")
+
+    found = _bare_count(path)
+    allowed = KNOWN_BARE_COMPOSE[name]
+
+    assert found == allowed, (
+        f"{name} now has {found} bare `docker compose` command(s) but "
+        f"KNOWN_BARE_COMPOSE still says {allowed}. Lower it to {found}."
+    )
+
+
+def test_the_service_down_runbook_uses_production_compose():
+    """The runbook this guard was written for, asserted directly."""
+    text = (RUNBOOKS / "service-down-alerts.md").read_text(encoding="utf-8")
+
+    assert "production_compose" in text
+    assert not BARE_COMPOSE.search(text)

--- a/tests/test_service_app_helpers.py
+++ b/tests/test_service_app_helpers.py
@@ -1188,10 +1188,13 @@ def test_websocket_fallback_classifies_failures_and_limits_queue():
     manager.polling_clients[polling_id] = client
     manager.session_polling_clients["session-1"].add(polling_id)
 
+    # Overflow now returns False instead of silently dropping the oldest
+    # queued message, so sends past the 100-message bound must fail.
     for index in range(105):
-        assert manager.send_message_to_polling_client(
+        sent = manager.send_message_to_polling_client(
             polling_id, {"type": "msg", "index": index}
         )
+        assert sent is (index < 100)
 
     assert len(manager.polling_clients[polling_id].message_queue) == 100
     session_status = manager.get_session_fallback_status("session-1")

--- a/tests/test_service_down_alerting.py
+++ b/tests/test_service_down_alerting.py
@@ -1,0 +1,115 @@
+"""#220: a stopped model service must raise an alert.
+
+The *ServiceDown rules match `<svc>_health_status == 0`, a metric scraped from
+the service itself. When the container stops the series disappears rather than
+going to zero, so the expression matches nothing and the alert never fires.
+Every scrape-failure rule here is the companion that does fire.
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+ALERTS = ROOT / "monitoring" / "alert_rules.yml"
+PROMETHEUS = ROOT / "monitoring" / "prometheus.yml"
+
+MODEL_SERVICES = ("asr", "translation", "tts")
+
+GROUP = "ssf-service-health"
+
+# The gateway gets 1m because its failure is a total outage; the model
+# services get 2m to ride out a restart. A test that cannot tell these apart
+# would let the two get swapped silently.
+EXPECTED_FOR = {"asr": "2m", "translation": "2m", "tts": "2m", "api_gateway": "1m"}
+
+
+def _rules() -> dict[str, dict]:
+    """Scoped to one group on purpose.
+
+    Flattening every group into one name-keyed dict lets a duplicate alert name
+    elsewhere in the file overwrite these silently, and proves nothing about
+    where the rules actually live.
+    """
+    groups = yaml.safe_load(ALERTS.read_text())["groups"]
+    group = next((g for g in groups if g["name"] == GROUP), None)
+    return {rule["alert"]: rule for rule in group["rules"]} if group else {}
+
+
+def _scrape_jobs() -> set[str]:
+    config = yaml.safe_load(PROMETHEUS.read_text())
+    return {job["job_name"] for job in config["scrape_configs"]}
+
+
+class TestEveryModelServiceIsScraped:
+    @pytest.mark.parametrize("service", MODEL_SERVICES + ("api_gateway",))
+    def test_the_job_exists(self, service: str):
+        """An up{job=...} alert on a job Prometheus does not scrape is inert."""
+        assert service in _scrape_jobs()
+
+
+class TestScrapeFailureRaisesAnAlert:
+    @pytest.mark.parametrize("service", MODEL_SERVICES + ("api_gateway",))
+    def test_a_scrape_down_rule_exists(self, service: str):
+        expected = f'up{{job="{service}"}} == 0'
+        exprs = [rule["expr"].strip() for rule in _rules().values()]
+        assert expected in exprs, (
+            f"no rule matches {expected}; stopping the {service} container "
+            "would raise nothing"
+        )
+
+    @pytest.mark.parametrize("service,expected_for", EXPECTED_FOR.items())
+    def test_it_is_critical_and_fires_within_the_expected_wait(
+        self, service: str, expected_for: str
+    ):
+        rule = next(
+            r for r in _rules().values()
+            if r["expr"].strip() == f'up{{job="{service}"}} == 0'
+        )
+        assert rule["labels"]["severity"] == "critical"
+        assert rule["labels"]["service"] == service
+        assert rule["for"] == expected_for, (
+            f"{rule['alert']} waits {rule['for']}, expected {expected_for}; "
+            "a dead service should not wait longer than its outage warrants"
+        )
+
+
+class TestTheHealthStatusRulesAreKeptButNotRelieduponAlone:
+    """The <svc>_health_status rules stay: they catch a service that answers
+    but reports itself unhealthy -- a different failure from the container
+    being gone, which up{job=...} cannot detect."""
+
+    @pytest.mark.parametrize(
+        "alert_name",
+        ("ASRServiceDown", "TranslationServiceDown", "TTSServiceDown"),
+    )
+    def test_the_health_rule_still_exists(self, alert_name: str):
+        assert alert_name in _rules()
+
+
+class TestTheRulesLiveWhereTheyAreLookedFor:
+    @pytest.mark.parametrize(
+        "alert_name",
+        (
+            "ASRScrapeDown",
+            "TranslationScrapeDown",
+            "TTSScrapeDown",
+            "APIGatewayScrapeDown",
+        ),
+    )
+    def test_the_scrape_rule_is_in_the_service_health_group(self, alert_name: str):
+        assert alert_name in _rules(), f"{alert_name} is not in the {GROUP} group"
+
+
+class TestEveryRuleIsDocumented:
+    def test_each_alert_carries_a_runbook_annotation(self):
+        """runbook_url, not runbook: Alertmanager and Grafana templates render
+        the former and silently ignore the latter, so the link an operator
+        needs at 03:00 would never appear."""
+        missing = [
+            name for name, rule in _rules().items()
+            if not rule.get("annotations", {}).get("runbook_url")
+            and name.endswith("ScrapeDown")
+        ]
+        assert not missing, f"no runbook_url annotation on {missing}"

--- a/tests/test_sonar_new_coverage_websocket.py
+++ b/tests/test_sonar_new_coverage_websocket.py
@@ -123,8 +123,10 @@ async def test_endpoint_returns_error_message_after_message_handler_failure(
 
     assert "WebSocket message processing failed" in caplog.messages
     websocket.send_json.assert_awaited_once()
+    # Not "client_disconnect": the loop was left because the socket could no
+    # longer be written to, which is an abnormal termination.
     manager.disconnect_websocket.assert_awaited_once_with(
-        "connection-1", "client_disconnect"
+        "connection-1", "connection_error"
     )
 
 

--- a/tests/test_websocket_close_code_classification.py
+++ b/tests/test_websocket_close_code_classification.py
@@ -1,0 +1,109 @@
+"""An abnormal close code is not a clean client exit.
+
+The endpoint's receive loop treats every WebSocketDisconnect the same and
+leaves exit_reason at "client_disconnect". A browser closing its tab and a
+connection dying mid-frame (1006) or a server error (1011) then record the
+identical reason, so the unexpected-disconnect KPI and
+WebSocketConnectionFailures stay blind to the failures they exist to catch --
+the same defect this branch fixed one layer down, still present at the seam.
+"""
+
+import pytest
+from fastapi import WebSocketDisconnect
+
+from services.api_gateway import websocket as ws
+from services.api_gateway.session_manager import SessionStatus
+from services.api_gateway.websocket_monitor import DisconnectReason
+
+
+class TestOrdinaryClosesStayClean:
+    @pytest.mark.parametrize(
+        "code",
+        [
+            1000,  # normal closure
+            1001,  # going away -- tab closed, navigation
+            1005,  # no status received: a close frame that carried no code
+        ],
+    )
+    def test_a_routine_close_is_a_client_disconnect(self, code: int):
+        assert ws.disconnect_reason_for_close_code(code) == "client_disconnect"
+
+
+class TestAbnormalClosesAreReported:
+    @pytest.mark.parametrize(
+        "code",
+        [
+            1006,  # abnormal closure: no close frame at all
+            1011,  # internal server error
+            1012,  # service restart
+            1013,  # try again later
+            1014,  # bad gateway
+            1015,  # TLS handshake failure
+        ],
+    )
+    def test_an_abnormal_close_is_a_connection_error(self, code: int):
+        reason = ws.disconnect_reason_for_close_code(code)
+
+        assert reason == "connection_error"
+        assert DisconnectReason.from_wire(reason) is DisconnectReason.CONNECTION_ERROR
+
+    @pytest.mark.parametrize("code", [1002, 1003, 1007, 1008, 1009, 1010])
+    def test_a_protocol_level_close_is_a_protocol_error(self, code: int):
+        assert ws.disconnect_reason_for_close_code(code) == "protocol_error"
+
+    def test_an_unknown_code_is_not_silently_clean(self):
+        """Consistent with DisconnectReason.from_wire: an unrecognised cause is
+        not evidence of a clean exit."""
+        assert ws.disconnect_reason_for_close_code(4999) != "client_disconnect"
+
+
+class TestTheReasonReachesCleanup:
+    """The classifier is only worth having if the endpoint uses it."""
+
+    @pytest.mark.parametrize(
+        "code,expected",
+        [
+            (1000, DisconnectReason.CLIENT_DISCONNECT),
+            (1006, DisconnectReason.CONNECTION_ERROR),
+            (1011, DisconnectReason.CONNECTION_ERROR),
+        ],
+    )
+    async def test_the_endpoint_records_the_classified_reason(
+        self, monkeypatch, code: int, expected: DisconnectReason
+    ):
+        recorded: list[str] = []
+
+        class _Session:
+            status = SessionStatus.ACTIVE
+
+        class _SessionManager:
+            def get_session(self, session_id):
+                return _Session()
+
+        class _Manager:
+            session_manager = _SessionManager()
+
+            async def connect_websocket(self, *args, **kwargs):
+                return "conn-1"
+
+            async def disconnect_websocket(self, connection_id, reason, *args):
+                recorded.append(reason)
+
+        class _Socket:
+            async def receive_json(self):
+                raise WebSocketDisconnect(code=code)
+
+        monkeypatch.setattr(ws, "validate_websocket_origin", _always_allowed)
+        await ws.websocket_endpoint(
+            websocket=_Socket(),
+            session_id="session-1",
+            client_type="customer",
+            manager=_Manager(),
+            origin="https://console.example",
+        )
+
+        assert recorded == [expected.value]
+
+
+async def _always_allowed(origin):
+    return True

--- a/tests/test_websocket_connection_identity.py
+++ b/tests/test_websocket_connection_identity.py
@@ -1,0 +1,111 @@
+"""Two sockets on one session must never share a connection id.
+
+The monitor keys its active-connection map by this id, so a collision makes one
+socket's metrics describe the other's — and the connection KPIs (R1-R4) divide
+by those counts. The polling fallback has the same defect with worse
+consequences: its id keys a dict of message queues, so a collision discards a
+whole queue.
+"""
+
+import time
+from unittest.mock import AsyncMock, Mock
+
+from services.api_gateway.session_manager import SessionManager
+from services.api_gateway.websocket import ClientType, WebSocketManager
+from services.api_gateway.websocket_fallback import (
+    FallbackConfig,
+    FallbackReason,
+    WebSocketFallbackManager,
+)
+
+
+def _websocket() -> Mock:
+    socket = Mock()
+    socket.accept = AsyncMock()
+    socket.send_json = AsyncMock()
+    socket.close = AsyncMock()
+    return socket
+
+
+def test_ids_are_unique_within_the_same_second(monkeypatch):
+    """The old format was f"{session}_{type}_{int(time.time())}"."""
+    monkeypatch.setattr(time, "time", lambda: 1_757_000_000.0)
+
+    ids = {
+        WebSocketManager._build_connection_id("session-a", ClientType.CUSTOMER)
+        for _ in range(100)
+    }
+
+    assert len(ids) == 100, f"only {len(ids)} distinct ids from 100 connections"
+
+
+def test_the_id_still_names_its_session_and_client_type():
+    """Kept readable on purpose: these ids appear in operator log lines."""
+    connection_id = WebSocketManager._build_connection_id(
+        "session-a", ClientType.CUSTOMER
+    )
+
+    assert connection_id.startswith(f"session-a_{ClientType.CUSTOMER.value}_")
+
+
+class TestTheEndpointItselfBuildsUniqueIds:
+    """_build_connection_id in isolation is not the seam that broke.
+
+    connect_websocket used to inline the id construction; a revert that puts
+    the timestamp back there passes every test that only calls the helper.
+    """
+
+    async def test_two_connections_for_one_session_get_different_ids(self):
+        manager = WebSocketManager(SessionManager())
+
+        first = await manager.connect_websocket(
+            _websocket(), "session-a", ClientType.CUSTOMER
+        )
+        second = await manager.connect_websocket(
+            _websocket(), "session-a", ClientType.CUSTOMER
+        )
+
+        try:
+            assert first != second
+            assert len(manager.all_connections) == 2
+            assert len(manager.session_connections["session-a"]) == 2
+        finally:
+            await manager.stop_heartbeat_system()
+
+
+class TestThePollingFallbackKeepsBothQueues:
+    """A polling id keys a message queue; a collision loses one of them whole.
+
+    _evaluate_connection_error runs per connection inside the broadcast loop,
+    so one failed broadcast to a session with two same-type connections
+    activated the fallback twice in the same instant.
+    """
+
+    async def test_two_activations_in_one_instant_do_not_overwrite_each_other(self):
+        manager = WebSocketFallbackManager(
+            FallbackConfig(enable_jitter=False, enable_user_notifications=False)
+        )
+
+        first = await manager.activate_polling_fallback(
+            "session-a", "customer", None, FallbackReason.NETWORK_ERROR
+        )
+        second = await manager.activate_polling_fallback(
+            "session-a", "customer", None, FallbackReason.NETWORK_ERROR
+        )
+
+        assert first != second
+        assert len(manager.polling_clients) == 2
+
+        manager.send_message_to_polling_client(first, {"type": "translation"})
+
+        assert len(manager.polling_clients[first].message_queue) == 1
+        assert len(manager.polling_clients[second].message_queue) == 0
+
+    async def test_the_manager_level_fallback_id_is_unique_too(self):
+        manager = WebSocketManager(SessionManager())
+
+        first = await manager.enable_polling_fallback("session-a", ClientType.CUSTOMER)
+        second = await manager.enable_polling_fallback("session-a", ClientType.CUSTOMER)
+
+        assert first != second
+        assert len(manager.polling_clients) == 2

--- a/tests/test_websocket_disconnect_reasons.py
+++ b/tests/test_websocket_disconnect_reasons.py
@@ -229,6 +229,8 @@ class TestNormalSessionEndDoesNotPageWebSocketConnectionFailures:
             "session_timeout",
             "manual_termination",
             "manual_admin_termination",
+            "system_cleanup",
+            "timeout",
         ],
     )
     def test_a_normal_session_end_reason_is_excluded(self, wire_reason: str):
@@ -239,8 +241,68 @@ class TestNormalSessionEndDoesNotPageWebSocketConnectionFailures:
             "routine session lifecycle"
         )
 
+    def test_every_termination_reason_the_session_layer_can_name_is_excluded(self):
+        """Enumerated from the enum, not listed by hand.
+
+        The hand-written list above is what let system_cleanup -- a member of
+        this closed enum and the default of terminate_all_active_sessions --
+        map to PROTOCOL_ERROR and page critical for a deliberate operator
+        action. A new member of SessionTerminationReason now fails here
+        instead.
+        """
+        from services.api_gateway.quality_telemetry import SessionTerminationReason
+
+        excluded = _excluded_disconnect_reasons()
+        offenders = {}
+        for reason in SessionTerminationReason:
+            if reason in (
+                SessionTerminationReason.NONE,
+                SessionTerminationReason.OTHER,
+            ):
+                continue
+            mapped = DisconnectReason.from_wire(reason.value)
+            if mapped.value not in excluded:
+                offenders[reason.value] = mapped.value
+
+        assert not offenders, (
+            f"deliberate session terminations mapping outside the exclusion "
+            f"list: {offenders} -- each would contribute to "
+            "WebSocketConnectionFailures and page critical"
+        )
+
+    def test_a_session_error_is_an_error_not_a_protocol_violation(self):
+        """_get_termination_message carries "error"; it is a fault and must
+        still page, but calling it a protocol violation misroutes triage."""
+        assert DisconnectReason.from_wire("error") is DisconnectReason.CONNECTION_ERROR
+        assert (
+            DisconnectReason.CONNECTION_ERROR.value not in _excluded_disconnect_reasons()
+        )
+
     def test_a_genuine_connection_error_still_pages(self):
         assert (
             DisconnectReason.CONNECTION_ERROR.value
             not in _excluded_disconnect_reasons()
         )
+
+
+class TestOneCauseDoesNotRaiseTwoAlerts:
+    """A blocked origin is a configuration problem with a purpose-built rule.
+    Leaving it in the generic failure rate as well pages critical for the same
+    cause the warning already covers, ten times less sensitively."""
+
+    def test_a_blocked_origin_is_owned_by_its_own_rule(self):
+        assert (
+            DisconnectReason.ORIGIN_NOT_ALLOWED.value in _excluded_disconnect_reasons()
+        ), (
+            "origin_not_allowed contributes to WebSocketConnectionFailures "
+            "(critical) as well as WebSocketOriginBlocked (warning)"
+        )
+
+    def test_the_dedicated_rule_still_matches_it(self):
+        """Excluding it from the generic rule is only safe while this exists."""
+        groups = yaml.safe_load(ALERT_RULES.read_text())["groups"]
+        group = next(g for g in groups if g["name"] == "websocket-health")
+        rule = next(r for r in group["rules"] if r["alert"] == "WebSocketOriginBlocked")
+
+        assert 'disconnect_reason="origin_not_allowed"' in rule["expr"]
+        assert rule["labels"]["severity"] == "warning"

--- a/tests/test_websocket_disconnect_reasons.py
+++ b/tests/test_websocket_disconnect_reasons.py
@@ -1,0 +1,246 @@
+"""A disconnect reason the code already knows must reach the monitor.
+
+R2 (unexpected disconnect rate) and two alert rules filter on this label. While
+every disconnect records `client_disconnect`, all three read zero forever.
+"""
+
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+import yaml
+
+from services.api_gateway.websocket_monitor import DisconnectReason
+
+ALERT_RULES = Path(__file__).resolve().parents[1] / "monitoring" / "alert_rules.yml"
+
+
+def _websocket_connection_failures_expr() -> str:
+    groups = yaml.safe_load(ALERT_RULES.read_text())["groups"]
+    group = next(g for g in groups if g["name"] == "websocket-health")
+    rule = next(r for r in group["rules"] if r["alert"] == "WebSocketConnectionFailures")
+    return rule["expr"]
+
+
+def _excluded_disconnect_reasons() -> set[str]:
+    """The alternation inside disconnect_reason!~"...": the label values
+    treated as routine lifecycle and excluded from the failure rate.
+
+    Parsed from the rule file rather than hardcoded, so an edit to the
+    expression that is not reflected here fails this test instead of
+    silently going stale.
+    """
+    match = re.search(r'disconnect_reason!~"([^"]+)"', _websocket_connection_failures_expr())
+    assert match, "WebSocketConnectionFailures no longer filters on disconnect_reason"
+    return set(match.group(1).split("|"))
+
+
+class TestTheWireFormatMapsToTheEnum:
+    @pytest.mark.parametrize(
+        "wire,expected",
+        [
+            ("client_disconnect", DisconnectReason.CLIENT_DISCONNECT),
+            ("heartbeat_timeout", DisconnectReason.HEARTBEAT_TIMEOUT),
+            ("origin_not_allowed", DisconnectReason.ORIGIN_NOT_ALLOWED),
+            ("no_connections", DisconnectReason.SERVER_DISCONNECT),
+            ("session_timeout", DisconnectReason.SESSION_EXPIRED),
+            ("manual_termination", DisconnectReason.SERVER_DISCONNECT),
+            ("manual_admin_termination", DisconnectReason.SERVER_DISCONNECT),
+        ],
+    )
+    def test_known_reasons_map(self, wire: str, expected: DisconnectReason):
+        assert DisconnectReason.from_wire(wire) is expected
+
+    def test_an_unknown_reason_is_not_silently_a_client_disconnect(self):
+        """Counting an unknown cause as a clean client exit is the bug itself."""
+        assert DisconnectReason.from_wire("something_new") is DisconnectReason.PROTOCOL_ERROR
+
+
+class TestTheAlertsCanFire:
+    def test_origin_not_allowed_is_a_real_enum_value(self):
+        """alert_rules.yml:199 matches this label; the enum lacked the member."""
+        assert DisconnectReason.ORIGIN_NOT_ALLOWED.value == "origin_not_allowed"
+
+    def test_a_heartbeat_timeout_is_not_labelled_a_client_disconnect(self):
+        """alert_rules.yml:159 filters reason!="client_disconnect"."""
+        assert (
+            DisconnectReason.from_wire("heartbeat_timeout").value != "client_disconnect"
+        )
+
+
+class TestTheReasonSurvivesCleanup:
+    async def test_a_heartbeat_timeout_reaches_the_monitor(self, monkeypatch):
+        from services.api_gateway import websocket as ws
+        from services.api_gateway.session_manager import SessionManager
+
+        recorded: list[DisconnectReason] = []
+
+        class _Monitor:
+            def connection_closed(self, connection_id, reason):
+                recorded.append(reason)
+                return None
+
+        monkeypatch.setattr(ws, "get_websocket_monitor", lambda: _Monitor())
+
+        manager = ws.WebSocketManager(SessionManager())
+        connection_id = manager._build_connection_id("s1", ws.ClientType.CUSTOMER)
+        manager.all_connections[connection_id] = ws.WebSocketConnection(
+            websocket=Mock(),
+            client_type=ws.ClientType.CUSTOMER,
+            session_id="s1",
+            connected_at=datetime.now(timezone.utc),
+            last_heartbeat=datetime.now(timezone.utc),
+            state=ws.ConnectionState.CONNECTED,
+        )
+        await manager._cleanup_connection(
+            connection_id, DisconnectReason.HEARTBEAT_TIMEOUT
+        )
+
+        assert recorded == [DisconnectReason.HEARTBEAT_TIMEOUT]
+
+
+class _RecordingMonitor:
+    """Only the two calls these paths make; anything else is a test bug."""
+
+    def __init__(self) -> None:
+        self.closed: list[DisconnectReason] = []
+        self.rejected: list[DisconnectReason] = []
+
+    def connection_closed(self, connection_id, reason):
+        self.closed.append(reason)
+        return None
+
+    def record_rejected_connection(self, reason):
+        self.rejected.append(reason)
+
+
+def _manager_with_one_connection(monkeypatch, monitor: _RecordingMonitor):
+    from services.api_gateway import websocket as ws
+    from services.api_gateway.session_manager import SessionManager
+
+    monkeypatch.setattr(ws, "get_websocket_monitor", lambda: monitor)
+
+    manager = ws.WebSocketManager(SessionManager())
+    connection_id = manager._build_connection_id("s1", ws.ClientType.CUSTOMER)
+    socket = Mock()
+    socket.send_json = AsyncMock()
+    socket.close = AsyncMock()
+    connection = ws.WebSocketConnection(
+        websocket=socket,
+        client_type=ws.ClientType.CUSTOMER,
+        session_id="s1",
+        connected_at=datetime.now(timezone.utc),
+        last_heartbeat=datetime.now(timezone.utc),
+        state=ws.ConnectionState.CONNECTED,
+    )
+    manager.all_connections[connection_id] = connection
+    manager.session_connections["s1"] = {connection_id: connection}
+    return manager, connection_id
+
+
+class TestTheReasonSurvivesTheCallOperatorsActuallyMake:
+    """_cleanup_connection is the seam the fix edited; disconnect_websocket is
+    the seam every caller uses. Dropping the argument at that call site passes
+    a suite that only exercises the former."""
+
+    async def test_a_heartbeat_timeout_reaches_the_monitor(self, monkeypatch):
+        monitor = _RecordingMonitor()
+        manager, connection_id = _manager_with_one_connection(monkeypatch, monitor)
+
+        await manager.disconnect_websocket(connection_id, "heartbeat_timeout")
+
+        assert monitor.closed == [DisconnectReason.HEARTBEAT_TIMEOUT]
+
+    async def test_the_default_is_still_a_clean_client_exit(self, monkeypatch):
+        monitor = _RecordingMonitor()
+        manager, connection_id = _manager_with_one_connection(monkeypatch, monitor)
+
+        await manager.disconnect_websocket(connection_id)
+
+        assert monitor.closed == [DisconnectReason.CLIENT_DISCONNECT]
+
+
+class TestASessionTerminationIsNotAFailure:
+    """terminate_all_active_sessions(reason="new_session_created") runs on every
+    new session. Recording those as CONNECTION_ERROR feeds routine traffic into
+    a critical alert."""
+
+    @pytest.mark.parametrize(
+        "reason,expected",
+        [
+            ("session_timeout", DisconnectReason.SESSION_EXPIRED),
+            ("new_session_created", DisconnectReason.SERVER_DISCONNECT),
+            ("session_ended", DisconnectReason.SERVER_DISCONNECT),
+        ],
+    )
+    async def test_the_termination_reason_reaches_the_monitor(
+        self, monkeypatch, reason: str, expected: DisconnectReason
+    ):
+        monitor = _RecordingMonitor()
+        manager, _ = _manager_with_one_connection(monkeypatch, monitor)
+
+        await manager.handle_session_termination("s1", reason)
+
+        assert monitor.closed == [expected]
+
+
+class TestARejectedOriginIsCounted:
+    """WebSocketOriginBlocked matches a counter nothing incremented before the
+    rejection path started recording it."""
+
+    async def test_the_rejection_increments_the_disconnect_counter(self, monkeypatch):
+        from services.api_gateway import websocket as ws
+
+        monitor = _RecordingMonitor()
+        monkeypatch.setattr(ws, "get_websocket_monitor", lambda: monitor)
+
+        async def deny(_origin):
+            return False
+
+        monkeypatch.setattr(ws, "validate_websocket_origin", deny)
+
+        socket = Mock()
+        socket.close = AsyncMock()
+
+        await ws.websocket_endpoint(
+            socket, "TEST1234", "admin", Mock(), "https://not-allowed.example"
+        )
+
+        assert monitor.rejected == [DisconnectReason.ORIGIN_NOT_ALLOWED]
+        socket.close.assert_awaited_once()
+
+
+class TestNormalSessionEndDoesNotPageWebSocketConnectionFailures:
+    """The alert expression is now load-bearing on specific enum values: a
+    reason that DisconnectReason.from_wire maps outside its exclusion list
+    contributes to the failure rate and can page. An operator terminating a
+    session (manual_termination, manual_admin_termination), a new session
+    replacing an old one (new_session_created), a clean shutdown
+    (session_ended) and a session ageing out (session_timeout) are all
+    routine lifecycle, not connection failures."""
+
+    @pytest.mark.parametrize(
+        "wire_reason",
+        [
+            "new_session_created",
+            "session_ended",
+            "session_timeout",
+            "manual_termination",
+            "manual_admin_termination",
+        ],
+    )
+    def test_a_normal_session_end_reason_is_excluded(self, wire_reason: str):
+        mapped = DisconnectReason.from_wire(wire_reason)
+        assert mapped.value in _excluded_disconnect_reasons(), (
+            f"{wire_reason!r} maps to {mapped.value!r}, which "
+            "WebSocketConnectionFailures does not exclude -- it would page on "
+            "routine session lifecycle"
+        )
+
+    def test_a_genuine_connection_error_still_pages(self):
+        assert (
+            DisconnectReason.CONNECTION_ERROR.value
+            not in _excluded_disconnect_reasons()
+        )

--- a/tests/test_websocket_polling_behavior.py
+++ b/tests/test_websocket_polling_behavior.py
@@ -52,6 +52,14 @@ async def test_poll_rejects_unknown_client_before_accessing_queue(monkeypatch):
 
 
 @pytest.mark.asyncio
+def _recording_send(queued):
+    def send(polling_id, message):
+        queued.append((polling_id, message))
+        return True
+
+    return send
+
+
 async def test_polling_send_broadcasts_and_queues_only_other_clients(monkeypatch):
     websocket_manager = Mock()
     websocket_manager.broadcast_to_session = AsyncMock()
@@ -74,7 +82,10 @@ async def test_polling_send_broadcasts_and_queues_only_other_clients(monkeypatch
     monkeypatch.setattr(
         polling_routes.fallback_manager,
         "send_message_to_polling_client",
-        lambda polling_id, message: queued.append((polling_id, message)),
+        # The real function returns True when the message was queued with
+        # nothing evicted; list.append returns None, which the route now reads
+        # as an overflowed recipient queue.
+        _recording_send(queued),
     )
     from services.api_gateway import websocket
 

--- a/tests/test_websocket_polling_coverage.py
+++ b/tests/test_websocket_polling_coverage.py
@@ -23,20 +23,20 @@ from services.api_gateway.websocket_monitor import (
 
 
 @pytest.mark.asyncio
-async def test_fallback_activation_queues_messages_and_suggests_recovery(monkeypatch):
+async def test_fallback_activation_queues_messages_and_suggests_recovery():
     """Polling clients receive queued messages and due recovery instructions."""
     manager = WebSocketFallbackManager(
         FallbackConfig(enable_jitter=False, enable_user_notifications=False)
     )
-    monkeypatch.setattr("services.api_gateway.websocket_fallback.time.time", lambda: 42)
-
     polling_id = await manager.activate_polling_fallback(
         "session-1",
         "admin",
         "https://console.example",
         FallbackReason.NETWORK_ERROR,
     )
-    assert polling_id == "poll_session-1_admin_42"
+    # The id ends in a random suffix, not a timestamp: two activations for one
+    # session and client type inside a second used to collide and drop a queue.
+    assert polling_id.startswith("poll_session-1_admin_")
     assert manager.send_message_to_polling_client(polling_id, {"type": "transcript"})
 
     client = manager.polling_clients[polling_id]

--- a/tests/test_websocket_polling_queue_overflow.py
+++ b/tests/test_websocket_polling_queue_overflow.py
@@ -13,6 +13,7 @@ import pytest
 from services.api_gateway.websocket_fallback import (
     FallbackConfig,
     FallbackReason,
+    POLLING_MAX_CLIENTS_PER_SESSION_CLIENT_TYPE,
     POLLING_QUEUE_MAX_MESSAGES,
     WebSocketFallbackManager,
 )
@@ -177,3 +178,116 @@ class TestTheOverflowWarningIsSafeToLog:
         assert "\n" not in warning, "an unescaped newline can forge a log record"
         assert session_id not in warning
         assert polling_id not in warning
+
+
+class TestThePollingClientMapIsBounded:
+    """`/api/websocket/polling/activate` has no authentication -- it checks
+    only that the session exists. While polling ids ended in a timestamp,
+    repeat activations inside one second collided and overwrote each other,
+    which accidentally capped the map. Unique ids removed that accident, so the
+    bound has to be explicit."""
+
+    async def test_repeat_activations_do_not_grow_the_map_without_limit(self):
+        manager = WebSocketFallbackManager(
+            FallbackConfig(enable_jitter=False, enable_user_notifications=False)
+        )
+
+        for _ in range(50):
+            await manager.activate_polling_fallback(
+                "session-1", "customer", None, FallbackReason.NETWORK_ERROR
+            )
+
+        assert (
+            len(manager.polling_clients)
+            == POLLING_MAX_CLIENTS_PER_SESSION_CLIENT_TYPE
+        )
+        assert (
+            len(manager.session_polling_clients["session-1"])
+            == POLLING_MAX_CLIENTS_PER_SESSION_CLIENT_TYPE
+        )
+
+    async def test_the_newest_activation_survives(self):
+        """The client repairing its connection keeps the queue it will poll."""
+        manager = WebSocketFallbackManager(
+            FallbackConfig(enable_jitter=False, enable_user_notifications=False)
+        )
+
+        ids = [
+            await manager.activate_polling_fallback(
+                "session-1", "customer", None, FallbackReason.NETWORK_ERROR
+            )
+            for _ in range(POLLING_MAX_CLIENTS_PER_SESSION_CLIENT_TYPE + 2)
+        ]
+
+        assert ids[-1] in manager.polling_clients
+        assert ids[0] not in manager.polling_clients
+
+    async def test_the_cap_is_per_client_type_not_per_process(self):
+        """An admin activating must not evict the customer on the same session."""
+        manager = WebSocketFallbackManager(
+            FallbackConfig(enable_jitter=False, enable_user_notifications=False)
+        )
+
+        customer = await manager.activate_polling_fallback(
+            "session-1", "customer", None, FallbackReason.NETWORK_ERROR
+        )
+        for _ in range(POLLING_MAX_CLIENTS_PER_SESSION_CLIENT_TYPE + 2):
+            await manager.activate_polling_fallback(
+                "session-1", "admin", None, FallbackReason.NETWORK_ERROR
+            )
+
+        assert customer in manager.polling_clients
+
+
+class TestTheDropLogDoesNotFlood:
+    """A wedged client -- queue full, not yet 30-minute-stale -- drops every
+    subsequent message. One WARNING per drop meant a line per translation for
+    up to half an hour, for exactly the client this code exists to report."""
+
+    def test_a_saturated_queue_warns_once_not_per_message(
+        self, polling_client, caplog
+    ):
+        manager, polling_id = polling_client
+
+        with caplog.at_level(logging.WARNING):
+            for index in range(POLLING_QUEUE_MAX_MESSAGES + 200):
+                manager.send_message_to_polling_client(
+                    polling_id, {"type": "translation", "seq": index}
+                )
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warnings) == 1, (
+            f"{len(warnings)} warnings for 200 drops -- the log floods for a "
+            "single wedged client"
+        )
+
+    def test_the_counter_still_records_every_drop(self, polling_client):
+        """Bounding the log must not bound the metric."""
+        manager, polling_id = polling_client
+        before = _dropped(manager)
+
+        for index in range(POLLING_QUEUE_MAX_MESSAGES + 200):
+            manager.send_message_to_polling_client(
+                polling_id, {"type": "translation", "seq": index}
+            )
+
+        assert _dropped(manager) - before == 200
+
+    def test_a_client_that_recovers_and_saturates_again_warns_again(
+        self, polling_client, caplog
+    ):
+        manager, polling_id = polling_client
+
+        with caplog.at_level(logging.WARNING):
+            for index in range(POLLING_QUEUE_MAX_MESSAGES + 5):
+                manager.send_message_to_polling_client(
+                    polling_id, {"type": "translation", "seq": index}
+                )
+            manager.poll_messages(polling_id)
+            for index in range(POLLING_QUEUE_MAX_MESSAGES + 5):
+                manager.send_message_to_polling_client(
+                    polling_id, {"type": "translation", "seq": index}
+                )
+
+        # One per episode, plus the drain summary between them.
+        assert len([r for r in caplog.records if r.levelno == logging.WARNING]) == 3

--- a/tests/test_websocket_polling_queue_overflow.py
+++ b/tests/test_websocket_polling_queue_overflow.py
@@ -1,0 +1,179 @@
+"""Overflow on the polling fallback must be counted, never silent.
+
+This is the path a client uses when WebSockets fail -- the worst networks. It
+dropped the oldest queued translation past 100 and returned True, so Q3
+(delivery success) and Q7 (ordering) could not be measured and the user simply
+lost a message.
+"""
+
+import logging
+
+import pytest
+
+from services.api_gateway.websocket_fallback import (
+    FallbackConfig,
+    FallbackReason,
+    POLLING_QUEUE_MAX_MESSAGES,
+    WebSocketFallbackManager,
+)
+
+
+@pytest.fixture
+async def polling_client():
+    manager = WebSocketFallbackManager(
+        FallbackConfig(enable_jitter=False, enable_user_notifications=False)
+    )
+    polling_id = await manager.activate_polling_fallback(
+        "session-1",
+        "customer",
+        "https://console.example",
+        FallbackReason.NETWORK_ERROR,
+    )
+    return manager, polling_id
+
+
+def _dropped(
+    manager: WebSocketFallbackManager, client_type: str = "customer"
+) -> float:
+    return manager.messages_dropped.labels(client_type=client_type)._value.get()
+
+
+class TestTheBoundIsStillEnforced:
+    def test_the_queue_does_not_grow_without_limit(self, polling_client):
+        manager, polling_id = polling_client
+
+        for index in range(POLLING_QUEUE_MAX_MESSAGES + 50):
+            manager.send_message_to_polling_client(
+                polling_id, {"type": "translation", "seq": index}
+            )
+
+        assert (
+            len(manager.polling_clients[polling_id].message_queue)
+            == POLLING_QUEUE_MAX_MESSAGES
+        )
+
+
+class TestOverflowIsVisible:
+    def test_a_dropped_message_increments_the_counter(self, polling_client):
+        manager, polling_id = polling_client
+        before = _dropped(manager)
+
+        for index in range(POLLING_QUEUE_MAX_MESSAGES + 5):
+            manager.send_message_to_polling_client(
+                polling_id, {"type": "translation", "seq": index}
+            )
+
+        assert _dropped(manager) - before == 5
+
+    def test_no_drop_means_no_increment(self, polling_client):
+        manager, polling_id = polling_client
+        before = _dropped(manager)
+
+        manager.send_message_to_polling_client(
+            polling_id, {"type": "translation", "seq": 0}
+        )
+
+        assert _dropped(manager) == before
+
+    def test_the_send_reports_failure_when_it_dropped_something(self, polling_client):
+        manager, polling_id = polling_client
+
+        for index in range(POLLING_QUEUE_MAX_MESSAGES):
+            assert (
+                manager.send_message_to_polling_client(polling_id, {"seq": index})
+                is True
+            )
+
+        assert (
+            manager.send_message_to_polling_client(
+                polling_id, {"seq": POLLING_QUEUE_MAX_MESSAGES}
+            )
+            is False
+        )
+
+
+class TestTheCounterSurvivesTheRegistryBoundary:
+    """A counter is not a signal until Prometheus can scrape it.
+
+    /metrics serves app.state.prometheus_registry. A series left on
+    prometheus_client's global default registry is counted in-process, appears
+    in no scrape, and can carry no alert — which is the same "signal that looks
+    present but cannot fire" defect this branch exists to remove. Reading the
+    counter object directly cannot catch that; only the endpoint body can.
+    """
+
+    async def test_a_real_drop_reaches_the_metrics_endpoint(self):
+        import services.api_gateway.app  # noqa: F401  binds the gateway registry
+        from services.api_gateway.routes.metrics import metrics
+        from services.api_gateway.websocket_fallback import fallback_manager
+
+        polling_id = await fallback_manager.activate_polling_fallback(
+            "session-metrics", "customer", None, FallbackReason.NETWORK_ERROR
+        )
+        try:
+            for index in range(POLLING_QUEUE_MAX_MESSAGES + 2):
+                fallback_manager.send_message_to_polling_client(
+                    polling_id, {"type": "translation", "seq": index}
+                )
+            body = metrics().body.decode("utf-8")
+        finally:
+            fallback_manager.deactivate_polling_fallback(polling_id)
+
+        assert "websocket_polling_messages_dropped_total" in body, (
+            "the drop counter is not in the scraped registry; overflow is "
+            "counted only inside the process"
+        )
+        sample = next(
+            line
+            for line in body.splitlines()
+            if line.startswith(
+                'websocket_polling_messages_dropped_total{client_type="customer"}'
+            )
+        )
+        assert float(sample.rsplit(" ", 1)[1]) > 0
+
+
+class TestTheLabelCannotBeMintedByAClient:
+    """client_type arrives unvalidated from POST /api/websocket/polling/activate,
+    which has no auth dependency. An unbounded label value is a cardinality
+    blowup."""
+
+    async def test_an_unrecognised_client_type_is_folded_into_unknown(self):
+        manager = WebSocketFallbackManager(
+            FallbackConfig(enable_jitter=False, enable_user_notifications=False)
+        )
+        attacker_value = "attacker-" + "x" * 100
+        polling_id = await manager.activate_polling_fallback(
+            "session-1", attacker_value, None, FallbackReason.NETWORK_ERROR
+        )
+
+        for index in range(POLLING_QUEUE_MAX_MESSAGES + 1):
+            manager.send_message_to_polling_client(polling_id, {"seq": index})
+
+        assert _dropped(manager, "unknown") == 1
+        assert (attacker_value,) not in manager.messages_dropped._metrics
+
+
+class TestTheOverflowWarningIsSafeToLog:
+    """The dropped message's `type` is an unconstrained client string (CWE-117),
+    and a log line about a lost message must not leak who lost it."""
+
+    def test_it_names_the_sanitized_type_and_no_identifiers(
+        self, polling_client, caplog
+    ):
+        manager, polling_id = polling_client
+        session_id = manager.polling_clients[polling_id].session_id
+        forged = "translation\nWARNING: admin session terminated"
+
+        with caplog.at_level(
+            logging.WARNING, logger="services.api_gateway.websocket_fallback"
+        ):
+            for _ in range(POLLING_QUEUE_MAX_MESSAGES + 1):
+                manager.send_message_to_polling_client(polling_id, {"type": forged})
+
+        warning = next(m for m in caplog.messages if "Polling queue full" in m)
+
+        assert "translation\\nWARNING: admin session terminated" in warning
+        assert "\n" not in warning, "an unescaped newline can forge a log record"
+        assert session_id not in warning
+        assert polling_id not in warning

--- a/tests/test_websocket_sender_exclusion.py
+++ b/tests/test_websocket_sender_exclusion.py
@@ -1,0 +1,102 @@
+"""A client must not receive an echo of its own message.
+
+`broadcast_to_session` excludes by connection id, and two handlers used to
+rebuild that id from `int(connection.connected_at.timestamp())`. That string
+matched the real id only because the id ended in `int(time.time())` too, and
+both were computed in the same second -- an accident, not a lookup. Making
+connection ids unique broke the accident, so the sender was included in its
+own broadcast and every message arrived twice.
+
+No test covered the exclusion path, so nothing failed when it broke. These do.
+"""
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from services.api_gateway import websocket as ws
+from services.api_gateway.session_manager import SessionManager
+
+
+@pytest.fixture(autouse=True)
+def _silent_monitor(monkeypatch):
+    """broadcast_to_session reports every send to the monitor."""
+    monkeypatch.setattr(ws, "get_websocket_monitor", lambda: Mock())
+
+
+def _register(manager: ws.WebSocketManager, session_id: str, client_type: ws.ClientType):
+    """Register a live connection the way connect_websocket does."""
+    connection_id = manager._build_connection_id(session_id, client_type)
+    socket = Mock()
+    socket.send_json = AsyncMock()
+    connection = ws.WebSocketConnection(
+        websocket=socket,
+        client_type=client_type,
+        session_id=session_id,
+        connected_at=datetime.now(timezone.utc),
+        last_heartbeat=datetime.now(timezone.utc),
+        state=ws.ConnectionState.CONNECTED,
+    )
+    manager.session_connections.setdefault(session_id, {})[connection_id] = connection
+    manager.all_connections[connection_id] = connection
+    return connection_id, connection, socket
+
+
+@pytest.fixture
+def session():
+    manager = ws.WebSocketManager(SessionManager())
+    _, admin, admin_socket = _register(manager, "session-1", ws.ClientType.ADMIN)
+    _, customer, customer_socket = _register(
+        manager, "session-1", ws.ClientType.CUSTOMER
+    )
+    return {
+        "manager": manager,
+        "admin": admin,
+        "admin_socket": admin_socket,
+        "customer": customer,
+        "customer_socket": customer_socket,
+    }
+
+
+class TestTheSenderIsExcludedFromItsOwnBroadcast:
+    async def test_a_chat_message_does_not_come_back_to_its_sender(self, session):
+        await session["manager"]._handle_client_message(
+            session["customer"], {"content": "hallo"}
+        )
+
+        assert session["customer_socket"].send_json.await_count == 0
+        assert session["admin_socket"].send_json.await_count == 1
+
+    async def test_a_typing_indicator_does_not_come_back_to_its_sender(self, session):
+        await session["manager"]._handle_typing_indicator(
+            session["admin"], {"is_typing": True}
+        )
+
+        assert session["admin_socket"].send_json.await_count == 0
+        assert session["customer_socket"].send_json.await_count == 1
+
+
+class TestTheExclusionUsesTheRegisteredId:
+    def test_the_id_is_looked_up_not_rebuilt(self, session):
+        """A rebuilt id is a guess about the id format; this is the map itself."""
+        manager = session["manager"]
+        registered = next(
+            connection_id
+            for connection_id, connection in manager.all_connections.items()
+            if connection is session["customer"]
+        )
+
+        assert manager._registered_connection_id(session["customer"]) == registered
+
+    def test_an_unregistered_connection_has_no_id(self, session):
+        stranger = ws.WebSocketConnection(
+            websocket=Mock(),
+            client_type=ws.ClientType.CUSTOMER,
+            session_id="session-1",
+            connected_at=datetime.now(timezone.utc),
+            last_heartbeat=datetime.now(timezone.utc),
+            state=ws.ConnectionState.CONNECTED,
+        )
+
+        assert session["manager"]._registered_connection_id(stranger) is None


### PR DESCRIPTION
## Description

Wave 0 of the architecture backlog: five defects that share one theme — a
signal that looks present and cannot fire. Three model services were
published on every interface with no authentication; the connection
telemetry that four KPIs depend on was recording collided ids and a
hardcoded disconnect reason; the polling fallback dropped messages and
reported success; and the service-down alerts matched a metric that
disappears when the service dies.

## Type of Change

- [x]  Bug fix (non-breaking change which fixes an issue)
- [x]  Documentation update
- [x]  Test update
- [x]  Security fix

## Related Issues

Closes #221
Closes #220

## Changes Made

**Close the model-service ports (#221)** — `asr`, `translation` and `tts`
published `8001:8000`, `8002:8000`, `8003:8000` on every interface with no
authentication, in both `docker-compose.yml` and the pinned
`deploy/production/docker-compose.production.yml`. They move to `expose`,
matching the `clickhouse` precedent: the gateway still reaches them over the
compose network, nothing outside it can.

**Stop two sockets sharing one connection id** — the id ended in
`int(time.time())`, so two connections for one session and client type inside
a second collided. The monitor keys its active map by that id, so one socket's
metrics became the other's — worst during exactly the reconnect storms the
connection KPIs measure. The polling client id had the same defect and dropped
one client's queue.

**Record the disconnect reason the code already had** —
`disconnect_websocket` receives a real reason (`heartbeat_timeout`,
`no_connections`, `origin_not_allowed`), put it in the close frame, then
discarded it and recorded `CLIENT_DISCONNECT` for every disconnect. That
zeroed the unexpected-disconnect KPI and left two alerts unfireable:
`WebSocketConnectionFailures` filters `reason!=client_disconnect`, and
`WebSocketOriginBlocked` matched a label value the enum never defined.

**Count polling-queue overflow instead of hiding it** — past 100 queued
messages the fallback discarded the oldest and returned `True`, so a client on
the worst network lost a translation and nothing recorded it. The bound stays;
overflow now increments `websocket_polling_messages_dropped_total`, logs, and
returns `False`.

**Alert on scrape failure, not only self-reported health (#220)** —
`ASRServiceDown` and its siblings matched `<svc>_health_status == 0`, a metric
scraped *from the service itself*. A stopped container makes that series
vanish rather than go to zero, so the alert stayed silent through the outage it
was written for. Adds `up{job=...} == 0` companions for the three model
services and the gateway, keeping the health rules for the different failure
of a process that is up and reporting itself unhealthy.

## Testing

Run on this branch with `origin/main` merged in:

```
1040 passed, 62 skipped, 9 failed
promtool check rules monitoring/alert_rules.yml → SUCCESS: 39 rules found
```

The 9 failures are `PermissionError: [Errno 13] Permission denied: '/data'`
in the audio-storage tests. The identical 9 fail on a clean `origin/main`
worktree in the same environment — they are pre-existing and unrelated to
this branch.

Each of the four code guards was verified by reinstating the original bug and
watching the new test reject it, then restoring the fix. Three of those
reversions initially passed the whole suite; the tests were strengthened at the
endpoint seam until they caught them.

**#220's acceptance criterion is empirical, and was met by observation, not by
a unit test.** With `translation` stopped, `up{job="translation"}` read `0`
while `translation_health_status` was `SERIES ABSENT` — the defect,
reproduced. Each of the three model-service alerts was then observed reaching
`firing` in `/api/v1/alerts` and clearing on restart. `APIGatewayScrapeDown`
was deliberately not exercised, since the gateway serves the local stack.

### Test Coverage

- [x] All existing tests pass (except the 9 pre-existing failures above)
- [x] New tests added for this change
- [x] Manual testing completed
- [ ] Integration tests pass — not run; they need a rebuilt image and `--run-integration`
- [ ] Load tests pass (if applicable) — not applicable

### How to Test

```bash
pytest tests/test_ai_service_port_exposure.py \
       tests/test_websocket_connection_identity.py \
       tests/test_websocket_disconnect_reasons.py \
       tests/test_websocket_polling_queue_overflow.py \
       tests/test_service_down_alerting.py

docker run --rm --entrypoint promtool -v "$PWD/monitoring:/m" \
  prom/prometheus:latest check rules /m/alert_rules.yml
```

## Review round

A review of the first five commits found two blockers and six other defects.
All eight are fixed in the four commits that follow, each with a guard that
was watched failing on the broken code first.

**The blockers.** Two handlers rebuilt the sender's connection id from
`int(connection.connected_at.timestamp())` and passed it as
`exclude_connection`. That string matched the real id only because the id
also ended in `int(time.time())`, computed microseconds earlier — an
accident, not a lookup. Making ids unique broke the accident, so every client
received an echo of its own messages and typing indicators. No test covered
the exclusion path, which is why the suite stayed green. It is covered now,
and the exclusion asks the connection map rather than guessing the id format.

**The rest.**

- `system_cleanup` — the default reason of `terminate_all_active_sessions`
  and a member of the closed `SessionTerminationReason` enum — mapped to
  `PROTOCOL_ERROR`, so an operator running a maintenance cleanup paged
  critical. `timeout` and `error` had the same gap. The new guard enumerates
  the enum rather than listing reasons by hand, since a hand-written list is
  what let this through.
- `origin_not_allowed` is now excluded from `WebSocketConnectionFailures`.
  `WebSocketOriginBlocked` matches it at 0.01/s against that rule's 0.1/s with
  the same `for: 1m`, so the warning always fired first and the critical was a
  second page for one cause.
- The polling client map had no bound. `/api/websocket/polling/activate` has
  no authentication, and unique polling ids removed the accidental cap that id
  collisions used to provide. Entries are now reclaimed oldest-first past a
  per-session cap.
- The overflow log emitted one WARNING per dropped message, so a single wedged
  client produced a line per translation for up to 30 minutes. One line per
  saturation episode now; the counter still records every drop.
- The SSH tunnel these docs offer forwarded to `localhost:8001-8003` on the
  GPU host — the ports this PR closes. It would have worked only until the
  change it documents was deployed. It now targets the container addresses on
  port 8000.
- The runbook's own verification step could not work: Prometheus is
  expose-only so `curl localhost:9090` is refused, and `grep -c` counts lines
  in a single-line JSON body, so it reported `1` however many rules matched.
  Both are fixed and the command was verified returning `4`.

## Checklist

### Code Quality

- [x] Code follows the project's style guidelines
- [x] Self-review of code completed
- [x] Code is commented where necessary
- [x] No new warnings generated

### Testing

- [x] Tests added/updated for new functionality
- [x] All tests pass locally (see the pre-existing failures above)
- [x] Test coverage maintained or improved

Three existing tests asserted the old, buggy contracts and are updated, each
with a comment saying why: an always-`True` send past the queue bound, an
exact timestamped polling id, and a disconnect reason of `client_disconnect`
where the code now reports `connection_error`.

### Documentation

- [x] Documentation updated (README, docs/, docstrings)
- [x] `docs/operations/runbooks/service-down-alerts.md` added

The READMEs and `CONTRIBUTING.md` documented `curl localhost:8001-8003` health
checks that the port closure breaks. They now show the compose-network address
and the SSH tunnel that reaches the services from a host, binding both the
Docker bridge and loopback.

### Dependencies

- [x] No new dependencies added

### Security

- [x] No sensitive data exposed
- [x] Security best practices followed

## Performance Impact

- [x] No performance impact

## Deployment Notes

- [x] Requires configuration changes
- [x] Requires service restart

**Prometheus must be restarted or sent a config reload** for the new rules to
load; until then `/api/v1/alerts` will not list them and the alerts cannot
fire.

**The port closure is verified in the repository, not yet on the running
host.** `asr`, `translation` and `tts` keep their published ports on the GPU
server until the next production deploy recreates those containers. Confirm
with `curl --max-time 5 http://<gpu-host>:8001/health` after deploying —
a refusal or timeout is the pass.

## Additional Notes

Three exposures were found while closing #221 and are **not** fixed here,
to keep this PR to its stated scope:

1. **`grafana` publishes `3000:3000` on every interface** in both compose
   files, with `GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}`.
   If that variable is unset in production, Grafana is publicly reachable on
   `admin`/`admin`. This is worth checking before this PR is merged; it is a
   wider hole than the one #221 was filed for.
2. **`api_gateway` publishes `8000:8000`** on every interface. That is the
   public integration boundary and is intended, but it is also the reason
   the model services were reachable at all, and it belongs on the record.
3. **`frontend-archive` publishes `5173:5173`.** It sits behind the
   `production` profile, so it does not start by default.

Two sub-items of #220 are deliberately deferred: aligning the
circuit-breaker thresholds (depends on #219) and recalibrating the
GPU-memory (`0.95`) and translation-latency (`3s`) thresholds. Both numbers
are inherited and unproven; the runbook records them as such rather than
replacing them with invented ones, since a baseline window is what would
settle them.

The `runbook_url` annotations point at GitHub blob permalinks for the new
runbook. An earlier draft pointed at `docs.smart-village.solutions`, matching
the file's existing precedent — that hostname is **NXDOMAIN**, so every
`runbook_url` already in `alert_rules.yml` is a dead link. Worth a separate
issue.
