### PR TITLE
fix(asr): use Whisper large-v3-turbo

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Ein containerisiertes Microservice-Backend für Echtzeit-Sprachverarbeitung und 
 
 ## ✨ Features at a Glance
 
-- 🎤 **Automatic Speech Recognition** – Transkription mit OpenAI Whisper
+- 🎤 **Automatic Speech Recognition** – Transcription with OpenAI Whisper large-v3-turbo
 - 🌍 **Multi-Language Translation** – 100+ Sprachen mit Facebook M2M100
 - 🔊 **Text-to-Speech** – Natürliche Sprachsynthese mit Coqui-TTS & HuggingFace MMS
 - ⚡ **GPU-Accelerated** – CUDA-Support für optimale Performance
@@ -107,7 +107,7 @@ Der aktuelle Haupt-Workflow fuer Admin/Customer-Kommunikation ist sessionbasiert
 ### 1. ASR Service (Speech-to-Text)
 - **Port:** 8001
 - **Funktion:** Automatische Spracherkennung für verschiedene Sprachen und Audioformate
-- **Modelle:** Whisper, Wav2Vec, etc. (lokal geladen)
+- **Model:** OpenAI Whisper large-v3-turbo (loaded locally)
 - **Endpunkte:** `/transcribe` (POST), `/health` (GET), `/metrics` (GET), `/supported-languages` (GET)
 - **Beispiel:**
    ```bash
@@ -424,7 +424,7 @@ Falls die Sprachparameter fehlen oder ungültig sind, liefert das Backend eine F
 Eine ausführliche Dokumentation zu den in den Services verwendeten KI-Modellen, deren Quellen und Lizenzen findest du unter [models.md](./models.md).
 
 ### Hauptmodelle
-- **ASR:** OpenAI Whisper (verschiedene Größen)
+- **ASR:** OpenAI Whisper large-v3-turbo
 - **Translation:** Facebook M2M100 (1.2B Parameter)
 - **TTS:** Coqui-TTS (europäische Sprachen), HuggingFace MMS-TTS (weitere Sprachen)
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Ein containerisiertes Microservice-Backend für Echtzeit-Sprachverarbeitung und 
 
 ## ✨ Features at a Glance
 
-- 🎤 **Automatic Speech Recognition** – Transcription with OpenAI Whisper large-v3-turbo
+- 🎤 **Automatic Speech Recognition** – Transkription mit OpenAI Whisper large-v3-turbo
 - 🌍 **Multi-Language Translation** – 100+ Sprachen mit Facebook M2M100
 - 🔊 **Text-to-Speech** – Natürliche Sprachsynthese mit Coqui-TTS & HuggingFace MMS
 - ⚡ **GPU-Accelerated** – CUDA-Support für optimale Performance
@@ -107,7 +107,7 @@ Der aktuelle Haupt-Workflow fuer Admin/Customer-Kommunikation ist sessionbasiert
 ### 1. ASR Service (Speech-to-Text)
 - **Port:** 8001
 - **Funktion:** Automatische Spracherkennung für verschiedene Sprachen und Audioformate
-- **Model:** OpenAI Whisper large-v3-turbo (loaded locally)
+- **Modell:** OpenAI Whisper large-v3-turbo (lokal geladen)
 - **Endpunkte:** `/transcribe` (POST), `/health` (GET), `/metrics` (GET), `/supported-languages` (GET)
 - **Beispiel:**
    ```bash

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,7 +7,7 @@ This roadmap outlines completed v1.0 features, ongoing work, and planned improve
 ### ✅ Completed Features
 
 #### Core Services
-- ✅ **ASR Service** – Speech recognition with OpenAI Whisper
+- ✅ **ASR Service** – Speech recognition with OpenAI Whisper large-v3-turbo
 - ✅ **Translation Service** – 100+ languages with Facebook M2M100
 - ✅ **TTS Service** – Text-to-speech with Coqui-TTS & HuggingFace MMS
 - ✅ **API Gateway** – Unified REST API and pipeline orchestration

--- a/docs/architecture/SYSTEM_ARCHITECTURE.md
+++ b/docs/architecture/SYSTEM_ARCHITECTURE.md
@@ -84,7 +84,7 @@ Interne Service-Kommunikation erfolgt über das Docker-Netzwerk (`http://api_gat
 ### **Microservices Layer**
 
 **ASR Service** *(Interner Host: `http://asr:8000`, Port nach außen via Traefik nicht freigegeben)* - Spracherkennung
-- Whisper Models: Mehrsprachig, GPU-optimiert
+- Whisper large-v3-turbo: Multilingual, GPU-optimized ASR
 - Audio Processing: Format Detection, Normalisierung, Quality Enhancement
 
 **Translation Service** *(Interner Host: `http://translation:8000`)* - Textübersetzung
@@ -345,10 +345,8 @@ Interne Service-Kommunikation erfolgt über das Docker-Netzwerk (`http://api_gat
 
 **Whisper-basierte Spracherkennung:**
 
-**Models:**
-- whisper-base: Schnell, moderate Genauigkeit
-- whisper-medium: Balance zwischen Speed und Accuracy
-- whisper-large: Höchste Genauigkeit, langsamer
+**Production model:**
+- whisper-large-v3-turbo: Higher recognition quality with faster decoding than Whisper large-v3
 
 **Processing-Module:**
 - audio_normalization: WAV-Konvertierung, Rauschreduzierung

--- a/docs/architecture/SYSTEM_ARCHITECTURE.md
+++ b/docs/architecture/SYSTEM_ARCHITECTURE.md
@@ -84,7 +84,7 @@ Interne Service-Kommunikation erfolgt über das Docker-Netzwerk (`http://api_gat
 ### **Microservices Layer**
 
 **ASR Service** *(Interner Host: `http://asr:8000`, Port nach außen via Traefik nicht freigegeben)* - Spracherkennung
-- Whisper large-v3-turbo: Multilingual, GPU-optimized ASR
+- Whisper large-v3-turbo: Mehrsprachige, GPU-optimierte Spracherkennung
 - Audio Processing: Format Detection, Normalisierung, Quality Enhancement
 
 **Translation Service** *(Interner Host: `http://translation:8000`)* - Textübersetzung

--- a/docs/architecture/models.md
+++ b/docs/architecture/models.md
@@ -6,7 +6,7 @@
 - **Link:** [https://github.com/openai/whisper](https://github.com/openai/whisper)
 - **Verwendung im Code:**
   - **Datei:** `services/asr/app.py`
-  - **Details:** Wird über `import whisper` eingebunden und mit `whisper.load_model("base", ...)` geladen. Die Transkription erfolgt über die Funktion `model.transcribe(...)`.
+  - **Details:** Loaded through `import whisper` with `whisper.load_model("large-v3-turbo", ...)`. Transcription uses `model.transcribe(...)`.
 
 
 ## **2. M2M100** (Translation Service)

--- a/docs/architecture/models.md
+++ b/docs/architecture/models.md
@@ -6,7 +6,7 @@
 - **Link:** [https://github.com/openai/whisper](https://github.com/openai/whisper)
 - **Verwendung im Code:**
   - **Datei:** `services/asr/app.py`
-  - **Details:** Loaded through `import whisper` with `whisper.load_model("large-v3-turbo", ...)`. Transcription uses `model.transcribe(...)`.
+  - **Details:** Wird über `import whisper` mit `whisper.load_model("large-v3-turbo", ...)` geladen. Die Transkription verwendet `model.transcribe(...)`.
 
 
 ## **2. M2M100** (Translation Service)

--- a/openspec/project.md
+++ b/openspec/project.md
@@ -20,7 +20,7 @@ Smart Speech Flow Backend ist ein containerisiertes Microservice-System für meh
 - **NVIDIA CUDA 13.0** - GPU-Beschleunigung für KI-Modelle
 
 ### AI/ML Components
-- **OpenAI Whisper** - Automatische Spracherkennung (ASR)
+- **OpenAI Whisper large-v3-turbo** - Automatic speech recognition (ASR)
 - **Facebook M2M100** - Mehrsprachige Übersetzung (100+ Sprachen)
 - **Coqui-TTS & HuggingFace MMS-TTS** - Text-zu-Sprache-Synthese
 - **Ollama (gpt-oss:20b)** - LLM-basierte Übersetzungsverfeinerung (optional)

--- a/openspec/project.md
+++ b/openspec/project.md
@@ -20,7 +20,7 @@ Smart Speech Flow Backend ist ein containerisiertes Microservice-System für meh
 - **NVIDIA CUDA 13.0** - GPU-Beschleunigung für KI-Modelle
 
 ### AI/ML Components
-- **OpenAI Whisper large-v3-turbo** - Automatic speech recognition (ASR)
+- **OpenAI Whisper large-v3-turbo** - Automatische Spracherkennung (ASR)
 - **Facebook M2M100** - Mehrsprachige Übersetzung (100+ Sprachen)
 - **Coqui-TTS & HuggingFace MMS-TTS** - Text-zu-Sprache-Synthese
 - **Ollama (gpt-oss:20b)** - LLM-basierte Übersetzungsverfeinerung (optional)

--- a/services/asr/README.en.md
+++ b/services/asr/README.en.md
@@ -45,7 +45,7 @@ Validation errors use FastAPI's error payload format, for example:
 
 ## Implementation notes
 
-- Models such as Whisper or Wav2Vec are loaded locally; audio is not sent to an external API.
+- The service permanently loads Whisper `large-v3-turbo` locally; audio is not sent to an external API.
 - Loaded models remain in memory to improve performance.
 - If the ASR model is not loaded, the endpoint returns the configured fallback response instead of failing the request.
 

--- a/services/asr/README.md
+++ b/services/asr/README.md
@@ -56,7 +56,7 @@ Prometheus-kompatible Metriken für Monitoring.
 
 ## Architektur & Funktionsweise
 1. **Modellwahl:**
-   - Die Spracherkennung erfolgt über lokal geladene Modelle (z. B. Whisper, Wav2Vec, etc.), je nach Konfiguration in `app.py`.
+   - The ASR service permanently loads Whisper `large-v3-turbo` locally.
    - Die Verarbeitung erfolgt immer lokal, keine Daten werden an externe APIs gesendet.
 2. **Caching:**
    - Geladene Modelle werden im Speicher gehalten, um die Performance zu optimieren.

--- a/services/asr/README.md
+++ b/services/asr/README.md
@@ -56,7 +56,7 @@ Prometheus-kompatible Metriken für Monitoring.
 
 ## Architektur & Funktionsweise
 1. **Modellwahl:**
-   - The ASR service permanently loads Whisper `large-v3-turbo` locally.
+   - Der ASR-Service lädt Whisper `large-v3-turbo` dauerhaft lokal.
    - Die Verarbeitung erfolgt immer lokal, keine Daten werden an externe APIs gesendet.
 2. **Caching:**
    - Geladene Modelle werden im Speicher gehalten, um die Performance zu optimieren.

--- a/services/asr/app.py
+++ b/services/asr/app.py
@@ -81,6 +81,7 @@ except ImportError:  # pragma: no cover - optional dependency
     pynvml = None
 
 _nvml_initialized = False
+ASR_MODEL_NAME = "large-v3-turbo"
 TRANSCRIBE_ERROR_RESPONSES = {
     400: {"description": "Invalid transcription request"},
     503: {"description": "ASR model unavailable"},
@@ -112,7 +113,7 @@ def _build_debug_info(lang: str) -> Dict[str, Any]:
         "output": None,
         "error": None,
         "duration": None,
-        "model": "whisper-base",
+        "model": f"whisper-{ASR_MODEL_NAME}",
         "system": _get_system_stats(),
     }
 
@@ -129,17 +130,21 @@ app = FastAPI(title="ASR Service")
 SUPPORTED_LANGS = ["de", "en", "ar", "tr", "am", "fa", "ru", "uk", "ku", "ti"]
 requests_total = Counter("asr_requests_total", "Total ASR requests")
 health_status = Gauge("asr_health_status", "Health status of ASR service")
-model = None
-model_loaded = False
-if whisper:
+
+
+def _load_asr_model():
+    if not whisper:
+        return None
     try:
-        model = whisper.load_model(
-            "base", device="cuda" if torch.cuda.is_available() else "cpu"
+        return whisper.load_model(
+            ASR_MODEL_NAME, device="cuda" if torch.cuda.is_available() else "cpu"
         )
-        model_loaded = True
     except Exception:
-        model = None
-        model_loaded = False
+        return None
+
+
+model = _load_asr_model()
+model_loaded = model is not None
 
 
 @app.get("/health")

--- a/services/asr/tests/test_transcribe.py
+++ b/services/asr/tests/test_transcribe.py
@@ -2,10 +2,28 @@ from pathlib import Path
 
 from fastapi.testclient import TestClient
 
+from services.asr import app as asr_app
 from services.asr.app import app
 
 client = TestClient(app)
 SAMPLE_WAV = Path(__file__).with_name("sample.wav")
+
+
+def test_model_loader_uses_large_v3_turbo():
+    calls = []
+
+    def load_model(model_name, *, device):
+        calls.append((model_name, device))
+        return object()
+
+    original_loader = asr_app.whisper.load_model
+    asr_app.whisper.load_model = load_model
+    try:
+        asr_app._load_asr_model()
+    finally:
+        asr_app.whisper.load_model = original_loader
+
+    assert calls == [("large-v3-turbo", "cpu")]
 
 
 def test_transcribe_success():
@@ -21,6 +39,18 @@ def test_transcribe_success():
     assert "text" in data
     assert isinstance(data["text"], str)
     assert len(data["text"]) > 0
+
+
+def test_transcribe_debug_response_identifies_large_v3_turbo():
+    with SAMPLE_WAV.open("rb") as f:
+        response = client.post(
+            "/transcribe",
+            files={"file": ("sample.wav", f, "audio/wav")},
+            data={"lang": "de", "debug": "true"},
+        )
+
+    assert response.status_code == 200
+    assert response.json()["debug"]["model"] == "whisper-large-v3-turbo"
 
 
 def test_transcribe_invalid_language():

--- a/services/asr/tests/test_transcribe.py
+++ b/services/asr/tests/test_transcribe.py
@@ -9,19 +9,17 @@ client = TestClient(app)
 SAMPLE_WAV = Path(__file__).with_name("sample.wav")
 
 
-def test_model_loader_uses_large_v3_turbo():
+def test_model_loader_uses_large_v3_turbo(monkeypatch):
     calls = []
 
     def load_model(model_name, *, device):
         calls.append((model_name, device))
         return object()
 
-    original_loader = asr_app.whisper.load_model
-    asr_app.whisper.load_model = load_model
-    try:
-        asr_app._load_asr_model()
-    finally:
-        asr_app.whisper.load_model = original_loader
+    monkeypatch.setattr(asr_app.torch.cuda, "is_available", lambda: False)
+    monkeypatch.setattr(asr_app.whisper, "load_model", load_model)
+
+    asr_app._load_asr_model()
 
     assert calls == [("large-v3-turbo", "cpu")]
 

--- a/tests/test_model_service_coverage.py
+++ b/tests/test_model_service_coverage.py
@@ -107,6 +107,35 @@ async def test_asr_transcription_returns_text_and_removes_temporary_audio(
     assert not os.path.exists(normalized_file.name)
 
 
+def test_asr_model_loader_uses_the_fixed_turbo_model(asr_service, monkeypatch):
+    loaded_model = object()
+    calls = []
+
+    def load_model(model_name, *, device):
+        calls.append((model_name, device))
+        return loaded_model
+
+    monkeypatch.setattr(
+        asr_service, "whisper", SimpleNamespace(load_model=load_model)
+    )
+
+    assert asr_service._load_asr_model() is loaded_model
+    assert calls == [("large-v3-turbo", "cpu")]
+
+
+def test_asr_model_loader_returns_none_when_model_loading_fails(
+    asr_service, monkeypatch
+):
+    def load_model(*_args, **_kwargs):
+        raise RuntimeError("model unavailable")
+
+    monkeypatch.setattr(
+        asr_service, "whisper", SimpleNamespace(load_model=load_model)
+    )
+
+    assert asr_service._load_asr_model() is None
+
+
 @pytest.mark.asyncio
 async def test_translation_returns_scalar_and_list_results_with_request_metadata(
     translation_service, monkeypatch

--- a/tests/test_pipeline_metadata_enhancement.py
+++ b/tests/test_pipeline_metadata_enhancement.py
@@ -26,7 +26,7 @@ class TestPipelineMetadataTransformation:
                     "name": "asr",
                     "input": {"lang": "de"},
                     "output": "Hallo Welt",
-                    "model": "whisper-base",
+                    "model": "whisper-large-v3-turbo",
                     "started_at": "2025-11-05T20:00:55.000Z",
                     "completed_at": "2025-11-05T20:00:57.500Z",
                     "duration_ms": 2500
@@ -74,7 +74,7 @@ class TestPipelineMetadataTransformation:
         asr_step = result["steps"][0]
         assert asr_step["name"] == "asr"
         assert asr_step["output"]["text"] == "Hallo Welt"
-        assert asr_step["output"]["model"] == "whisper-base"
+        assert asr_step["output"]["model"] == "whisper-large-v3-turbo"
         assert asr_step["duration_ms"] == 2500
 
         # Translation step


### PR DESCRIPTION
## Description

Permanently switches the ASR service from Whisper base to Whisper large-v3-turbo to improve recognition quality.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 📝 Documentation update
- [x] ✅ Test update

## Related Issues

Closes #

## Changes Made

- Load `large-v3-turbo` as the fixed ASR model, without an environment-variable override.
- Report `whisper-large-v3-turbo` in ASR debug and pipeline metadata.
- Add regression coverage for the actual Whisper loader selection and debug response.
- Update ASR, architecture, roadmap, README, and OpenSpec documentation.

## Testing

- [x] All existing tests pass (`.venv/bin/python -m pytest`: 954 passed, 62 skipped)
- [x] New tests added for this change
- [x] Manual testing completed

### How to Test

```bash
.venv/bin/python -m pytest
docker compose build asr
docker compose up -d --no-deps asr
curl -F "file=@services/asr/tests/sample.wav;type=audio/wav" -F "lang=de" -F "debug=true" http://127.0.0.1:8001/transcribe
```

Confirm the response reports `debug.model` as `whisper-large-v3-turbo`.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Pre-commit hooks pass
- [x] Tests added/updated for new functionality
- [x] All tests pass locally
- [x] Documentation updated
- [x] No new dependencies added
- [x] No sensitive data exposed

## Performance Impact

- [x] Performance may be impacted

The larger model increases model-download, GPU-memory, and inference-latency requirements; it is selected for improved recognition quality.

## Breaking Changes

None. The ASR model is intentionally fixed in code; switching models now requires a code change.

## Deployment Notes

- [x] Requires service restart

Rebuild and restart the ASR service. The first startup downloads approximately 1.51 GB of model weights.