### PR TITLE
fix: align Studio runtime mock tenant contract

### DIFF
--- a/docs/architecture/sva-studio-control-plane.md
+++ b/docs/architecture/sva-studio-control-plane.md
@@ -129,10 +129,10 @@ The SSF plugin owns one PostgreSQL database per SSF installation. It contains
 both installation-wide and tenant-specific configuration. The Studio Core
 knows no SSF tables or domain fields.
 
-Tenant records use the canonical Studio `tenant_id` as their tenant key;
-`studio_instance_id` identifies only the enclosing Studio deployment.
+Tenant records use the canonical Studio `tenant_id` as their SSF tenant key.
 Tenant access is bound server-side to this context and secured with row-level
-security. Root access follows a separate, explicitly authorised database path.
+security. An `organization_id` is not a tenant identifier or an access-security
+boundary. Root access follows a separate, explicitly authorised database path.
 Migrations, repositories, and schema ownership belong to the SSF plugin.
 
 The database can later contain installation-wide model, integration, and
@@ -148,8 +148,8 @@ references to SSF.
 SSF determines the tenant from a valid session token, Keycloak login, or
 server-resolved guest-join credential. The SSF backend then calls the internal
 Studio API with its own Client-Credentials service identity and an
-`X-Tenant-Id` header. A freely supplied tenant or instance ID is not a trust
-boundary.
+`X-Studio-Tenant-Id` header. The later user-token claim is
+`studio_tenant_id`. A freely supplied tenant ID is not a trust boundary.
 
 The Studio host validates the technical identity, configured audience, validity,
 and `ssf.runtime-configuration.read` permission before invoking the SSF plugin

--- a/docs/architecture/sva-studio-control-plane.md
+++ b/docs/architecture/sva-studio-control-plane.md
@@ -148,7 +148,7 @@ references to SSF.
 SSF determines the tenant from a valid session token, Keycloak login, or
 server-resolved guest-join credential. The SSF backend then calls the internal
 Studio API with its own Client-Credentials service identity and an
-`X-Studio-Tenant-Id` header. The later user-token claim is
+`X-Studio-Tenant-Id` header. The signed user-token claim is
 `studio_tenant_id`. A freely supplied tenant ID is not a trust boundary.
 
 The Studio host validates the technical identity, configured audience, validity,

--- a/docs/operations/keycloak-admin-access.md
+++ b/docs/operations/keycloak-admin-access.md
@@ -35,7 +35,7 @@ Every request requires these headers:
 
 ```text
 Authorization: Bearer studio-mock-authorized-token
-X-Studio-Instance-Id: tenant-kassel
+X-Studio-Tenant-Id: tenant-kassel
 X-Correlation-Id: local-test-correlation-id
 ```
 
@@ -43,8 +43,9 @@ X-Correlation-Id: local-test-correlation-id
 `ssf.runtime-configuration.read`; `Bearer studio-mock-unauthorized-token`
 models an authenticated caller without that permission. `tenant-kassel`
 returns storage mode `ask`; `tenant-fulda` returns `disabled`. Send
-`X-Mock-Scenario: authorization-pending` or `unavailable` to exercise `409`
-or `503`. Send an unknown Studio instance ID to exercise `404`.
+`X-Mock-Scenario: tenant-suspended`, `plugin-inactive`,
+`tenant-not-ready`, or `unavailable` to exercise the documented `409` and
+`503` failures. Send an unknown Studio tenant ID to exercise `404`.
 Every error response has the Studio V1 `contractVersion` and `error` envelope
 documented in the mock's OpenAPI description.
 

--- a/docs/superpowers/specs/2026-08-31-studio-ssf-runtime-configuration-contract-v1-design.md
+++ b/docs/superpowers/specs/2026-08-31-studio-ssf-runtime-configuration-contract-v1-design.md
@@ -1,5 +1,11 @@
 # Studio--SSF Runtime Configuration Contract V1
 
+> **Status: Superseded historical design record.** Preserve this document as a
+> record of its original proposal. The cross-system contract is pending in
+> [sva-studio#1286](https://github.com/smart-village-solutions/sva-studio/issues/1286);
+> the SSF mock work is tracked by the active
+> `openspec/changes/add-studio-runtime-configuration-mock/` change.
+
 ## Status and purpose
 
 This is the implementation-ready revision of the Studio--SSF runtime
@@ -15,11 +21,10 @@ out of scope.
 
 ## Terms and ownership
 
-- `X-Studio-Tenant-Id` identifies one stable Studio tenant and exactly one SSF
-  tenant at the Studio--SSF boundary.
-- `tenant_id` is the SSF-internal key for that tenant. It is not an external
-  alias, and an `organization_id` is neither a tenant ID nor an access-security
-  boundary.
+- `studio_instance_id` identifies a Studio installation. It is contextual
+  metadata and MUST NOT be used as an SSF data-access boundary.
+- `tenant_id` identifies one stable Studio tenant and exactly one SSF tenant.
+  It is the canonical tenant identifier for this contract.
 - Studio Core owns tenant records, tenant lifecycle, Keycloak provisioning,
   user accounts, policies, media, configuration, readiness, and audit.
 - The Studio SSF plugin owns resolution of server-wide, tenant-specific, and
@@ -41,7 +46,8 @@ the following signed claims in addition to standard OIDC claims:
 ```json
 {
   "sub": "keycloak-user-id",
-  "studio_tenant_id": "01J...",
+  "studio_instance_id": "01J...",
+  "tenant_id": "01J...",
   "ssf_roles": ["user"],
   "ssf_permissions": ["ssf.sessions.create"],
   "preferred_username": "erika",
@@ -62,7 +68,7 @@ operational permission catalogue is:
 The token roles are `system_admin`, `tenant_admin`, and `user`. A
 `tenant_admin` has no operational SSF conversation permissions unless it also
 has `user` and the corresponding permissions. A `system_admin` has no
-`studio_tenant_id` and MUST NOT access tenant conversations or tenant data; tenant
+`tenant_id` and MUST NOT access tenant conversations or tenant data; tenant
 configuration and inspection remain Studio responsibilities.
 
 Guests receive neither a Studio account nor a regular Keycloak token. The
@@ -94,14 +100,14 @@ conflicting context MUST fail closed.
 ```http
 GET /internal/plugins/ssf/v1/runtime-configuration
 Authorization: Bearer <service-token>
-X-Studio-Tenant-Id: <canonical-tenant-id>
+X-Tenant-Id: <tenant-id-derived-by-SSF>
 X-Correlation-Id: <correlation-id>
 ```
 
 The endpoint is internal-network only and is callable only by the SSF backend.
 SSF uses a dedicated Keycloak client with Client Credentials. Its token MUST
 carry the configured audience and `ssf.runtime-configuration.read`. It is
-separate from browser and user clients. Studio treats `X-Studio-Tenant-Id` as a
+separate from browser and user clients. Studio treats `X-Tenant-Id` as a
 statement by the authenticated SSF backend. V1 requires neither a second
 tenant assertion, replay storage, nor mTLS.
 
@@ -126,9 +132,9 @@ tenant ID in `tenant.id`.
     "icon": { "url": "https://example.org/icon.png", "alternativeText": "Icon" }
   },
   "localization": {
-    "defaultLocale": "de-DE",
-    "locales": [{
-      "locale": "de-DE",
+    "defaultLanguage": "de-DE",
+    "languages": [{
+      "language": "de-DE",
       "authenticatedHomeExplanationHtml": "<p>...</p>",
       "guestExplanationHtml": "<p>...</p>",
       "conversationContentStorageQuestionHtml": "<p>...</p>"
@@ -140,13 +146,13 @@ tenant ID in `tenant.id`.
 
 `branding.logo` and `branding.icon` MAY each be `null`. If the effective
 storage mode is `disabled`, `conversationContentStorageQuestionHtml` MUST be
-`null` for every locale.
+`null` for every language.
 
 `configurationRevision` is `sha256:` followed by SHA-256 over the RFC 8785
 JSON Canonicalization Scheme representation of the fully resolved configuration
 excluding `configurationRevision` itself.
 
-The effective value of every field and locale is resolved independently:
+The effective value of every field and language is resolved independently:
 
 ```text
 tenant customization
@@ -171,14 +177,14 @@ processing only.
 
 ## Languages, texts, and branding
 
-All external locale values in this contract MUST use BCP-47 language tags,
-including enabled locales, default locale, text variants, session language
-selection, and SSF API data. SSF displays only the enabled locales from
+All external language values in this contract MUST use BCP-47 language tags,
+including enabled languages, default language, text variants, session language
+selection, and SSF API data. SSF displays only the enabled languages from
 Studio. Mapping a BCP-47 value to an ASR, translation, or TTS provider code is
 an SSF-internal implementation detail. V1 does not require server-side denial
 of a pipeline language code that is called outside the UI.
 
-For every enabled locale Studio returns the authenticated-home explanation,
+For every enabled language Studio returns the authenticated-home explanation,
 guest explanation, and, when applicable, conversation-storage question. The
 default language MUST be enabled. At least one language MUST remain enabled.
 Existing tenant overrides MAY remain stored while their language is disabled.
@@ -238,13 +244,10 @@ is outside this integration contract.
 
 Runtime errors use the stable `contractVersion` and `error` envelope with a
 machine-readable `code`, generic `message`, boolean `retryable`, and
-`correlationId`. The only stable codes are `service_authentication_invalid`
-(`401`, not retryable), `service_action_forbidden` (`403`, not retryable),
-`tenant_not_found` (`404`, not retryable), `tenant_suspended` (`409`, not
-retryable), `ssf_plugin_inactive` (`409`, not retryable),
-`ssf_tenant_not_ready` (`409`, retryable), and
-`runtime_configuration_unavailable` (`503`, retryable). Responses MUST NOT
-disclose secrets, internal persistence details, or data of another tenant.
+`correlationId`. `401` and `403` apply to the service client, `404` to an
+unknown tenant, `409` to unavailable tenant states, and `503` to temporary
+runtime-configuration unavailability. Responses MUST NOT disclose secrets,
+internal persistence details, or data of another tenant.
 
 Studio durably audits configuration and policy changes. Normal runtime reads
 produce only technical metrics and structured logs. `X-Correlation-Id` links

--- a/docs/superpowers/specs/2026-08-31-studio-ssf-runtime-configuration-contract-v1-design.md
+++ b/docs/superpowers/specs/2026-08-31-studio-ssf-runtime-configuration-contract-v1-design.md
@@ -15,10 +15,11 @@ out of scope.
 
 ## Terms and ownership
 
-- `studio_instance_id` identifies a Studio installation. It is contextual
-  metadata and MUST NOT be used as an SSF data-access boundary.
-- `tenant_id` identifies one stable Studio tenant and exactly one SSF tenant.
-  It is the canonical tenant identifier for this contract.
+- `X-Studio-Tenant-Id` identifies one stable Studio tenant and exactly one SSF
+  tenant at the Studio--SSF boundary.
+- `tenant_id` is the SSF-internal key for that tenant. It is not an external
+  alias, and an `organization_id` is neither a tenant ID nor an access-security
+  boundary.
 - Studio Core owns tenant records, tenant lifecycle, Keycloak provisioning,
   user accounts, policies, media, configuration, readiness, and audit.
 - The Studio SSF plugin owns resolution of server-wide, tenant-specific, and
@@ -40,8 +41,7 @@ the following signed claims in addition to standard OIDC claims:
 ```json
 {
   "sub": "keycloak-user-id",
-  "studio_instance_id": "01J...",
-  "tenant_id": "01J...",
+  "studio_tenant_id": "01J...",
   "ssf_roles": ["user"],
   "ssf_permissions": ["ssf.sessions.create"],
   "preferred_username": "erika",
@@ -62,7 +62,7 @@ operational permission catalogue is:
 The token roles are `system_admin`, `tenant_admin`, and `user`. A
 `tenant_admin` has no operational SSF conversation permissions unless it also
 has `user` and the corresponding permissions. A `system_admin` has no
-`tenant_id` and MUST NOT access tenant conversations or tenant data; tenant
+`studio_tenant_id` and MUST NOT access tenant conversations or tenant data; tenant
 configuration and inspection remain Studio responsibilities.
 
 Guests receive neither a Studio account nor a regular Keycloak token. The
@@ -94,14 +94,14 @@ conflicting context MUST fail closed.
 ```http
 GET /internal/plugins/ssf/v1/runtime-configuration
 Authorization: Bearer <service-token>
-X-Tenant-Id: <tenant-id-derived-by-SSF>
+X-Studio-Tenant-Id: <canonical-tenant-id>
 X-Correlation-Id: <correlation-id>
 ```
 
 The endpoint is internal-network only and is callable only by the SSF backend.
 SSF uses a dedicated Keycloak client with Client Credentials. Its token MUST
 carry the configured audience and `ssf.runtime-configuration.read`. It is
-separate from browser and user clients. Studio treats `X-Tenant-Id` as a
+separate from browser and user clients. Studio treats `X-Studio-Tenant-Id` as a
 statement by the authenticated SSF backend. V1 requires neither a second
 tenant assertion, replay storage, nor mTLS.
 
@@ -126,9 +126,9 @@ tenant ID in `tenant.id`.
     "icon": { "url": "https://example.org/icon.png", "alternativeText": "Icon" }
   },
   "localization": {
-    "defaultLanguage": "de-DE",
-    "languages": [{
-      "language": "de-DE",
+    "defaultLocale": "de-DE",
+    "locales": [{
+      "locale": "de-DE",
       "authenticatedHomeExplanationHtml": "<p>...</p>",
       "guestExplanationHtml": "<p>...</p>",
       "conversationContentStorageQuestionHtml": "<p>...</p>"
@@ -140,13 +140,13 @@ tenant ID in `tenant.id`.
 
 `branding.logo` and `branding.icon` MAY each be `null`. If the effective
 storage mode is `disabled`, `conversationContentStorageQuestionHtml` MUST be
-`null` for every language.
+`null` for every locale.
 
 `configurationRevision` is `sha256:` followed by SHA-256 over the RFC 8785
 JSON Canonicalization Scheme representation of the fully resolved configuration
 excluding `configurationRevision` itself.
 
-The effective value of every field and language is resolved independently:
+The effective value of every field and locale is resolved independently:
 
 ```text
 tenant customization
@@ -171,14 +171,14 @@ processing only.
 
 ## Languages, texts, and branding
 
-All external language values in this contract MUST use BCP-47 language tags,
-including enabled languages, default language, text variants, session language
-selection, and SSF API data. SSF displays only the enabled languages from
+All external locale values in this contract MUST use BCP-47 language tags,
+including enabled locales, default locale, text variants, session language
+selection, and SSF API data. SSF displays only the enabled locales from
 Studio. Mapping a BCP-47 value to an ASR, translation, or TTS provider code is
 an SSF-internal implementation detail. V1 does not require server-side denial
 of a pipeline language code that is called outside the UI.
 
-For every enabled language Studio returns the authenticated-home explanation,
+For every enabled locale Studio returns the authenticated-home explanation,
 guest explanation, and, when applicable, conversation-storage question. The
 default language MUST be enabled. At least one language MUST remain enabled.
 Existing tenant overrides MAY remain stored while their language is disabled.
@@ -238,10 +238,13 @@ is outside this integration contract.
 
 Runtime errors use the stable `contractVersion` and `error` envelope with a
 machine-readable `code`, generic `message`, boolean `retryable`, and
-`correlationId`. `401` and `403` apply to the service client, `404` to an
-unknown tenant, `409` to unavailable tenant states, and `503` to temporary
-runtime-configuration unavailability. Responses MUST NOT disclose secrets,
-internal persistence details, or data of another tenant.
+`correlationId`. The only stable codes are `service_authentication_invalid`
+(`401`, not retryable), `service_action_forbidden` (`403`, not retryable),
+`tenant_not_found` (`404`, not retryable), `tenant_suspended` (`409`, not
+retryable), `ssf_plugin_inactive` (`409`, not retryable),
+`ssf_tenant_not_ready` (`409`, retryable), and
+`runtime_configuration_unavailable` (`503`, retryable). Responses MUST NOT
+disclose secrets, internal persistence details, or data of another tenant.
 
 Studio durably audits configuration and policy changes. Normal runtime reads
 produce only technical metrics and structured logs. `X-Correlation-Id` links

--- a/docs/superpowers/specs/2026-09-08-studio-runtime-configuration-mock-v1-contract-correction-design.md
+++ b/docs/superpowers/specs/2026-09-08-studio-runtime-configuration-mock-v1-contract-correction-design.md
@@ -1,17 +1,23 @@
 # Studio Runtime Configuration Mock V1 Contract Correction Design
 
+> **Status: Superseded historical design record.** Preserve this document as a
+> record of its original proposal. The cross-system contract is pending in
+> [sva-studio#1286](https://github.com/smart-village-solutions/sva-studio/issues/1286);
+> the SSF mock work is tracked by the active
+> `openspec/changes/add-studio-runtime-configuration-mock/` change.
+
 ## Context
 
 The existing mock was intentionally made browser-accessible over public HTTP.
 Review feedback establishes that this differs from the current Studio--SSF V1
-contract: Studio tenant identity, a service token with an explicit
+contract: Studio instance identity, a service token with an explicit
 permission, and a correlation identifier are required. The response structure
 also needs authorization metadata and locale naming aligned with the contract.
 
 ## Goals
 
 - Exercise the V1 request contract with `Authorization`,
-  `X-Studio-Tenant-Id`, and `X-Correlation-Id`.
+  `X-Studio-Instance-Id`, and `X-Correlation-Id`.
 - Model deterministic authentication, authorization, tenant, authorization
   projection, and dependency failures with the stable V1 error envelope.
 - Return contract-correct locale fields plus deterministic SHA-256
@@ -33,14 +39,13 @@ studio-mock-authorized-token` has `ssf.runtime-configuration.read` and is the
 only token that can receive a configuration. `Bearer
 studio-mock-unauthorized-token` represents an authenticated caller without
 that permission. A missing or unknown token produces `401
-service_authentication_invalid`; the known unauthorized token produces `403
-service_action_forbidden`.
+SERVICE_UNAUTHENTICATED`; the known unauthorized token produces `403
+SERVICE_FORBIDDEN`.
 
-`X-Studio-Tenant-Id` is the sole tenant selector. `X-Correlation-Id` is
-required and echoed in every error envelope. After successful authentication,
-missing or invalid tenant or correlation selection produces `404
-tenant_not_found`, matching the Studio endpoint's stable behavior. Legacy
-tenant and Studio deployment headers are not interpreted.
+`X-Studio-Instance-Id` is the sole tenant selector. `X-Correlation-Id` is
+required and echoed in every error envelope. Missing either required header
+produces a stable `400` envelope. The removed `tenantId` query parameter is
+not interpreted.
 
 ### Response and revisions
 
@@ -49,17 +54,16 @@ Configuration fixtures use `localization.defaultLocale`,
 configuration excluding `configurationRevision` is serialized deterministically
 with sorted keys and compact separators, then SHA-256 hashed. The mock uses
 the same deterministic process for the authorization fixture excluding
-`authorizationRevision`, using `tenant_id` as the SSF-internal key; both values
-are emitted as `sha256:` followed by 64 lowercase hexadecimal characters.
+`authorizationRevision`; both values are emitted as `sha256:` followed by 64
+lowercase hexadecimal characters.
 
 ### Failure simulation
 
-`X-Mock-Scenario: tenant-suspended` returns `409 tenant_suspended`,
-`plugin-inactive` returns `409 ssf_plugin_inactive`, `tenant-not-ready` returns
-`409 ssf_tenant_not_ready` with `retryable: true`, and `unavailable` returns
-`503 runtime_configuration_unavailable` with `retryable: true`. An unknown
-Studio tenant returns `404 tenant_not_found`. These and the authentication and
-authorization failures share the V1 `contractVersion` and `error` envelope.
+`X-Mock-Scenario: authorization-pending` returns `409
+AUTHORIZATION_PROJECTION_PENDING`. `X-Mock-Scenario: unavailable` returns
+`503 RUNTIME_CONFIGURATION_UNAVAILABLE`. An unknown Studio instance returns
+`404 TENANT_NOT_FOUND`. These, authentication, authorization, and missing
+header failures share the V1 `contractVersion` and `error` envelope.
 
 ### Exposure
 

--- a/docs/superpowers/specs/2026-09-08-studio-runtime-configuration-mock-v1-contract-correction-design.md
+++ b/docs/superpowers/specs/2026-09-08-studio-runtime-configuration-mock-v1-contract-correction-design.md
@@ -4,14 +4,14 @@
 
 The existing mock was intentionally made browser-accessible over public HTTP.
 Review feedback establishes that this differs from the current Studio--SSF V1
-contract: Studio instance identity, a service token with an explicit
+contract: Studio tenant identity, a service token with an explicit
 permission, and a correlation identifier are required. The response structure
 also needs authorization metadata and locale naming aligned with the contract.
 
 ## Goals
 
 - Exercise the V1 request contract with `Authorization`,
-  `X-Studio-Instance-Id`, and `X-Correlation-Id`.
+  `X-Studio-Tenant-Id`, and `X-Correlation-Id`.
 - Model deterministic authentication, authorization, tenant, authorization
   projection, and dependency failures with the stable V1 error envelope.
 - Return contract-correct locale fields plus deterministic SHA-256
@@ -33,13 +33,14 @@ studio-mock-authorized-token` has `ssf.runtime-configuration.read` and is the
 only token that can receive a configuration. `Bearer
 studio-mock-unauthorized-token` represents an authenticated caller without
 that permission. A missing or unknown token produces `401
-SERVICE_UNAUTHENTICATED`; the known unauthorized token produces `403
-SERVICE_FORBIDDEN`.
+service_authentication_invalid`; the known unauthorized token produces `403
+service_action_forbidden`.
 
-`X-Studio-Instance-Id` is the sole tenant selector. `X-Correlation-Id` is
-required and echoed in every error envelope. Missing either required header
-produces a stable `400` envelope. The removed `tenantId` query parameter is
-not interpreted.
+`X-Studio-Tenant-Id` is the sole tenant selector. `X-Correlation-Id` is
+required and echoed in every error envelope. After successful authentication,
+missing or invalid tenant or correlation selection produces `404
+tenant_not_found`, matching the Studio endpoint's stable behavior. Legacy
+tenant and Studio deployment headers are not interpreted.
 
 ### Response and revisions
 
@@ -48,16 +49,17 @@ Configuration fixtures use `localization.defaultLocale`,
 configuration excluding `configurationRevision` is serialized deterministically
 with sorted keys and compact separators, then SHA-256 hashed. The mock uses
 the same deterministic process for the authorization fixture excluding
-`authorizationRevision`; both values are emitted as `sha256:` followed by 64
-lowercase hexadecimal characters.
+`authorizationRevision`, using `tenant_id` as the SSF-internal key; both values
+are emitted as `sha256:` followed by 64 lowercase hexadecimal characters.
 
 ### Failure simulation
 
-`X-Mock-Scenario: authorization-pending` returns `409
-AUTHORIZATION_PROJECTION_PENDING`. `X-Mock-Scenario: unavailable` returns
-`503 RUNTIME_CONFIGURATION_UNAVAILABLE`. An unknown Studio instance returns
-`404 TENANT_NOT_FOUND`. These, authentication, authorization, and missing
-header failures share the V1 `contractVersion` and `error` envelope.
+`X-Mock-Scenario: tenant-suspended` returns `409 tenant_suspended`,
+`plugin-inactive` returns `409 ssf_plugin_inactive`, `tenant-not-ready` returns
+`409 ssf_tenant_not_ready` with `retryable: true`, and `unavailable` returns
+`503 runtime_configuration_unavailable` with `retryable: true`. An unknown
+Studio tenant returns `404 tenant_not_found`. These and the authentication and
+authorization failures share the V1 `contractVersion` and `error` envelope.
 
 ### Exposure
 

--- a/openspec/changes/add-studio-runtime-configuration-mock/design.md
+++ b/openspec/changes/add-studio-runtime-configuration-mock/design.md
@@ -10,7 +10,10 @@ adding a shortcut inside SSF.
 - The mock is a standalone FastAPI service at the exact V1 path.
 - It reads no real credentials but models fixed service-token authentication
   and `ssf.runtime-configuration.read` authorization.
-- A request header selects a documented error scenario only in the mock.
+- `X-Studio-Tenant-Id` is the only tenant selector. The mock does not accept
+  legacy tenant or Studio deployment headers.
+- A request header selects one of four documented error scenarios only in the
+  mock.
 - Docker Compose publishes the mock as `http://127.0.0.1:8010` only through
   the explicitly selected `studio-mock` profile. It does not use Traefik or
   TLS because this is an internal test dependency.
@@ -19,7 +22,7 @@ adding a shortcut inside SSF.
 ## Risks and Mitigations
 
 - Contract drift: verify response schemas and error envelopes in tests.
-- Contract drift: validate the mandatory V1 headers, V1 locale names, error
-  envelopes, and canonical revisions in tests.
+- Contract drift: validate the mandatory V1 headers, V1 locale names, the
+  seven stable error envelopes, and canonical revisions in tests.
 - Accidental exposure: isolate the service behind an opt-in profile and bind
   it only to loopback.

--- a/openspec/changes/add-studio-runtime-configuration-mock/proposal.md
+++ b/openspec/changes/add-studio-runtime-configuration-mock/proposal.md
@@ -11,8 +11,8 @@ is available in every developer environment.
 - Add an opt-in FastAPI mock for the Studio Runtime Configuration V1 read API.
 - Serve deterministic configurations for two tenants and the `ask` and
   `disabled` conversation-storage policies.
-- Provide deterministic `400`, `401`, `403`, `404`, `409`, and `503` error
-  envelopes.
+- Provide deterministic V1 error envelopes using only the seven stable
+  lowercase snake_case error codes.
 - Package the mock in a dedicated Docker Compose profile with loopback-only
   HTTP exposure.
 

--- a/openspec/changes/add-studio-runtime-configuration-mock/specs/studio-runtime-configuration-mock/spec.md
+++ b/openspec/changes/add-studio-runtime-configuration-mock/specs/studio-runtime-configuration-mock/spec.md
@@ -9,24 +9,55 @@ Configuration Contract V1 development and tests.
 #### Scenario: Tenant configuration is returned
 
 - **WHEN** a request presents an authorized bearer service token,
-  `X-Studio-Instance-Id`, and `X-Correlation-Id`
+  `X-Studio-Tenant-Id`, and `X-Correlation-Id`
 - **THEN** the service returns a Contract V1 configuration for that tenant
+  whose `tenant.id` exactly equals `X-Studio-Tenant-Id`
 
 #### Scenario: Service token lacks permission
 
 - **WHEN** a request uses the known mock service token without
   `ssf.runtime-configuration.read`
-- **THEN** the service returns a `403` error envelope
+- **THEN** the service returns `403 service_action_forbidden` with
+  `retryable: false`
+
+### Requirement: Stable runtime-configuration errors
+
+The mock SHALL return only the seven Contract V1 stable lowercase snake_case
+error codes with their assigned HTTP status and retryability.
+
+#### Scenario: Authentication and tenant selection fail
+
+- **WHEN** service authentication is invalid
+- **THEN** the service returns `401 service_authentication_invalid` with
+  `retryable: false`
+- **WHEN** the Studio tenant or correlation selection is missing, invalid, or
+  unknown after authentication
+- **THEN** the service returns `404 tenant_not_found` with `retryable: false`
+
+#### Scenario: Tenant and plugin access are blocked
+
+- **WHEN** the selected mock scenario is `tenant-suspended`
+- **THEN** the service returns `409 tenant_suspended` with `retryable: false`
+- **WHEN** the selected mock scenario is `plugin-inactive`
+- **THEN** the service returns `409 ssf_plugin_inactive` with
+  `retryable: false`
+- **WHEN** the selected mock scenario is `tenant-not-ready`
+- **THEN** the service returns `409 ssf_tenant_not_ready` with
+  `retryable: true`
+- **WHEN** the selected mock scenario is `unavailable`
+- **THEN** the service returns `503 runtime_configuration_unavailable` with
+  `retryable: true`
 
 ### Requirement: Deterministic storage-policy and error testing
 
 The mock SHALL provide two tenant configurations with `ask` and `disabled`
 conversation-content storage policies and the documented error envelopes.
 
-#### Scenario: Authorization projection is pending
+#### Scenario: Documented mock scenario has no tenant content
 
-- **WHEN** a request selects the mock authorization-pending scenario
-- **THEN** the service returns a `409` error envelope without tenant content
+- **WHEN** a request selects any documented mock scenario
+- **THEN** the service returns its stable V1 error envelope without tenant
+  content
 
 ### Requirement: Protected internal mock exposure
 

--- a/openspec/changes/add-studio-runtime-configuration-mock/tasks.md
+++ b/openspec/changes/add-studio-runtime-configuration-mock/tasks.md
@@ -17,3 +17,12 @@
   token authorization.
 - [x] 3.2 Align authorization and locale response fields with Contract V1.
 - [x] 3.3 Restore loopback-only operation and document the swappable endpoint.
+
+## 4. Studio tenant naming correction
+
+- [x] 4.1 Replace the mock tenant selector with `X-Studio-Tenant-Id` and use
+  `tenant_id` for the mock's SSF-internal revision input.
+- [x] 4.2 Remove legacy headers, uppercase error codes, and the
+  `authorization-pending` scenario; model the four explicit scenarios.
+- [x] 4.3 Update the OpenAPI, operational runbook, architecture documentation,
+  and contract tests for the V1 Studio tenant boundary.

--- a/services/studio_mock/app.py
+++ b/services/studio_mock/app.py
@@ -3,7 +3,7 @@
 import hashlib
 import json
 from copy import deepcopy
-from typing import Any
+from typing import Any, Literal
 
 from fastapi import FastAPI, Header
 from fastapi.openapi.utils import get_openapi
@@ -17,11 +17,21 @@ _AUTHORIZED_TOKEN = "Bearer studio-mock-authorized-token"
 _UNAUTHORIZED_TOKEN = "Bearer studio-mock-unauthorized-token"
 _UNAVAILABLE_MESSAGE = "The requested tenant is unavailable."
 
+RuntimeErrorCode = Literal[
+    "service_authentication_invalid",
+    "service_action_forbidden",
+    "tenant_not_found",
+    "tenant_suspended",
+    "ssf_plugin_inactive",
+    "ssf_tenant_not_ready",
+    "runtime_configuration_unavailable",
+]
+
 
 class RuntimeError(BaseModel):
     """The nested error object defined by the Studio V1 contract."""
 
-    code: str
+    code: RuntimeErrorCode
     message: str
     retryable: bool
     correlation_id: str | None = Field(alias="correlationId")
@@ -111,29 +121,28 @@ class RuntimeConfigurationResponse(BaseModel):
 
 
 _ERROR_RESPONSES = {
-    400: {
-        "model": RuntimeErrorEnvelope,
-        "description": "A required header is missing.",
-    },
     401: {
         "model": RuntimeErrorEnvelope,
-        "description": "Service authentication failed.",
+        "description": "service_authentication_invalid; retryable: false.",
     },
     403: {
         "model": RuntimeErrorEnvelope,
-        "description": "Service permission is missing.",
+        "description": "service_action_forbidden; retryable: false.",
     },
     404: {
         "model": RuntimeErrorEnvelope,
-        "description": "The Studio instance does not exist.",
+        "description": "tenant_not_found; retryable: false.",
     },
     409: {
         "model": RuntimeErrorEnvelope,
-        "description": "Authorization projection is pending.",
+        "description": (
+            "tenant_suspended or ssf_plugin_inactive (retryable: false); "
+            "ssf_tenant_not_ready (retryable: true)."
+        ),
     },
     503: {
         "model": RuntimeErrorEnvelope,
-        "description": "Runtime configuration is unavailable.",
+        "description": "runtime_configuration_unavailable; retryable: true.",
     },
 }
 
@@ -191,11 +200,11 @@ def _revision(payload: dict[str, Any]) -> str:
     return f"sha256:{hashlib.sha256(canonical_json).hexdigest()}"
 
 
-def _configuration_for(studio_instance_id: str) -> dict[str, Any]:
+def _configuration_for(tenant_id: str) -> dict[str, Any]:
     """Return the effective configuration and its two deterministic revisions."""
-    configuration = deepcopy(_TENANT_CONFIGURATION_TEMPLATES[studio_instance_id])
+    configuration = deepcopy(_TENANT_CONFIGURATION_TEMPLATES[tenant_id])
     authorization = {
-        "studioInstanceId": studio_instance_id,
+        "tenant_id": tenant_id,
         "permissions": ["ssf.runtime-configuration.read"],
     }
     configuration["authorizationRevision"] = _revision(authorization)
@@ -232,32 +241,34 @@ def _error_response(
 )
 def runtime_configuration(
     authorization: str | None = Header(default=None),
-    x_studio_instance_id: str | None = Header(default=None),
+    x_studio_tenant_id: str | None = Header(default=None),
     x_correlation_id: str | None = Header(default=None),
     x_mock_scenario: str | None = Header(default=None),
 ) -> dict[str, Any] | JSONResponse:
     """Return deterministic V1 data for authorized Studio service callers."""
     if authorization not in {_AUTHORIZED_TOKEN, _UNAUTHORIZED_TOKEN}:
-        return _error_response(401, "SERVICE_UNAUTHENTICATED", x_correlation_id, False)
+        return _error_response(
+            401, "service_authentication_invalid", x_correlation_id, False
+        )
     if authorization == _UNAUTHORIZED_TOKEN:
-        return _error_response(403, "SERVICE_FORBIDDEN", x_correlation_id, False)
-    if x_studio_instance_id is None:
+        return _error_response(403, "service_action_forbidden", x_correlation_id, False)
+    if not x_studio_tenant_id or not x_correlation_id:
         return _error_response(
-            400, "STUDIO_INSTANCE_ID_REQUIRED", x_correlation_id, False
+            404, "tenant_not_found", x_correlation_id or "unavailable", False
         )
-    if x_correlation_id is None:
-        return _error_response(400, "CORRELATION_ID_REQUIRED", None, False)
-    if x_mock_scenario == "authorization-pending":
-        return _error_response(
-            409, "AUTHORIZATION_PROJECTION_PENDING", x_correlation_id, True
-        )
+    if x_mock_scenario == "tenant-suspended":
+        return _error_response(409, "tenant_suspended", x_correlation_id, False)
+    if x_mock_scenario == "plugin-inactive":
+        return _error_response(409, "ssf_plugin_inactive", x_correlation_id, False)
+    if x_mock_scenario == "tenant-not-ready":
+        return _error_response(409, "ssf_tenant_not_ready", x_correlation_id, True)
     if x_mock_scenario == "unavailable":
         return _error_response(
-            503, "RUNTIME_CONFIGURATION_UNAVAILABLE", x_correlation_id, True
+            503, "runtime_configuration_unavailable", x_correlation_id, True
         )
-    if x_studio_instance_id not in _TENANT_CONFIGURATION_TEMPLATES:
-        return _error_response(404, "TENANT_NOT_FOUND", x_correlation_id, False)
-    return _configuration_for(x_studio_instance_id)
+    if x_studio_tenant_id not in _TENANT_CONFIGURATION_TEMPLATES:
+        return _error_response(404, "tenant_not_found", x_correlation_id, False)
+    return _configuration_for(x_studio_tenant_id)
 
 
 def _custom_openapi() -> dict[str, Any]:
@@ -271,11 +282,21 @@ def _custom_openapi() -> dict[str, Any]:
     for parameter in parameters:
         if parameter["in"] == "header" and parameter["name"] in {
             "authorization",
-            "x-studio-instance-id",
+            "x-studio-tenant-id",
             "x-correlation-id",
         }:
             parameter["required"] = True
             parameter["schema"] = {"type": "string"}
+        elif parameter["in"] == "header" and parameter["name"] == "x-mock-scenario":
+            parameter["schema"] = {
+                "type": "string",
+                "enum": [
+                    "tenant-suspended",
+                    "plugin-inactive",
+                    "tenant-not-ready",
+                    "unavailable",
+                ],
+            }
     app.openapi_schema = schema
     return app.openapi_schema
 

--- a/tests/test_studio_runtime_configuration_mock.py
+++ b/tests/test_studio_runtime_configuration_mock.py
@@ -4,6 +4,7 @@ import hashlib
 import json
 import re
 
+import pytest
 from fastapi.testclient import TestClient
 
 from services.studio_mock.app import app
@@ -14,141 +15,168 @@ AUTHORIZED_TOKEN = "Bearer studio-mock-authorized-token"
 UNAUTHORIZED_TOKEN = "Bearer studio-mock-unauthorized-token"
 
 
-def _headers(
-    studio_instance_id: str = "tenant-kassel", **additional: str
-) -> dict[str, str]:
+def _headers(tenant_id: str = "tenant-kassel", **additional: str) -> dict[str, str]:
     return {
         "Authorization": AUTHORIZED_TOKEN,
-        "X-Studio-Instance-Id": studio_instance_id,
+        "X-Studio-Tenant-Id": tenant_id,
         "X-Correlation-Id": "test-correlation-id",
         **additional,
     }
 
 
-def test_returns_v1_configuration_for_authorized_studio_instance() -> None:
+def test_returns_v1_configuration_for_authorized_studio_tenant() -> None:
     response = CLIENT.get(PATH, headers=_headers())
 
     assert response.status_code == 200
     payload = response.json()
-    assert payload == {
-        "contractVersion": "1.0",
-        "configurationRevision": payload["configurationRevision"],
-        "authorizationRevision": payload["authorizationRevision"],
-        "tenant": {
-            "id": "tenant-kassel",
-            "displayName": "Kassel Test Municipality",
-            "timeZone": "Europe/Berlin",
-        },
-        "branding": {"logo": None, "icon": None},
-        "localization": {
-            "defaultLocale": "de-DE",
-            "locales": [
-                {
-                    "locale": "de-DE",
-                    "authenticatedHomeExplanationHtml": "<p>Test environment</p>",
-                    "guestExplanationHtml": "<p>Guest test environment</p>",
-                    "conversationContentStorageQuestionHtml": "<p>Store this conversation?</p>",
-                }
-            ],
-        },
-        "conversationContentStorage": {"mode": "ask"},
-    }
-    configuration_revision = payload.pop("configurationRevision")
-    authorization_revision = payload["authorizationRevision"]
-    assert re.fullmatch(r"sha256:[0-9a-f]{64}", configuration_revision)
-    assert re.fullmatch(r"sha256:[0-9a-f]{64}", authorization_revision)
-    expected_configuration_revision = hashlib.sha256(
-        json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode()
-    ).hexdigest()
-    assert configuration_revision == f"sha256:{expected_configuration_revision}"
+    assert payload["tenant"]["id"] == "tenant-kassel"
+    assert payload["localization"]["defaultLocale"] == "de-DE"
+    assert payload["localization"]["locales"][0]["locale"] == "de-DE"
+    assert payload["conversationContentStorage"] == {"mode": "ask"}
 
 
-def test_returns_disabled_policy_for_second_studio_instance() -> None:
-    response = CLIENT.get(PATH, headers=_headers("tenant-fulda"))
+def test_response_tenant_identity_exactly_matches_studio_tenant_header() -> None:
+    tenant_id = "tenant-fulda"
+
+    response = CLIENT.get(PATH, headers=_headers(tenant_id))
 
     assert response.status_code == 200
-    payload = response.json()
-    assert payload["tenant"]["id"] == "tenant-fulda"
-    assert payload["conversationContentStorage"] == {"mode": "disabled"}
-    assert payload["localization"]["locales"][0]["conversationContentStorageQuestionHtml"] is None
+    assert response.json()["tenant"]["id"] == tenant_id
+    assert response.json()["conversationContentStorage"] == {"mode": "disabled"}
 
 
-def test_rejects_missing_or_unknown_service_token() -> None:
-    missing_token = CLIENT.get(PATH, headers={"X-Correlation-Id": "test-correlation-id"})
-    unknown_token = CLIENT.get(PATH, headers=_headers(Authorization="Bearer unknown"))
-
-    for response in (missing_token, unknown_token):
-        assert response.status_code == 401
-        assert response.json()["error"]["code"] == "SERVICE_UNAUTHENTICATED"
-
-
-def test_rejects_service_token_without_runtime_configuration_permission() -> None:
-    response = CLIENT.get(PATH, headers=_headers(Authorization=UNAUTHORIZED_TOKEN))
-
-    assert response.status_code == 403
-    assert response.json()["error"]["code"] == "SERVICE_FORBIDDEN"
-
-
-def test_requires_studio_instance_and_correlation_headers() -> None:
-    missing_instance = CLIENT.get(
+@pytest.mark.parametrize("legacy_header", ["X-Studio-Instance-Id", "X-Tenant-Id"])
+def test_rejects_legacy_tenant_headers_without_the_canonical_header(
+    legacy_header: str,
+) -> None:
+    response = CLIENT.get(
         PATH,
-        headers={"Authorization": AUTHORIZED_TOKEN, "X-Correlation-Id": "test-correlation-id"},
+        headers={
+            "Authorization": AUTHORIZED_TOKEN,
+            legacy_header: "tenant-kassel",
+            "X-Correlation-Id": "test-correlation-id",
+        },
     )
-    missing_correlation = CLIENT.get(
-        PATH,
-        headers={"Authorization": AUTHORIZED_TOKEN, "X-Studio-Instance-Id": "tenant-kassel"},
-    )
-
-    assert missing_instance.status_code == 400
-    assert missing_instance.json()["error"]["code"] == "STUDIO_INSTANCE_ID_REQUIRED"
-    assert missing_correlation.status_code == 400
-    assert missing_correlation.json()["error"]["code"] == "CORRELATION_ID_REQUIRED"
-
-
-def test_does_not_use_browser_tenant_query_parameter_for_identity() -> None:
-    response = CLIENT.get(PATH, params={"tenantId": "tenant-kassel"})
-
-    assert response.status_code == 401
-    assert response.json()["error"]["code"] == "SERVICE_UNAUTHENTICATED"
-
-
-def test_returns_not_found_for_unknown_studio_instance() -> None:
-    response = CLIENT.get(PATH, headers=_headers("tenant-unknown"))
 
     assert response.status_code == 404
-    assert response.json()["error"]["code"] == "TENANT_NOT_FOUND"
+    assert response.json()["error"] == {
+        "code": "tenant_not_found",
+        "message": "The requested tenant is unavailable.",
+        "retryable": False,
+        "correlationId": "test-correlation-id",
+    }
 
 
-def test_returns_documented_mock_failure_envelopes() -> None:
-    for scenario, status_code, code, retryable in [
-        ("authorization-pending", 409, "AUTHORIZATION_PROJECTION_PENDING", True),
-        ("unavailable", 503, "RUNTIME_CONFIGURATION_UNAVAILABLE", True),
-    ]:
-        response = CLIENT.get(PATH, headers=_headers(**{"X-Mock-Scenario": scenario}))
+@pytest.mark.parametrize(
+    ("headers", "status_code", "code", "retryable"),
+    [
+        ({"X-Correlation-Id": "test-correlation-id"}, 401, "service_authentication_invalid", False),
+        (
+            {"Authorization": UNAUTHORIZED_TOKEN, "X-Correlation-Id": "test-correlation-id"},
+            403,
+            "service_action_forbidden",
+            False,
+        ),
+        (_headers("tenant-unknown"), 404, "tenant_not_found", False),
+        (
+            _headers(**{"X-Mock-Scenario": "tenant-suspended"}),
+            409,
+            "tenant_suspended",
+            False,
+        ),
+        (
+            _headers(**{"X-Mock-Scenario": "plugin-inactive"}),
+            409,
+            "ssf_plugin_inactive",
+            False,
+        ),
+        (
+            _headers(**{"X-Mock-Scenario": "tenant-not-ready"}),
+            409,
+            "ssf_tenant_not_ready",
+            True,
+        ),
+        (
+            _headers(**{"X-Mock-Scenario": "unavailable"}),
+            503,
+            "runtime_configuration_unavailable",
+            True,
+        ),
+    ],
+)
+def test_returns_only_documented_stable_error_codes(
+    headers: dict[str, str], status_code: int, code: str, retryable: bool
+) -> None:
+    response = CLIENT.get(PATH, headers=headers)
 
-        assert response.status_code == status_code
-        assert response.json() == {
-            "contractVersion": "1.0",
-            "error": {
-                "code": code,
-                "message": "The requested tenant is unavailable.",
-                "retryable": retryable,
-                "correlationId": "test-correlation-id",
-            },
-        }
+    assert response.status_code == status_code
+    assert response.json() == {
+        "contractVersion": "1.0",
+        "error": {
+            "code": code,
+            "message": "The requested tenant is unavailable.",
+            "retryable": retryable,
+            "correlationId": "test-correlation-id",
+        },
+    }
 
 
-def test_openapi_documents_every_runtime_configuration_error() -> None:
-    responses = CLIENT.get("/openapi.json").json()["paths"][PATH]["get"]["responses"]
+@pytest.mark.parametrize(
+    "scenario", ["tenant-suspended", "plugin-inactive", "tenant-not-ready", "unavailable"]
+)
+def test_each_documented_mock_scenario_is_selectable(scenario: str) -> None:
+    response = CLIENT.get(PATH, headers=_headers(**{"X-Mock-Scenario": scenario}))
 
-    for status_code in ("400", "401", "403", "404", "409", "503"):
-        assert responses[status_code]["description"]
-        assert responses[status_code]["content"]["application/json"]["schema"]["$ref"].endswith(
-            "RuntimeErrorEnvelope"
-        )
+    assert response.status_code in {409, 503}
 
 
-def test_openapi_documents_required_v1_headers_and_success_contract() -> None:
+def test_authorization_pending_is_not_a_mock_scenario_alias() -> None:
+    response = CLIENT.get(
+        PATH, headers=_headers(**{"X-Mock-Scenario": "authorization-pending"})
+    )
+
+    assert response.status_code == 200
+
+
+def test_missing_or_invalid_required_selection_headers_use_tenant_not_found() -> None:
+    missing_correlation = CLIENT.get(
+        PATH,
+        headers={"Authorization": AUTHORIZED_TOKEN, "X-Studio-Tenant-Id": "tenant-kassel"},
+    )
+    empty_tenant = CLIENT.get(PATH, headers=_headers(""))
+
+    for response in (missing_correlation, empty_tenant):
+        assert response.status_code == 404
+        assert response.json()["error"]["code"] == "tenant_not_found"
+
+
+def test_revisions_are_deterministic_and_canonically_hashed() -> None:
+    first_payload = CLIENT.get(PATH, headers=_headers()).json()
+    second_payload = CLIENT.get(PATH, headers=_headers()).json()
+
+    assert first_payload["configurationRevision"] == second_payload["configurationRevision"]
+    assert first_payload["authorizationRevision"] == second_payload["authorizationRevision"]
+    assert re.fullmatch(r"sha256:[0-9a-f]{64}", first_payload["configurationRevision"])
+    assert re.fullmatch(r"sha256:[0-9a-f]{64}", first_payload["authorizationRevision"])
+
+    authorization = {
+        "tenant_id": "tenant-kassel",
+        "permissions": ["ssf.runtime-configuration.read"],
+    }
+    expected_authorization_revision = hashlib.sha256(
+        json.dumps(authorization, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode()
+    ).hexdigest()
+    assert first_payload["authorizationRevision"] == f"sha256:{expected_authorization_revision}"
+
+    configuration = dict(first_payload)
+    configuration.pop("configurationRevision")
+    expected_configuration_revision = hashlib.sha256(
+        json.dumps(configuration, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode()
+    ).hexdigest()
+    assert first_payload["configurationRevision"] == f"sha256:{expected_configuration_revision}"
+
+
+def test_openapi_documents_only_the_canonical_tenant_header_and_v1_contract() -> None:
     schema = CLIENT.get("/openapi.json").json()
     operation = schema["paths"][PATH]["get"]
     headers = {
@@ -157,28 +185,33 @@ def test_openapi_documents_required_v1_headers_and_success_contract() -> None:
         if parameter["in"] == "header"
     }
 
-    for header_name in (
-        "authorization",
-        "x-studio-instance-id",
-        "x-correlation-id",
-    ):
+    assert set(headers) == {"authorization", "x-studio-tenant-id", "x-correlation-id", "x-mock-scenario"}
+    for header_name in ("authorization", "x-studio-tenant-id", "x-correlation-id"):
         assert headers[header_name]["required"] is True
         assert headers[header_name]["schema"] == {"type": "string"}
+    assert headers["x-mock-scenario"]["required"] is False
+    assert set(headers["x-mock-scenario"]["schema"]["enum"]) == {
+        "tenant-suspended",
+        "plugin-inactive",
+        "tenant-not-ready",
+        "unavailable",
+    }
+    assert "x-studio-instance-id" not in headers
+    assert "x-tenant-id" not in headers
 
-    success_schema = operation["responses"]["200"]["content"]["application/json"][
-        "schema"
+    error_code_schema = schema["components"]["schemas"]["RuntimeError"]["properties"][
+        "code"
     ]
-    assert success_schema["$ref"].endswith("RuntimeConfigurationResponse")
-    response_definition = schema["components"]["schemas"]["RuntimeConfigurationResponse"]
-    assert {"configurationRevision", "authorizationRevision", "localization"} <= set(
-        response_definition["properties"]
-    )
-    branding_definition = schema["components"]["schemas"]["BrandingResponse"]
-    logo_schema = branding_definition["properties"]["logo"]
-    assert {
-        item["$ref"]
-        for item in logo_schema["anyOf"]
-        if "$ref" in item
-    } == {"#/components/schemas/BrandingAssetResponse"}
-    asset_definition = schema["components"]["schemas"]["BrandingAssetResponse"]
-    assert {"url", "alternativeText"} <= set(asset_definition["properties"])
+    assert set(error_code_schema["enum"]) == {
+        "service_authentication_invalid",
+        "service_action_forbidden",
+        "tenant_not_found",
+        "tenant_suspended",
+        "ssf_plugin_inactive",
+        "ssf_tenant_not_ready",
+        "runtime_configuration_unavailable",
+    }
+
+    responses = operation["responses"]
+    assert set(responses) >= {"200", "401", "403", "404", "409", "503"}
+    assert "400" not in responses

--- a/tests/test_studio_runtime_configuration_mock_compose.py
+++ b/tests/test_studio_runtime_configuration_mock_compose.py
@@ -26,3 +26,10 @@ def test_runbook_documents_protected_swappable_mock_endpoint() -> None:
     assert "http://studio-mock:8000" in runbook
     assert "studio-mock-authorized-token" in runbook
     assert "STUDIO_RUNTIME_CONFIGURATION_BASE_URL" in runbook
+    assert "X-Studio-Tenant-Id: tenant-kassel" in runbook
+    assert "tenant-suspended" in runbook
+    assert "plugin-inactive" in runbook
+    assert "tenant-not-ready" in runbook
+    assert "authorization-pending" not in runbook
+    assert "X-Studio-Instance-Id" not in runbook
+    assert "X-Tenant-Id" not in runbook


### PR DESCRIPTION
## Summary
- align the Studio runtime-configuration mock with the V1 `X-Studio-Tenant-Id` boundary
- remove legacy header handling, uppercase error codes, and the authorization-pending scenario
- document stable errors, deterministic revisions, OpenAPI scenario values, and the updated operational contract

Closes #294

Depends on smart-village-solutions/sva-studio#1286.

## Validation
- `pytest tests/test_studio_runtime_configuration_mock.py tests/test_studio_runtime_configuration_mock_compose.py -q`
- `openspec validate add-studio-runtime-configuration-mock --strict`
- `docker compose --profile studio-mock config` (with non-production placeholders for required unrelated infrastructure variables)
- `flake8`, Python compilation, and pre-commit hooks

## Known dependency
The missing-correlation-ID behavior remains pending until `sva-studio#1286` freezes the shared server-generated correlation-ID contract.

## Note
- The full `pytest -q` suite cannot collect two pre-existing Quality Telemetry modules in this environment because `opentelemetry` is not installed.