### PR TITLE
feat: validate signed Studio tenant context

### DIFF
--- a/docs/superpowers/specs/2026-08-31-studio-ssf-runtime-configuration-contract-v1-design.md
+++ b/docs/superpowers/specs/2026-08-31-studio-ssf-runtime-configuration-contract-v1-design.md
@@ -40,8 +40,7 @@ the following signed claims in addition to standard OIDC claims:
 ```json
 {
   "sub": "keycloak-user-id",
-  "studio_instance_id": "01J...",
-  "tenant_id": "01J...",
+  "studio_tenant_id": "01J...",
   "ssf_roles": ["user"],
   "ssf_permissions": ["ssf.sessions.create"],
   "preferred_username": "erika",
@@ -59,7 +58,9 @@ operational permission catalogue is:
 - `ssf.sessions.terminate`
 - `ssf.conversations.participate`
 
-The token roles are `system_admin`, `tenant_admin`, and `user`. A
+`studio_tenant_id` is the only accepted tenant claim. SSF maps it to its
+internal `tenant_id`; legacy `tenant_id` and `studio_instance_id` claim aliases
+are rejected. The token roles are `system_admin`, `tenant_admin`, and `user`. A
 `tenant_admin` has no operational SSF conversation permissions unless it also
 has `user` and the corresponding permissions. A `system_admin` has no
 `tenant_id` and MUST NOT access tenant conversations or tenant data; tenant
@@ -72,9 +73,11 @@ separate SSF change.
 
 ## Tenant context and guest sessions
 
-SSF MUST derive `tenant_id` from a validated user token for every authenticated
-tenant operation. When a user creates a session, SSF MUST bind that tenant ID
-to the session permanently.
+SSF MUST derive its internal `tenant_id` from the signed `studio_tenant_id`
+claim of a validated user token for every authenticated tenant operation. A
+tenant selector in a query parameter, request body, header, cookie, or other
+browser state MUST be rejected. When a user creates a session, SSF MUST bind
+the derived tenant ID to the session permanently.
 
 Guests join without logging in. SSF issues both an eight-character, human-
 usable session code and a high-entropy, session-scoped join token embedded in

--- a/openspec/changes/add-studio-tenant-context/proposal.md
+++ b/openspec/changes/add-studio-tenant-context/proposal.md
@@ -1,0 +1,23 @@
+# Change: Add the signed Studio tenant context
+
+## Why
+
+Tenant-bound SSF operations need one server-side tenant identity derived from
+the already validated Studio-issued user token. Browser-controlled tenant
+selectors must never become an alternative trust boundary.
+
+## What Changes
+
+- Validate the canonical signed `studio_tenant_id` claim.
+- Expose the validated value internally as an immutable `tenant_id` context.
+- Reject missing, malformed, legacy, or conflicting tenant claims.
+- Reject tenant selectors supplied through query parameters, JSON request
+  bodies, headers, or cookies.
+- Add focused positive and negative tests.
+
+## Impact
+
+- Affected specs: `studio-tenant-context`
+- Affected code: API-gateway authentication dependencies
+- Follow-up: #298 wires the context into tenant-bound runtime flows.
+

--- a/openspec/changes/add-studio-tenant-context/specs/studio-tenant-context/spec.md
+++ b/openspec/changes/add-studio-tenant-context/specs/studio-tenant-context/spec.md
@@ -1,0 +1,39 @@
+## ADDED Requirements
+
+### Requirement: Signed Studio tenant context
+
+For tenant-bound authenticated operations, the SSF gateway SHALL create
+exactly one immutable internal `tenant_id` context from the canonical
+`studio_tenant_id` claim of a fully validated Studio-issued user token.
+
+#### Scenario: Canonical tenant claim is valid
+
+- **WHEN** a validated user token contains one well-formed `studio_tenant_id`
+- **THEN** the gateway creates a tenant context with the same value as its
+  internal `tenant_id`
+
+#### Scenario: Canonical tenant claim is absent or malformed
+
+- **WHEN** a validated user token has no `studio_tenant_id` or its value is not
+  a supported tenant identifier
+- **THEN** the gateway rejects the tenant-bound operation
+
+#### Scenario: Legacy or conflicting tenant claim is present
+
+- **WHEN** a validated user token contains a legacy tenant-claim alias, with or
+  without the canonical claim
+- **THEN** the gateway rejects the tenant-bound operation
+
+### Requirement: Browser tenant selectors are rejected
+
+The SSF gateway SHALL reject tenant selectors supplied by a browser through
+query parameters, JSON request bodies, request headers, or cookies on an
+operation that derives a signed Studio tenant context.
+
+#### Scenario: Request includes a browser-controlled tenant selector
+
+- **WHEN** an authenticated request includes a tenant selector outside the
+  validated token
+- **THEN** the gateway rejects the request
+- **AND THEN** it does not replace the signed tenant context
+

--- a/openspec/changes/add-studio-tenant-context/tasks.md
+++ b/openspec/changes/add-studio-tenant-context/tasks.md
@@ -1,0 +1,8 @@
+## 1. Implementation
+
+- [x] 1.1 Add an immutable internal tenant-context model.
+- [x] 1.2 Derive the context only from the canonical signed claim.
+- [x] 1.3 Reject browser-controlled tenant selectors.
+- [x] 1.4 Add focused positive and negative tests.
+- [x] 1.5 Align the current Studio--SSF identity contract documentation.
+- [x] 1.6 Validate the OpenSpec change and targeted gateway scope.

--- a/services/api_gateway/tenant_context.py
+++ b/services/api_gateway/tenant_context.py
@@ -1,0 +1,85 @@
+"""Trusted Studio tenant context for tenant-bound gateway operations."""
+
+import json
+import re
+from dataclasses import dataclass
+from typing import Annotated, Any, Mapping
+
+from fastapi import Depends, HTTPException, Request, status
+
+from .auth import require_ssf_user
+
+_TENANT_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+_LEGACY_CLAIM_NAMES = frozenset({"tenant_id", "studio_instance_id"})
+_SELECTOR_NAMES = frozenset(
+    {
+        "instanceId",
+        "studio_instance_id",
+        "studio_tenant_id",
+        "studioTenantId",
+        "tenant_id",
+        "tenantId",
+    }
+)
+_SELECTOR_HEADER_NAMES = frozenset({"x-studio-instance-id", "x-studio-tenant-id", "x-tenant-id"})
+
+
+@dataclass(frozen=True)
+class StudioTenantContext:
+    """One trusted tenant identity represented with SSF terminology."""
+
+    tenant_id: str
+
+
+def studio_tenant_context_from_claims(
+    claims: Mapping[str, Any],
+) -> StudioTenantContext:
+    """Build a tenant context from validated claims or fail closed."""
+    if _LEGACY_CLAIM_NAMES.intersection(claims):
+        raise _invalid_tenant_claim()
+
+    tenant_id = claims.get("studio_tenant_id")
+    if not isinstance(tenant_id, str) or not _TENANT_ID_PATTERN.fullmatch(tenant_id):
+        raise _invalid_tenant_claim()
+
+    return StudioTenantContext(tenant_id=tenant_id)
+
+
+async def require_studio_tenant_context(
+    request: Request,
+    claims: Annotated[dict[str, Any], Depends(require_ssf_user)],
+) -> StudioTenantContext:
+    """Derive the tenant from signed claims and reject request-side selectors."""
+    if _request_has_tenant_selector(request, await _json_body(request)):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Tenant selectors are not accepted outside the bearer token",
+        )
+    return studio_tenant_context_from_claims(claims)
+
+
+def _request_has_tenant_selector(request: Request, body: object) -> bool:
+    if _SELECTOR_NAMES.intersection(request.query_params.keys()):
+        return True
+    if _SELECTOR_NAMES.intersection(request.cookies.keys()):
+        return True
+    if _SELECTOR_HEADER_NAMES.intersection(name.lower() for name in request.headers.keys()):
+        return True
+    return isinstance(body, dict) and bool(_SELECTOR_NAMES.intersection(body.keys()))
+
+
+async def _json_body(request: Request) -> object:
+    if request.headers.get("content-type", "").partition(";")[0].strip() != "application/json":
+        return None
+    try:
+        return json.loads(await request.body())
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return None
+
+
+def _invalid_tenant_claim() -> HTTPException:
+    return HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="A single valid studio_tenant_id claim is required",
+        headers={"WWW-Authenticate": "Bearer"},
+    )

--- a/services/api_gateway/tenant_context.py
+++ b/services/api_gateway/tenant_context.py
@@ -2,6 +2,7 @@
 
 import json
 import re
+from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import Annotated, Any, Mapping
 
@@ -13,12 +14,12 @@ _TENANT_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
 _LEGACY_CLAIM_NAMES = frozenset({"tenant_id", "studio_instance_id"})
 _SELECTOR_NAMES = frozenset(
     {
-        "instanceId",
         "studio_instance_id",
         "studio_tenant_id",
-        "studioTenantId",
+        "studiotenantid",
         "tenant_id",
-        "tenantId",
+        "tenantid",
+        "instanceid",
     }
 )
 _SELECTOR_HEADER_NAMES = frozenset({"x-studio-instance-id", "x-studio-tenant-id", "x-tenant-id"})
@@ -59,9 +60,9 @@ async def require_studio_tenant_context(
 
 
 def _request_has_tenant_selector(request: Request, body: object) -> bool:
-    if _SELECTOR_NAMES.intersection(request.query_params.keys()):
+    if _has_selector_name(request.query_params.keys()):
         return True
-    if _SELECTOR_NAMES.intersection(request.cookies.keys()):
+    if _has_selector_name(request.cookies.keys()):
         return True
     if _SELECTOR_HEADER_NAMES.intersection(name.lower() for name in request.headers.keys()):
         return True
@@ -69,13 +70,20 @@ def _request_has_tenant_selector(request: Request, body: object) -> bool:
 
 
 def _contains_tenant_selector(value: object) -> bool:
-    if isinstance(value, dict):
-        if _SELECTOR_NAMES.intersection(value.keys()):
-            return True
-        return any(_contains_tenant_selector(item) for item in value.values())
-    if isinstance(value, list):
-        return any(_contains_tenant_selector(item) for item in value)
+    pending = [value]
+    while pending:
+        item = pending.pop()
+        if isinstance(item, dict):
+            if _has_selector_name(item.keys()):
+                return True
+            pending.extend(item.values())
+        elif isinstance(item, list):
+            pending.extend(item)
     return False
+
+
+def _has_selector_name(names: Iterable[object]) -> bool:
+    return any(isinstance(name, str) and name.lower() in _SELECTOR_NAMES for name in names)
 
 
 async def _json_body(request: Request) -> object:
@@ -84,8 +92,11 @@ async def _json_body(request: Request) -> object:
         return None
     try:
         return json.loads(await request.body())
-    except (json.JSONDecodeError, UnicodeDecodeError):
-        return None
+    except (json.JSONDecodeError, RecursionError, UnicodeDecodeError):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="The JSON request body must be valid",
+        ) from None
 
 
 def _invalid_tenant_claim() -> HTTPException:

--- a/services/api_gateway/tenant_context.py
+++ b/services/api_gateway/tenant_context.py
@@ -65,11 +65,22 @@ def _request_has_tenant_selector(request: Request, body: object) -> bool:
         return True
     if _SELECTOR_HEADER_NAMES.intersection(name.lower() for name in request.headers.keys()):
         return True
-    return isinstance(body, dict) and bool(_SELECTOR_NAMES.intersection(body.keys()))
+    return _contains_tenant_selector(body)
+
+
+def _contains_tenant_selector(value: object) -> bool:
+    if isinstance(value, dict):
+        if _SELECTOR_NAMES.intersection(value.keys()):
+            return True
+        return any(_contains_tenant_selector(item) for item in value.values())
+    if isinstance(value, list):
+        return any(_contains_tenant_selector(item) for item in value)
+    return False
 
 
 async def _json_body(request: Request) -> object:
-    if request.headers.get("content-type", "").partition(";")[0].strip() != "application/json":
+    media_type = request.headers.get("content-type", "").partition(";")[0].strip().lower()
+    if media_type != "application/json" and not media_type.endswith("+json"):
         return None
     try:
         return json.loads(await request.body())

--- a/tests/test_tenant_context.py
+++ b/tests/test_tenant_context.py
@@ -67,6 +67,11 @@ def test_dependency_uses_only_the_validated_claim() -> None:
     [
         {"params": {"tenantId": "tenant-berlin"}},
         {"json": {"tenant_id": "tenant-berlin"}},
+        {"json": {"payload": [{"tenant_id": "tenant-berlin"}]}},
+        {
+            "content": '{"payload":{"tenant_id":"tenant-berlin"}}',
+            "headers": {"Content-Type": "application/vnd.api+json"},
+        },
         {"headers": {"X-Studio-Tenant-Id": "tenant-berlin"}},
         {"cookies": {"studio_tenant_id": "tenant-berlin"}},
     ],
@@ -75,7 +80,7 @@ def test_dependency_rejects_browser_controlled_tenant_selectors(
     request_kwargs: dict[str, Any],
 ) -> None:
     client = _tenant_test_client()
-    method = client.post if "json" in request_kwargs else client.get
+    method = client.post if {"json", "content"}.intersection(request_kwargs) else client.get
 
     response = method("/tenant-operation", **request_kwargs)
 

--- a/tests/test_tenant_context.py
+++ b/tests/test_tenant_context.py
@@ -66,8 +66,10 @@ def test_dependency_uses_only_the_validated_claim() -> None:
     ("request_kwargs"),
     [
         {"params": {"tenantId": "tenant-berlin"}},
+        {"params": {"TENANT_ID": "tenant-berlin"}},
         {"json": {"tenant_id": "tenant-berlin"}},
         {"json": {"payload": [{"tenant_id": "tenant-berlin"}]}},
+        {"json": {"payload": [[{"TenantId": "tenant-berlin"}]]}},
         {
             "content": '{"payload":{"tenant_id":"tenant-berlin"}}',
             "headers": {"Content-Type": "application/vnd.api+json"},

--- a/tests/test_tenant_context.py
+++ b/tests/test_tenant_context.py
@@ -1,0 +1,82 @@
+from typing import Any
+
+import pytest
+from fastapi import Depends, FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+from services.api_gateway.auth import require_ssf_user
+from services.api_gateway.tenant_context import (
+    StudioTenantContext,
+    require_studio_tenant_context,
+    studio_tenant_context_from_claims,
+)
+
+
+def test_canonical_validated_claim_creates_one_internal_tenant_context() -> None:
+    context = studio_tenant_context_from_claims(
+        {"sub": "user-1", "studio_tenant_id": "tenant-kassel"}
+    )
+
+    assert context == StudioTenantContext(tenant_id="tenant-kassel")
+
+
+@pytest.mark.parametrize(
+    "claims",
+    [
+        {},
+        {"studio_tenant_id": ""},
+        {"studio_tenant_id": "tenant kassel"},
+        {"studio_tenant_id": ["tenant-kassel"]},
+        {"tenant_id": "tenant-kassel"},
+        {"studio_instance_id": "tenant-kassel"},
+        {"studio_tenant_id": "tenant-kassel", "tenant_id": "tenant-berlin"},
+    ],
+)
+def test_missing_malformed_or_legacy_claims_fail_closed(claims: dict[str, Any]) -> None:
+    with pytest.raises(HTTPException) as error:
+        studio_tenant_context_from_claims(claims)
+
+    assert error.value.status_code == 401
+
+
+def _tenant_test_client() -> TestClient:
+    app = FastAPI()
+    app.dependency_overrides[require_ssf_user] = lambda: {
+        "sub": "user-1",
+        "studio_tenant_id": "tenant-kassel",
+    }
+
+    @app.api_route("/tenant-operation", methods=["GET", "POST"])
+    async def tenant_operation(
+        context: StudioTenantContext = Depends(require_studio_tenant_context),
+    ) -> dict[str, str]:
+        return {"tenant_id": context.tenant_id}
+
+    return TestClient(app)
+
+
+def test_dependency_uses_only_the_validated_claim() -> None:
+    response = _tenant_test_client().get("/tenant-operation")
+
+    assert response.status_code == 200
+    assert response.json() == {"tenant_id": "tenant-kassel"}
+
+
+@pytest.mark.parametrize(
+    ("request_kwargs"),
+    [
+        {"params": {"tenantId": "tenant-berlin"}},
+        {"json": {"tenant_id": "tenant-berlin"}},
+        {"headers": {"X-Studio-Tenant-Id": "tenant-berlin"}},
+        {"cookies": {"studio_tenant_id": "tenant-berlin"}},
+    ],
+)
+def test_dependency_rejects_browser_controlled_tenant_selectors(
+    request_kwargs: dict[str, Any],
+) -> None:
+    client = _tenant_test_client()
+    method = client.post if "json" in request_kwargs else client.get
+
+    response = method("/tenant-operation", **request_kwargs)
+
+    assert response.status_code == 400


### PR DESCRIPTION
## Summary
- derive one immutable internal `tenant_id` from the canonical validated `studio_tenant_id` claim
- fail closed for missing, malformed, legacy, or conflicting tenant claims
- reject browser-controlled tenant selectors in query parameters, JSON bodies, headers, and cookies
- document and specify the focused tenant-context boundary for the later #298 integration

Closes #295

Depends on smart-village-solutions/sva-studio#1286.

## Validation
- `PYTHONPATH=. pytest tests/test_tenant_context.py tests/test_auth.py -q` (18 passed)
- Black, isort, and flake8 on the changed Python files
- `openspec validate add-studio-tenant-context --strict`

## Scope
This PR deliberately does not call Studio, acquire service tokens, persist tenant data, or wire the context into session/runtime flows. That integration remains in #298.
