### PR TITLE
fix(mock): align Studio runtime tenant contract

### DIFF
--- a/docs/architecture/sva-studio-control-plane.md
+++ b/docs/architecture/sva-studio-control-plane.md
@@ -148,7 +148,9 @@ references to SSF.
 SSF determines the tenant from a valid session token, Keycloak login, or
 server-resolved guest-join credential. The SSF backend then calls the internal
 Studio API with its own Client-Credentials service identity and an
-`X-Tenant-Id` header. A freely supplied tenant or instance ID is not a trust
+`X-Studio-Tenant-Id` header. Studio returns that canonical value unchanged as
+`tenant.id`. Legacy tenant headers and query selectors are rejected without
+compatibility aliases. A freely supplied tenant or instance ID is not a trust
 boundary.
 
 The Studio host validates the technical identity, configured audience, validity,

--- a/docs/operations/keycloak-admin-access.md
+++ b/docs/operations/keycloak-admin-access.md
@@ -35,7 +35,7 @@ Every request requires these headers:
 
 ```text
 Authorization: Bearer studio-mock-authorized-token
-X-Studio-Instance-Id: tenant-kassel
+X-Studio-Tenant-Id: tenant-kassel
 X-Correlation-Id: local-test-correlation-id
 ```
 
@@ -43,8 +43,10 @@ X-Correlation-Id: local-test-correlation-id
 `ssf.runtime-configuration.read`; `Bearer studio-mock-unauthorized-token`
 models an authenticated caller without that permission. `tenant-kassel`
 returns storage mode `ask`; `tenant-fulda` returns `disabled`. Send
-`X-Mock-Scenario: authorization-pending` or `unavailable` to exercise `409`
-or `503`. Send an unknown Studio instance ID to exercise `404`.
+`X-Mock-Scenario: suspended`, `plugin-inactive`, `tenant-not-ready`, or
+`unavailable` to exercise the exact `409` and `503` contract envelopes. Send
+an unknown tenant ID to exercise `404`. Legacy headers (`X-Studio-Instance-Id`
+and `X-Tenant-Id`) and all query selectors are deliberately rejected.
 Every error response has the Studio V1 `contractVersion` and `error` envelope
 documented in the mock's OpenAPI description.
 

--- a/docs/superpowers/plans/2026-09-08-studio-runtime-mock-v1-contract-correction.md
+++ b/docs/superpowers/plans/2026-09-08-studio-runtime-mock-v1-contract-correction.md
@@ -4,7 +4,7 @@
 
 **Goal:** Make the Studio Runtime Configuration mock contract-faithful, protected, and directly swappable with the future Studio endpoint.
 
-**Architecture:** The mock keeps the real V1 path but requires a fixed mock service token, a Studio instance header, and a correlation ID. Compose returns to loopback-only exposure. Consumers address it through a configurable base URL: local SSF containers use `http://studio-mock:8000`; replacing that single base URL with the Studio origin preserves the endpoint path and request/response contract.
+**Architecture:** The mock keeps the real V1 path but requires a fixed mock service token, the canonical Studio tenant header, and a correlation ID. Compose returns to loopback-only exposure. Consumers address it through a configurable base URL: local SSF containers use `http://studio-mock:8000`; replacing that single base URL with the Studio origin preserves the endpoint path and request/response contract.
 
 **Tech Stack:** FastAPI, Pydantic, Docker Compose, pytest, GitHub Issues.
 
@@ -12,7 +12,7 @@
 
 ## Global Constraints
 
-- The mock MUST use `Authorization`, `X-Studio-Instance-Id`, and `X-Correlation-Id`; it MUST NOT use `tenantId` query selection.
+- The mock MUST use `Authorization`, `X-Studio-Tenant-Id`, and `X-Correlation-Id`; it MUST reject legacy headers and every query selector.
 - The mock MUST bind only to `127.0.0.1:8010` when its profile is explicitly enabled.
 - The mock MUST return only fixed, non-sensitive data and no Traefik route.
 - The caller-facing base URL is configurable; never hard-code a mock host in SSF client code.
@@ -27,7 +27,7 @@
 - Modify: `openspec/changes/add-studio-runtime-configuration-mock/`
 
 **Interfaces:**
-- Consumes: `Authorization: Bearer studio-mock-authorized-token`, `X-Studio-Instance-Id`, and `X-Correlation-Id`.
+- Consumes: `Authorization: Bearer studio-mock-authorized-token`, `X-Studio-Tenant-Id`, and `X-Correlation-Id`.
 - Produces: a V1 configuration containing canonical SHA-256 `configurationRevision` and `authorizationRevision`.
 
 - [x] **Step 1: Write failing V1 request-contract tests**
@@ -38,7 +38,7 @@ def test_returns_v1_configuration_for_authorized_studio_instance() -> None:
         PATH,
         headers={
             "Authorization": "Bearer studio-mock-authorized-token",
-            "X-Studio-Instance-Id": "tenant-kassel",
+            "X-Studio-Tenant-Id": "tenant-kassel",
             "X-Correlation-Id": "test-correlation-id",
         },
     )
@@ -110,7 +110,7 @@ Post an English comment containing:
 ```text
 Mock base URL for SSF containers: http://studio-mock:8000
 Path: /internal/plugins/ssf/v1/runtime-configuration
-Required headers: Authorization, X-Studio-Instance-Id, X-Correlation-Id
+Required headers: Authorization, X-Studio-Tenant-Id, X-Correlation-Id
 Authorized test token: Bearer studio-mock-authorized-token
 ```
 

--- a/docs/superpowers/specs/2026-09-08-studio-runtime-configuration-mock-v1-contract-correction-design.md
+++ b/docs/superpowers/specs/2026-09-08-studio-runtime-configuration-mock-v1-contract-correction-design.md
@@ -4,14 +4,14 @@
 
 The existing mock was intentionally made browser-accessible over public HTTP.
 Review feedback establishes that this differs from the current Studio--SSF V1
-contract: Studio instance identity, a service token with an explicit
+contract: canonical tenant identity, a service token with an explicit
 permission, and a correlation identifier are required. The response structure
 also needs authorization metadata and locale naming aligned with the contract.
 
 ## Goals
 
 - Exercise the V1 request contract with `Authorization`,
-  `X-Studio-Instance-Id`, and `X-Correlation-Id`.
+  `X-Studio-Tenant-Id`, and `X-Correlation-Id`.
 - Model deterministic authentication, authorization, tenant, authorization
   projection, and dependency failures with the stable V1 error envelope.
 - Return contract-correct locale fields plus deterministic SHA-256
@@ -33,13 +33,14 @@ studio-mock-authorized-token` has `ssf.runtime-configuration.read` and is the
 only token that can receive a configuration. `Bearer
 studio-mock-unauthorized-token` represents an authenticated caller without
 that permission. A missing or unknown token produces `401
-SERVICE_UNAUTHENTICATED`; the known unauthorized token produces `403
-SERVICE_FORBIDDEN`.
+service_authentication_invalid`; the known unauthorized token produces `403
+service_action_forbidden`.
 
-`X-Studio-Instance-Id` is the sole tenant selector. `X-Correlation-Id` is
-required and echoed in every error envelope. Missing either required header
-produces a stable `400` envelope. The removed `tenantId` query parameter is
-not interpreted.
+`X-Studio-Tenant-Id` is the sole tenant selector and is returned unchanged as
+`tenant.id`. `X-Correlation-Id` is required and echoed in every error envelope.
+Missing or competing selectors produce `404 tenant_not_found` just like the
+Studio endpoint. `X-Studio-Instance-Id`, `X-Tenant-Id`, and all query selectors
+are rejected without compatibility aliases.
 
 ### Response and revisions
 
@@ -53,11 +54,11 @@ lowercase hexadecimal characters.
 
 ### Failure simulation
 
-`X-Mock-Scenario: authorization-pending` returns `409
-AUTHORIZATION_PROJECTION_PENDING`. `X-Mock-Scenario: unavailable` returns
-`503 RUNTIME_CONFIGURATION_UNAVAILABLE`. An unknown Studio instance returns
-`404 TENANT_NOT_FOUND`. These, authentication, authorization, and missing
-header failures share the V1 `contractVersion` and `error` envelope.
+The `suspended`, `plugin-inactive`, and `tenant-not-ready` scenarios return
+the contract's exact `409` codes and retryability. `unavailable` returns
+`503 runtime_configuration_unavailable`. An unknown tenant returns
+`404 tenant_not_found`. These, authentication, authorization, and malformed
+selector failures share the V1 `contractVersion` and `error` envelope.
 
 ### Exposure
 

--- a/docs/superpowers/specs/2026-09-08-studio-runtime-configuration-mock-v1-contract-correction-design.md
+++ b/docs/superpowers/specs/2026-09-08-studio-runtime-configuration-mock-v1-contract-correction-design.md
@@ -37,7 +37,9 @@ service_authentication_invalid`; the known unauthorized token produces `403
 service_action_forbidden`.
 
 `X-Studio-Tenant-Id` is the sole tenant selector and is returned unchanged as
-`tenant.id`. `X-Correlation-Id` is required and echoed in every error envelope.
+`tenant.id`. `X-Correlation-Id` is required and echoed in every error envelope
+when present; malformed requests without it use the Studio-compatible,
+non-empty fallback `unavailable` required by the V1 error schema.
 Missing or competing selectors produce `404 tenant_not_found` just like the
 Studio endpoint. `X-Studio-Instance-Id`, `X-Tenant-Id`, and all query selectors
 are rejected without compatibility aliases.

--- a/openspec/changes/add-studio-runtime-configuration-mock/design.md
+++ b/openspec/changes/add-studio-runtime-configuration-mock/design.md
@@ -11,6 +11,8 @@ adding a shortcut inside SSF.
 - It reads no real credentials but models fixed service-token authentication
   and `ssf.runtime-configuration.read` authorization.
 - A request header selects a documented error scenario only in the mock.
+- `X-Studio-Tenant-Id` is the only accepted tenant selector. Legacy tenant
+  headers and query selectors are rejected without compatibility aliases.
 - Docker Compose publishes the mock as `http://127.0.0.1:8010` only through
   the explicitly selected `studio-mock` profile. It does not use Traefik or
   TLS because this is an internal test dependency.

--- a/openspec/changes/add-studio-runtime-configuration-mock/proposal.md
+++ b/openspec/changes/add-studio-runtime-configuration-mock/proposal.md
@@ -11,8 +11,10 @@ is available in every developer environment.
 - Add an opt-in FastAPI mock for the Studio Runtime Configuration V1 read API.
 - Serve deterministic configurations for two tenants and the `ask` and
   `disabled` conversation-storage policies.
-- Provide deterministic `400`, `401`, `403`, `404`, `409`, and `503` error
+- Provide deterministic `401`, `403`, `404`, `409`, and `503` error
   envelopes.
+- Use `X-Studio-Tenant-Id` as the only tenant selector and reject legacy
+  headers and query selectors without compatibility aliases.
 - Package the mock in a dedicated Docker Compose profile with loopback-only
   HTTP exposure.
 

--- a/openspec/changes/add-studio-runtime-configuration-mock/specs/studio-runtime-configuration-mock/spec.md
+++ b/openspec/changes/add-studio-runtime-configuration-mock/specs/studio-runtime-configuration-mock/spec.md
@@ -9,8 +9,15 @@ Configuration Contract V1 development and tests.
 #### Scenario: Tenant configuration is returned
 
 - **WHEN** a request presents an authorized bearer service token,
-  `X-Studio-Instance-Id`, and `X-Correlation-Id`
-- **THEN** the service returns a Contract V1 configuration for that tenant
+  `X-Studio-Tenant-Id`, and `X-Correlation-Id`
+- **THEN** the service returns a Contract V1 configuration whose `tenant.id`
+  exactly matches `X-Studio-Tenant-Id`
+
+#### Scenario: Competing tenant selector is rejected
+
+- **WHEN** a request presents `X-Studio-Instance-Id`, `X-Tenant-Id`, or any
+  query selector, with or without the canonical tenant header
+- **THEN** the service returns the stable `404 tenant_not_found` envelope
 
 #### Scenario: Service token lacks permission
 
@@ -23,10 +30,16 @@ Configuration Contract V1 development and tests.
 The mock SHALL provide two tenant configurations with `ask` and `disabled`
 conversation-content storage policies and the documented error envelopes.
 
-#### Scenario: Authorization projection is pending
+#### Scenario: Tenant or plugin is not ready
 
-- **WHEN** a request selects the mock authorization-pending scenario
-- **THEN** the service returns a `409` error envelope without tenant content
+- **WHEN** a request selects suspended, plugin-inactive, or tenant-not-ready
+- **THEN** the service returns the exact documented `409` envelope and
+  retryability for that scenario without tenant content
+
+#### Scenario: Runtime configuration is unavailable
+
+- **WHEN** a request selects the unavailable scenario
+- **THEN** the service returns the stable retryable `503` envelope
 
 ### Requirement: Protected internal mock exposure
 

--- a/openspec/changes/add-studio-runtime-configuration-mock/tasks.md
+++ b/openspec/changes/add-studio-runtime-configuration-mock/tasks.md
@@ -17,3 +17,14 @@
   token authorization.
 - [x] 3.2 Align authorization and locale response fields with Contract V1.
 - [x] 3.3 Restore loopback-only operation and document the swappable endpoint.
+
+## 4. Canonical tenant boundary
+
+- [x] 4.1 Replace `X-Studio-Instance-Id` with `X-Studio-Tenant-Id` and return
+  the selected value unchanged as `tenant.id`.
+- [x] 4.2 Reject legacy headers and query selectors without aliases.
+- [x] 4.3 Align stable error codes, statuses, messages, and retryability with
+  the frozen Studio V1 contract.
+- [x] 4.4 Replace the authorization-pending scenario with suspended,
+  plugin-inactive, tenant-not-ready, and unavailable scenarios.
+- [x] 4.5 Update focused tests, OpenAPI, operations, and architecture docs.

--- a/services/studio_mock/app.py
+++ b/services/studio_mock/app.py
@@ -35,7 +35,7 @@ class RuntimeError(BaseModel):
     code: RuntimeErrorCode
     message: str
     retryable: bool
-    correlation_id: str | None = Field(alias="correlationId")
+    correlation_id: str = Field(alias="correlationId")
 
     model_config = ConfigDict(populate_by_name=True)
 
@@ -211,7 +211,7 @@ def _configuration_for(tenant_id: str) -> dict[str, Any]:
 def _error_response(
     status_code: int,
     code: RuntimeErrorCode,
-    correlation_id: str | None,
+    correlation_id: str,
     retryable: bool,
     message: str = _UNAVAILABLE_MESSAGE,
 ) -> JSONResponse:

--- a/services/studio_mock/app.py
+++ b/services/studio_mock/app.py
@@ -3,9 +3,9 @@
 import hashlib
 import json
 from copy import deepcopy
-from typing import Any
+from typing import Any, Literal
 
-from fastapi import FastAPI, Header
+from fastapi import FastAPI, Header, Request
 from fastapi.openapi.utils import get_openapi
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, ConfigDict, Field
@@ -15,13 +15,24 @@ app = FastAPI(title="Studio Runtime Configuration Mock")
 _CONTRACT_VERSION = "1.0"
 _AUTHORIZED_TOKEN = "Bearer studio-mock-authorized-token"
 _UNAUTHORIZED_TOKEN = "Bearer studio-mock-unauthorized-token"
-_UNAVAILABLE_MESSAGE = "The requested tenant is unavailable."
+_UNAVAILABLE_MESSAGE = "Runtime configuration is unavailable."
+
+
+RuntimeErrorCode = Literal[
+    "service_authentication_invalid",
+    "service_action_forbidden",
+    "tenant_not_found",
+    "tenant_suspended",
+    "ssf_plugin_inactive",
+    "ssf_tenant_not_ready",
+    "runtime_configuration_unavailable",
+]
 
 
 class RuntimeError(BaseModel):
     """The nested error object defined by the Studio V1 contract."""
 
-    code: str
+    code: RuntimeErrorCode
     message: str
     retryable: bool
     correlation_id: str | None = Field(alias="correlationId")
@@ -68,9 +79,7 @@ class LocaleResponse(BaseModel):
     """A localized V1 runtime configuration entry."""
 
     locale: str
-    authenticated_home_explanation_html: str = Field(
-        alias="authenticatedHomeExplanationHtml"
-    )
+    authenticated_home_explanation_html: str = Field(alias="authenticatedHomeExplanationHtml")
     guest_explanation_html: str = Field(alias="guestExplanationHtml")
     conversation_content_storage_question_html: str | None = Field(
         alias="conversationContentStorageQuestionHtml"
@@ -111,10 +120,6 @@ class RuntimeConfigurationResponse(BaseModel):
 
 
 _ERROR_RESPONSES = {
-    400: {
-        "model": RuntimeErrorEnvelope,
-        "description": "A required header is missing.",
-    },
     401: {
         "model": RuntimeErrorEnvelope,
         "description": "Service authentication failed.",
@@ -125,11 +130,11 @@ _ERROR_RESPONSES = {
     },
     404: {
         "model": RuntimeErrorEnvelope,
-        "description": "The Studio instance does not exist.",
+        "description": "The tenant does not exist or the selector is malformed.",
     },
     409: {
         "model": RuntimeErrorEnvelope,
-        "description": "Authorization projection is pending.",
+        "description": "The tenant or SSF plugin is not ready.",
     },
     503: {
         "model": RuntimeErrorEnvelope,
@@ -191,11 +196,11 @@ def _revision(payload: dict[str, Any]) -> str:
     return f"sha256:{hashlib.sha256(canonical_json).hexdigest()}"
 
 
-def _configuration_for(studio_instance_id: str) -> dict[str, Any]:
+def _configuration_for(tenant_id: str) -> dict[str, Any]:
     """Return the effective configuration and its two deterministic revisions."""
-    configuration = deepcopy(_TENANT_CONFIGURATION_TEMPLATES[studio_instance_id])
+    configuration = deepcopy(_TENANT_CONFIGURATION_TEMPLATES[tenant_id])
     authorization = {
-        "studioInstanceId": studio_instance_id,
+        "tenantId": tenant_id,
         "permissions": ["ssf.runtime-configuration.read"],
     }
     configuration["authorizationRevision"] = _revision(authorization)
@@ -205,7 +210,7 @@ def _configuration_for(studio_instance_id: str) -> dict[str, Any]:
 
 def _error_response(
     status_code: int,
-    code: str,
+    code: RuntimeErrorCode,
     correlation_id: str | None,
     retryable: bool,
     message: str = _UNAVAILABLE_MESSAGE,
@@ -231,33 +236,44 @@ def _error_response(
     responses=_ERROR_RESPONSES,
 )
 def runtime_configuration(
+    request: Request,
     authorization: str | None = Header(default=None),
-    x_studio_instance_id: str | None = Header(default=None),
+    x_studio_tenant_id: str | None = Header(default=None),
     x_correlation_id: str | None = Header(default=None),
+    x_studio_instance_id: str | None = Header(default=None, include_in_schema=False),
+    x_tenant_id: str | None = Header(default=None, include_in_schema=False),
     x_mock_scenario: str | None = Header(default=None),
 ) -> dict[str, Any] | JSONResponse:
     """Return deterministic V1 data for authorized Studio service callers."""
     if authorization not in {_AUTHORIZED_TOKEN, _UNAUTHORIZED_TOKEN}:
-        return _error_response(401, "SERVICE_UNAUTHENTICATED", x_correlation_id, False)
+        return _error_response(
+            401, "service_authentication_invalid", x_correlation_id or "unavailable", False
+        )
     if authorization == _UNAUTHORIZED_TOKEN:
-        return _error_response(403, "SERVICE_FORBIDDEN", x_correlation_id, False)
-    if x_studio_instance_id is None:
         return _error_response(
-            400, "STUDIO_INSTANCE_ID_REQUIRED", x_correlation_id, False
+            403, "service_action_forbidden", x_correlation_id or "unavailable", False
         )
-    if x_correlation_id is None:
-        return _error_response(400, "CORRELATION_ID_REQUIRED", None, False)
-    if x_mock_scenario == "authorization-pending":
-        return _error_response(
-            409, "AUTHORIZATION_PROJECTION_PENDING", x_correlation_id, True
-        )
+    if (
+        not x_studio_tenant_id
+        or not x_correlation_id
+        or x_studio_instance_id is not None
+        or x_tenant_id is not None
+        or request.url.query
+    ):
+        return _error_response(404, "tenant_not_found", x_correlation_id or "unavailable", False)
+    scenario_errors: dict[str, tuple[int, RuntimeErrorCode, bool]] = {
+        "suspended": (409, "tenant_suspended", False),
+        "plugin-inactive": (409, "ssf_plugin_inactive", False),
+        "tenant-not-ready": (409, "ssf_tenant_not_ready", True),
+    }
+    if x_mock_scenario in scenario_errors:
+        status_code, code, retryable = scenario_errors[x_mock_scenario]
+        return _error_response(status_code, code, x_correlation_id, retryable)
     if x_mock_scenario == "unavailable":
-        return _error_response(
-            503, "RUNTIME_CONFIGURATION_UNAVAILABLE", x_correlation_id, True
-        )
-    if x_studio_instance_id not in _TENANT_CONFIGURATION_TEMPLATES:
-        return _error_response(404, "TENANT_NOT_FOUND", x_correlation_id, False)
-    return _configuration_for(x_studio_instance_id)
+        return _error_response(503, "runtime_configuration_unavailable", x_correlation_id, True)
+    if x_studio_tenant_id not in _TENANT_CONFIGURATION_TEMPLATES:
+        return _error_response(404, "tenant_not_found", x_correlation_id, False)
+    return _configuration_for(x_studio_tenant_id)
 
 
 def _custom_openapi() -> dict[str, Any]:
@@ -265,13 +281,13 @@ def _custom_openapi() -> dict[str, Any]:
     if app.openapi_schema:
         return app.openapi_schema
     schema = get_openapi(title=app.title, version=app.version, routes=app.routes)
-    parameters = schema["paths"]["/internal/plugins/ssf/v1/runtime-configuration"][
-        "get"
-    ]["parameters"]
+    parameters = schema["paths"]["/internal/plugins/ssf/v1/runtime-configuration"]["get"][
+        "parameters"
+    ]
     for parameter in parameters:
         if parameter["in"] == "header" and parameter["name"] in {
             "authorization",
-            "x-studio-instance-id",
+            "x-studio-tenant-id",
             "x-correlation-id",
         }:
             parameter["required"] = True

--- a/tests/test_studio_runtime_configuration_mock.py
+++ b/tests/test_studio_runtime_configuration_mock.py
@@ -5,6 +5,7 @@ import json
 import re
 
 from fastapi.testclient import TestClient
+from httpx import Response
 
 from services.studio_mock.app import app
 
@@ -14,18 +15,29 @@ AUTHORIZED_TOKEN = "Bearer studio-mock-authorized-token"
 UNAUTHORIZED_TOKEN = "Bearer studio-mock-unauthorized-token"
 
 
-def _headers(
-    studio_instance_id: str = "tenant-kassel", **additional: str
-) -> dict[str, str]:
+def _headers(tenant_id: str = "tenant-kassel", **additional: str) -> dict[str, str]:
     return {
         "Authorization": AUTHORIZED_TOKEN,
-        "X-Studio-Instance-Id": studio_instance_id,
+        "X-Studio-Tenant-Id": tenant_id,
         "X-Correlation-Id": "test-correlation-id",
         **additional,
     }
 
 
-def test_returns_v1_configuration_for_authorized_studio_instance() -> None:
+def _assert_error(response: Response, status: int, code: str, retryable: bool) -> None:
+    assert response.status_code == status
+    assert response.json() == {
+        "contractVersion": "1.0",
+        "error": {
+            "code": code,
+            "message": "Runtime configuration is unavailable.",
+            "retryable": retryable,
+            "correlationId": "test-correlation-id",
+        },
+    }
+
+
+def test_returns_v1_configuration_for_authorized_tenant() -> None:
     response = CLIENT.get(PATH, headers=_headers())
 
     assert response.status_code == 200
@@ -63,7 +75,7 @@ def test_returns_v1_configuration_for_authorized_studio_instance() -> None:
     assert configuration_revision == f"sha256:{expected_configuration_revision}"
 
 
-def test_returns_disabled_policy_for_second_studio_instance() -> None:
+def test_returns_disabled_policy_for_second_tenant() -> None:
     response = CLIENT.get(PATH, headers=_headers("tenant-fulda"))
 
     assert response.status_code == 200
@@ -78,74 +90,86 @@ def test_rejects_missing_or_unknown_service_token() -> None:
     unknown_token = CLIENT.get(PATH, headers=_headers(Authorization="Bearer unknown"))
 
     for response in (missing_token, unknown_token):
-        assert response.status_code == 401
-        assert response.json()["error"]["code"] == "SERVICE_UNAUTHENTICATED"
+        _assert_error(response, 401, "service_authentication_invalid", False)
 
 
 def test_rejects_service_token_without_runtime_configuration_permission() -> None:
     response = CLIENT.get(PATH, headers=_headers(Authorization=UNAUTHORIZED_TOKEN))
 
-    assert response.status_code == 403
-    assert response.json()["error"]["code"] == "SERVICE_FORBIDDEN"
+    _assert_error(response, 403, "service_action_forbidden", False)
 
 
-def test_requires_studio_instance_and_correlation_headers() -> None:
-    missing_instance = CLIENT.get(
+def test_rejects_missing_tenant_and_correlation_headers() -> None:
+    missing_tenant = CLIENT.get(
         PATH,
         headers={"Authorization": AUTHORIZED_TOKEN, "X-Correlation-Id": "test-correlation-id"},
     )
     missing_correlation = CLIENT.get(
         PATH,
-        headers={"Authorization": AUTHORIZED_TOKEN, "X-Studio-Instance-Id": "tenant-kassel"},
+        headers={"Authorization": AUTHORIZED_TOKEN, "X-Studio-Tenant-Id": "tenant-kassel"},
     )
 
-    assert missing_instance.status_code == 400
-    assert missing_instance.json()["error"]["code"] == "STUDIO_INSTANCE_ID_REQUIRED"
-    assert missing_correlation.status_code == 400
-    assert missing_correlation.json()["error"]["code"] == "CORRELATION_ID_REQUIRED"
+    assert missing_tenant.status_code == 404
+    assert missing_tenant.json()["error"]["code"] == "tenant_not_found"
+    assert missing_correlation.status_code == 404
+    assert missing_correlation.json()["error"]["code"] == "tenant_not_found"
 
 
-def test_does_not_use_browser_tenant_query_parameter_for_identity() -> None:
-    response = CLIENT.get(PATH, params={"tenantId": "tenant-kassel"})
+def test_rejects_competing_tenant_selectors() -> None:
+    responses = [
+        CLIENT.get(
+            PATH,
+            headers={
+                "Authorization": AUTHORIZED_TOKEN,
+                "X-Studio-Instance-Id": "tenant-kassel",
+                "X-Correlation-Id": "test-correlation-id",
+            },
+        ),
+        CLIENT.get(PATH, headers=_headers(**{"X-Studio-Instance-Id": "tenant-kassel"})),
+        CLIENT.get(PATH, headers=_headers(**{"X-Tenant-Id": "tenant-kassel"})),
+        CLIENT.get(PATH, params={"tenantId": "tenant-kassel"}, headers=_headers()),
+    ]
 
-    assert response.status_code == 401
-    assert response.json()["error"]["code"] == "SERVICE_UNAUTHENTICATED"
+    for response in responses:
+        _assert_error(response, 404, "tenant_not_found", False)
 
 
-def test_returns_not_found_for_unknown_studio_instance() -> None:
+def test_returns_not_found_for_unknown_tenant() -> None:
     response = CLIENT.get(PATH, headers=_headers("tenant-unknown"))
 
-    assert response.status_code == 404
-    assert response.json()["error"]["code"] == "TENANT_NOT_FOUND"
+    _assert_error(response, 404, "tenant_not_found", False)
 
 
 def test_returns_documented_mock_failure_envelopes() -> None:
     for scenario, status_code, code, retryable in [
-        ("authorization-pending", 409, "AUTHORIZATION_PROJECTION_PENDING", True),
-        ("unavailable", 503, "RUNTIME_CONFIGURATION_UNAVAILABLE", True),
+        ("suspended", 409, "tenant_suspended", False),
+        ("plugin-inactive", 409, "ssf_plugin_inactive", False),
+        ("tenant-not-ready", 409, "ssf_tenant_not_ready", True),
+        ("unavailable", 503, "runtime_configuration_unavailable", True),
     ]:
         response = CLIENT.get(PATH, headers=_headers(**{"X-Mock-Scenario": scenario}))
 
-        assert response.status_code == status_code
-        assert response.json() == {
-            "contractVersion": "1.0",
-            "error": {
-                "code": code,
-                "message": "The requested tenant is unavailable.",
-                "retryable": retryable,
-                "correlationId": "test-correlation-id",
-            },
-        }
+        _assert_error(response, status_code, code, retryable)
 
 
 def test_openapi_documents_every_runtime_configuration_error() -> None:
-    responses = CLIENT.get("/openapi.json").json()["paths"][PATH]["get"]["responses"]
+    schema = CLIENT.get("/openapi.json").json()
+    responses = schema["paths"][PATH]["get"]["responses"]
 
-    for status_code in ("400", "401", "403", "404", "409", "503"):
+    for status_code in ("401", "403", "404", "409", "503"):
         assert responses[status_code]["description"]
         assert responses[status_code]["content"]["application/json"]["schema"]["$ref"].endswith(
             "RuntimeErrorEnvelope"
         )
+    assert set(schema["components"]["schemas"]["RuntimeError"]["properties"]["code"]["enum"]) == {
+        "service_authentication_invalid",
+        "service_action_forbidden",
+        "tenant_not_found",
+        "tenant_suspended",
+        "ssf_plugin_inactive",
+        "ssf_tenant_not_ready",
+        "runtime_configuration_unavailable",
+    }
 
 
 def test_openapi_documents_required_v1_headers_and_success_contract() -> None:
@@ -159,15 +183,13 @@ def test_openapi_documents_required_v1_headers_and_success_contract() -> None:
 
     for header_name in (
         "authorization",
-        "x-studio-instance-id",
+        "x-studio-tenant-id",
         "x-correlation-id",
     ):
         assert headers[header_name]["required"] is True
         assert headers[header_name]["schema"] == {"type": "string"}
 
-    success_schema = operation["responses"]["200"]["content"]["application/json"][
-        "schema"
-    ]
+    success_schema = operation["responses"]["200"]["content"]["application/json"]["schema"]
     assert success_schema["$ref"].endswith("RuntimeConfigurationResponse")
     response_definition = schema["components"]["schemas"]["RuntimeConfigurationResponse"]
     assert {"configurationRevision", "authorizationRevision", "localization"} <= set(
@@ -175,10 +197,8 @@ def test_openapi_documents_required_v1_headers_and_success_contract() -> None:
     )
     branding_definition = schema["components"]["schemas"]["BrandingResponse"]
     logo_schema = branding_definition["properties"]["logo"]
-    assert {
-        item["$ref"]
-        for item in logo_schema["anyOf"]
-        if "$ref" in item
-    } == {"#/components/schemas/BrandingAssetResponse"}
+    assert {item["$ref"] for item in logo_schema["anyOf"] if "$ref" in item} == {
+        "#/components/schemas/BrandingAssetResponse"
+    }
     asset_definition = schema["components"]["schemas"]["BrandingAssetResponse"]
     assert {"url", "alternativeText"} <= set(asset_definition["properties"])

--- a/tests/test_studio_runtime_configuration_mock.py
+++ b/tests/test_studio_runtime_configuration_mock.py
@@ -112,7 +112,15 @@ def test_rejects_missing_tenant_and_correlation_headers() -> None:
     assert missing_tenant.status_code == 404
     assert missing_tenant.json()["error"]["code"] == "tenant_not_found"
     assert missing_correlation.status_code == 404
-    assert missing_correlation.json()["error"]["code"] == "tenant_not_found"
+    assert missing_correlation.json() == {
+        "contractVersion": "1.0",
+        "error": {
+            "code": "tenant_not_found",
+            "message": "Runtime configuration is unavailable.",
+            "retryable": False,
+            "correlationId": "unavailable",
+        },
+    }
 
 
 def test_rejects_competing_tenant_selectors() -> None:

--- a/tests/test_studio_runtime_configuration_mock_compose.py
+++ b/tests/test_studio_runtime_configuration_mock_compose.py
@@ -26,3 +26,5 @@ def test_runbook_documents_protected_swappable_mock_endpoint() -> None:
     assert "http://studio-mock:8000" in runbook
     assert "studio-mock-authorized-token" in runbook
     assert "STUDIO_RUNTIME_CONFIGURATION_BASE_URL" in runbook
+    assert "X-Studio-Tenant-Id" in runbook
+    assert "tenant-not-ready" in runbook


### PR DESCRIPTION
## Summary

- use `X-Studio-Tenant-Id` as the sole runtime tenant selector and return it unchanged as `tenant.id`
- reject legacy headers and query selectors without compatibility aliases
- align all mock error statuses, codes, messages, and retryability with Studio Runtime Configuration V1
- replace the authorization-pending shortcut with suspended, plugin-inactive, tenant-not-ready, and unavailable scenarios
- update OpenAPI, focused tests, runbook, active OpenSpec change, and current architecture documentation

## Verification

- `pytest tests/test_studio_runtime_configuration_mock.py tests/test_studio_runtime_configuration_mock_compose.py -q` (Python 3.12 container: 12 passed)
- `openspec validate add-studio-runtime-configuration-mock --strict`
- Black formatting check for changed Python files

Closes #294
