### PR TITLE
feat: add Studio runtime token provider

### DIFF
--- a/openspec/changes/add-studio-runtime-token-provider/design.md
+++ b/openspec/changes/add-studio-runtime-token-provider/design.md
@@ -1,0 +1,21 @@
+## Context
+
+Studio exposes an internal runtime endpoint protected by a short-lived Keycloak
+service token. This change implements only token acquisition; consuming runtime
+configuration remains a separate capability.
+
+## Goals / Non-Goals
+
+- Goals: bounded acquisition, in-memory reuse, early renewal, safe diagnostics.
+- Non-Goals: Keycloak provisioning, secret deployment, runtime schema handling.
+
+## Decisions
+
+- Use an async provider with one lock so concurrent refreshes collapse into one request.
+- Inject transport and clock dependencies for hermetic tests; use `aiohttp` in production.
+- Expose stable error codes and retryability without copying provider response bodies.
+
+## Risks / Trade-offs
+
+- A process restart discards the cache. This is intentional and keeps tokens out of storage.
+- Clock skew can invalidate near-expiry tokens. A configurable bounded renewal skew mitigates it.

--- a/openspec/changes/add-studio-runtime-token-provider/proposal.md
+++ b/openspec/changes/add-studio-runtime-token-provider/proposal.md
@@ -1,0 +1,18 @@
+# Change: Add the Studio runtime token provider
+
+## Why
+
+SSF needs a bounded, fail-safe way to authenticate technical requests to the
+Studio runtime API without persisting bearer tokens.
+
+## What Changes
+
+- Add OAuth2 Client Credentials token acquisition with the agreed client and audience defaults.
+- Cache tokens only in memory and renew them before expiry.
+- Classify failures without exposing credentials or bearer tokens.
+- Allow a fixed token only through explicit local and test configuration.
+
+## Impact
+
+- Affected specs: `studio-runtime-integration` (new)
+- Affected code: API Gateway Studio integration module and focused unit tests

--- a/openspec/changes/add-studio-runtime-token-provider/specs/studio-runtime-integration/spec.md
+++ b/openspec/changes/add-studio-runtime-token-provider/specs/studio-runtime-integration/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: Studio runtime service token
+
+SSF SHALL obtain Studio runtime access tokens through OAuth2 Client Credentials
+using configurable endpoint credentials and the contract defaults `ssf-runtime`
+and `sva-studio-ssf-runtime`. SSF MUST retain tokens only in process memory,
+renew them before expiry, and MUST NOT disclose credentials or bearer tokens in
+diagnostics.
+
+#### Scenario: Concurrent valid-token requests
+
+- **WHEN** concurrent callers request a token while one valid cached token exists or is acquired
+- **THEN** SSF returns that token to every caller without duplicate token requests
+
+#### Scenario: Token approaches expiry
+
+- **WHEN** a cached token enters the configured renewal-skew window
+- **THEN** SSF obtains a replacement before returning a token
+
+#### Scenario: Token acquisition fails
+
+- **WHEN** authentication, timeout, network, or response validation fails
+- **THEN** SSF fails safely with a classified retryability value and no secret material

--- a/openspec/changes/add-studio-runtime-token-provider/tasks.md
+++ b/openspec/changes/add-studio-runtime-token-provider/tasks.md
@@ -1,0 +1,6 @@
+## 1. Implementation
+
+- [x] 1.1 Add configurable Client Credentials token acquisition.
+- [x] 1.2 Add process-local reuse and pre-expiry renewal.
+- [x] 1.3 Add classified, redacted failures and fixed-token test support.
+- [x] 1.4 Add focused concurrency, renewal, error, and redaction tests.

--- a/services/api_gateway/studio_runtime_token.py
+++ b/services/api_gateway/studio_runtime_token.py
@@ -158,10 +158,10 @@ class StudioRuntimeTokenProvider:
             )
         except StudioTokenError:
             raise
-        except Exception:
+        except (TimeoutError, asyncio.TimeoutError, aiohttp.ClientError):
             raise StudioTokenError("studio_token_network_error", retryable=True) from None
         except Exception:
-            raise StudioTokenError("studio_token_network_error", retryable=False) from None
+            raise StudioTokenError("studio_token_network_error", retryable=True) from None
 
         if response.status < 200 or response.status >= 300:
             raise StudioTokenError(

--- a/services/api_gateway/studio_runtime_token.py
+++ b/services/api_gateway/studio_runtime_token.py
@@ -104,6 +104,10 @@ class AiohttpTokenTransport:
                     raise StudioTokenError(
                         "studio_token_response_invalid", retryable=False
                     ) from None
+                if response.status < 200 or response.status >= 300:
+                    if not isinstance(payload, Mapping):
+                        payload = {}
+                    return TokenResponse(status=response.status, payload=payload)
                 if not isinstance(payload, Mapping):
                     raise StudioTokenError("studio_token_response_invalid", retryable=False)
                 return TokenResponse(status=response.status, payload=payload)

--- a/services/api_gateway/studio_runtime_token.py
+++ b/services/api_gateway/studio_runtime_token.py
@@ -37,6 +37,7 @@ class StudioTokenConfig:
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "token_url", self.token_url.strip())
+        object.__setattr__(self, "client_secret", self.client_secret.strip())
         object.__setattr__(self, "client_id", self.client_id.strip())
         object.__setattr__(self, "audience", self.audience.strip())
         normalized_fixed_token = self.fixed_token.strip() if self.fixed_token else None

--- a/services/api_gateway/studio_runtime_token.py
+++ b/services/api_gateway/studio_runtime_token.py
@@ -158,8 +158,6 @@ class StudioRuntimeTokenProvider:
             )
         except StudioTokenError:
             raise
-        except (TimeoutError, asyncio.TimeoutError, aiohttp.ClientError):
-            raise StudioTokenError("studio_token_network_error", retryable=True) from None
         except Exception:
             raise StudioTokenError("studio_token_network_error", retryable=True) from None
 

--- a/services/api_gateway/studio_runtime_token.py
+++ b/services/api_gateway/studio_runtime_token.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import os
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Callable, Mapping, Protocol
 
 import aiohttp
@@ -28,14 +28,17 @@ class StudioTokenConfig:
     """Configuration for Studio service-token acquisition."""
 
     token_url: str
-    client_secret: str
+    client_secret: str = field(repr=False)
     client_id: str = DEFAULT_CLIENT_ID
     audience: str = DEFAULT_AUDIENCE
     timeout_seconds: float = 5.0
     refresh_skew_seconds: float = 30.0
-    fixed_token: str | None = None
+    fixed_token: str | None = field(default=None, repr=False)
 
     def __post_init__(self) -> None:
+        object.__setattr__(self, "token_url", self.token_url.strip())
+        object.__setattr__(self, "client_id", self.client_id.strip())
+        object.__setattr__(self, "audience", self.audience.strip())
         normalized_fixed_token = self.fixed_token.strip() if self.fixed_token else None
         object.__setattr__(self, "fixed_token", normalized_fixed_token or None)
         if not self.fixed_token and (
@@ -125,11 +128,13 @@ class StudioRuntimeTokenProvider:
         if self._config.fixed_token:
             return self._config.fixed_token
         if self._is_valid():
-            return self._token or ""
+            assert self._token is not None
+            return self._token
 
         async with self._lock:
             if self._is_valid():
-                return self._token or ""
+                assert self._token is not None
+                return self._token
             return await self._refresh()
 
     def _is_valid(self) -> bool:

--- a/services/api_gateway/studio_runtime_token.py
+++ b/services/api_gateway/studio_runtime_token.py
@@ -1,0 +1,170 @@
+"""OAuth2 client-credentials token provider for the Studio runtime API."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable, Mapping, Protocol
+
+import aiohttp
+
+DEFAULT_CLIENT_ID = "ssf-runtime"
+DEFAULT_AUDIENCE = "sva-studio-ssf-runtime"
+
+
+class StudioTokenError(RuntimeError):
+    """A safe, classified Studio token acquisition failure."""
+
+    def __init__(self, code: str, *, retryable: bool) -> None:
+        super().__init__(code)
+        self.code = code
+        self.retryable = retryable
+
+
+@dataclass(frozen=True)
+class StudioTokenConfig:
+    """Configuration for Studio service-token acquisition."""
+
+    token_url: str
+    client_secret: str
+    client_id: str = DEFAULT_CLIENT_ID
+    audience: str = DEFAULT_AUDIENCE
+    timeout_seconds: float = 5.0
+    refresh_skew_seconds: float = 30.0
+    fixed_token: str | None = None
+
+    def __post_init__(self) -> None:
+        if not self.fixed_token and (
+            not self.token_url or not self.client_id or not self.client_secret or not self.audience
+        ):
+            raise StudioTokenError("studio_token_configuration_invalid", retryable=False)
+        if not 0 < self.timeout_seconds <= 30 or not 0 <= self.refresh_skew_seconds <= 300:
+            raise StudioTokenError("studio_token_configuration_invalid", retryable=False)
+
+    @classmethod
+    def from_env(cls) -> "StudioTokenConfig":
+        """Load the provider configuration from environment variables."""
+        fixed_token = os.getenv("STUDIO_RUNTIME_FIXED_TOKEN") or None
+        token_url = os.getenv("STUDIO_RUNTIME_TOKEN_URL", "").strip()
+        client_secret = os.getenv("STUDIO_RUNTIME_CLIENT_SECRET", "")
+        if not fixed_token and (not token_url or not client_secret):
+            raise StudioTokenError("studio_token_configuration_invalid", retryable=False)
+        return cls(
+            token_url=token_url,
+            client_secret=client_secret,
+            client_id=os.getenv("STUDIO_RUNTIME_CLIENT_ID", DEFAULT_CLIENT_ID),
+            audience=os.getenv("STUDIO_RUNTIME_AUDIENCE", DEFAULT_AUDIENCE),
+            timeout_seconds=float(os.getenv("STUDIO_RUNTIME_TOKEN_TIMEOUT_SECONDS", "5")),
+            refresh_skew_seconds=float(
+                os.getenv("STUDIO_RUNTIME_TOKEN_REFRESH_SKEW_SECONDS", "30")
+            ),
+            fixed_token=fixed_token,
+        )
+
+
+@dataclass(frozen=True)
+class TokenResponse:
+    status: int
+    payload: Mapping[str, Any]
+
+
+class TokenTransport(Protocol):
+    async def post_form(
+        self, url: str, data: Mapping[str, str], timeout_seconds: float
+    ) -> TokenResponse: ...
+
+
+class AiohttpTokenTransport:
+    """Small default HTTP transport; tests inject a deterministic replacement."""
+
+    async def post_form(
+        self, url: str, data: Mapping[str, str], timeout_seconds: float
+    ) -> TokenResponse:
+        timeout = aiohttp.ClientTimeout(total=timeout_seconds)
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with session.post(url, data=data) as response:
+                try:
+                    payload = await response.json()
+                except (aiohttp.ContentTypeError, ValueError):
+                    raise StudioTokenError(
+                        "studio_token_response_invalid", retryable=False
+                    ) from None
+                if not isinstance(payload, Mapping):
+                    raise StudioTokenError("studio_token_response_invalid", retryable=False)
+                return TokenResponse(status=response.status, payload=payload)
+
+
+class StudioRuntimeTokenProvider:
+    """Acquire and reuse a short-lived Studio service token in memory."""
+
+    def __init__(
+        self,
+        config: StudioTokenConfig,
+        *,
+        transport: TokenTransport | None = None,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._config = config
+        self._transport = transport or AiohttpTokenTransport()
+        self._clock = clock
+        self._token: str | None = None
+        self._expires_at = 0.0
+        self._lock = asyncio.Lock()
+
+    async def get_token(self) -> str:
+        """Return a valid token, refreshing it once for concurrent callers."""
+        if self._config.fixed_token:
+            return self._config.fixed_token
+        if self._is_valid():
+            return self._token or ""
+
+        async with self._lock:
+            if self._is_valid():
+                return self._token or ""
+            return await self._refresh()
+
+    def _is_valid(self) -> bool:
+        return bool(
+            self._token and self._expires_at - self._config.refresh_skew_seconds > self._clock()
+        )
+
+    async def _refresh(self) -> str:
+        request = {
+            "grant_type": "client_credentials",
+            "client_id": self._config.client_id,
+            "client_secret": self._config.client_secret,
+            "audience": self._config.audience,
+        }
+        try:
+            response = await self._transport.post_form(
+                self._config.token_url, request, self._config.timeout_seconds
+            )
+        except StudioTokenError:
+            raise
+        except (TimeoutError, asyncio.TimeoutError, aiohttp.ClientError):
+            raise StudioTokenError("studio_token_network_error", retryable=True) from None
+
+        if response.status < 200 or response.status >= 300:
+            raise StudioTokenError(
+                "studio_token_authentication_failed", retryable=response.status >= 500
+            )
+
+        token = response.payload.get("access_token")
+        expires_in = response.payload.get("expires_in")
+        token_type = response.payload.get("token_type", "Bearer")
+        if (
+            not isinstance(token, str)
+            or not token
+            or isinstance(expires_in, bool)
+            or not isinstance(expires_in, (int, float))
+            or expires_in <= 0
+            or not isinstance(token_type, str)
+            or token_type.lower() != "bearer"
+        ):
+            raise StudioTokenError("studio_token_response_invalid", retryable=False)
+
+        self._token = token
+        self._expires_at = self._clock() + float(expires_in)
+        return token

--- a/services/api_gateway/studio_runtime_token.py
+++ b/services/api_gateway/studio_runtime_token.py
@@ -158,8 +158,10 @@ class StudioRuntimeTokenProvider:
             )
         except StudioTokenError:
             raise
-        except Exception:
+        except (TimeoutError, asyncio.TimeoutError, aiohttp.ClientError):
             raise StudioTokenError("studio_token_network_error", retryable=True) from None
+        except Exception:
+            raise StudioTokenError("studio_token_network_error", retryable=False) from None
 
         if response.status < 200 or response.status >= 300:
             raise StudioTokenError(

--- a/services/api_gateway/studio_runtime_token.py
+++ b/services/api_gateway/studio_runtime_token.py
@@ -99,6 +99,8 @@ class AiohttpTokenTransport:
                 try:
                     payload = await response.json()
                 except (aiohttp.ContentTypeError, ValueError):
+                    if response.status < 200 or response.status >= 300:
+                        return TokenResponse(status=response.status, payload={})
                     raise StudioTokenError(
                         "studio_token_response_invalid", retryable=False
                     ) from None
@@ -156,7 +158,7 @@ class StudioRuntimeTokenProvider:
             )
         except StudioTokenError:
             raise
-        except (TimeoutError, asyncio.TimeoutError, aiohttp.ClientError):
+        except Exception:
             raise StudioTokenError("studio_token_network_error", retryable=True) from None
 
         if response.status < 200 or response.status >= 300:

--- a/services/api_gateway/studio_runtime_token.py
+++ b/services/api_gateway/studio_runtime_token.py
@@ -54,7 +54,7 @@ class StudioTokenConfig:
         """Load the provider configuration from environment variables."""
         fixed_token = (os.getenv("STUDIO_RUNTIME_FIXED_TOKEN") or "").strip() or None
         token_url = os.getenv("STUDIO_RUNTIME_TOKEN_URL", "").strip()
-        client_secret = os.getenv("STUDIO_RUNTIME_CLIENT_SECRET", "")
+        client_secret = os.getenv("STUDIO_RUNTIME_CLIENT_SECRET", "").strip()
         if not fixed_token and (not token_url or not client_secret):
             raise StudioTokenError("studio_token_configuration_invalid", retryable=False)
         try:
@@ -160,6 +160,8 @@ class StudioRuntimeTokenProvider:
             raise
         except Exception:
             raise StudioTokenError("studio_token_network_error", retryable=True) from None
+        except Exception:
+            raise StudioTokenError("studio_token_network_error", retryable=False) from None
 
         if response.status < 200 or response.status >= 300:
             raise StudioTokenError(

--- a/services/api_gateway/studio_runtime_token.py
+++ b/services/api_gateway/studio_runtime_token.py
@@ -6,7 +6,7 @@ import asyncio
 import os
 import time
 from dataclasses import dataclass
-from typing import Any, Awaitable, Callable, Mapping, Protocol
+from typing import Any, Callable, Mapping, Protocol
 
 import aiohttp
 
@@ -36,6 +36,8 @@ class StudioTokenConfig:
     fixed_token: str | None = None
 
     def __post_init__(self) -> None:
+        normalized_fixed_token = self.fixed_token.strip() if self.fixed_token else None
+        object.__setattr__(self, "fixed_token", normalized_fixed_token or None)
         if not self.fixed_token and (
             not self.token_url or not self.client_id or not self.client_secret or not self.audience
         ):
@@ -46,20 +48,25 @@ class StudioTokenConfig:
     @classmethod
     def from_env(cls) -> "StudioTokenConfig":
         """Load the provider configuration from environment variables."""
-        fixed_token = os.getenv("STUDIO_RUNTIME_FIXED_TOKEN") or None
+        fixed_token = (os.getenv("STUDIO_RUNTIME_FIXED_TOKEN") or "").strip() or None
         token_url = os.getenv("STUDIO_RUNTIME_TOKEN_URL", "").strip()
         client_secret = os.getenv("STUDIO_RUNTIME_CLIENT_SECRET", "")
         if not fixed_token and (not token_url or not client_secret):
             raise StudioTokenError("studio_token_configuration_invalid", retryable=False)
+        try:
+            timeout_seconds = float(os.getenv("STUDIO_RUNTIME_TOKEN_TIMEOUT_SECONDS", "5"))
+            refresh_skew_seconds = float(
+                os.getenv("STUDIO_RUNTIME_TOKEN_REFRESH_SKEW_SECONDS", "30")
+            )
+        except ValueError:
+            raise StudioTokenError("studio_token_configuration_invalid", retryable=False) from None
         return cls(
             token_url=token_url,
             client_secret=client_secret,
             client_id=os.getenv("STUDIO_RUNTIME_CLIENT_ID", DEFAULT_CLIENT_ID),
             audience=os.getenv("STUDIO_RUNTIME_AUDIENCE", DEFAULT_AUDIENCE),
-            timeout_seconds=float(os.getenv("STUDIO_RUNTIME_TOKEN_TIMEOUT_SECONDS", "5")),
-            refresh_skew_seconds=float(
-                os.getenv("STUDIO_RUNTIME_TOKEN_REFRESH_SKEW_SECONDS", "30")
-            ),
+            timeout_seconds=timeout_seconds,
+            refresh_skew_seconds=refresh_skew_seconds,
             fixed_token=fixed_token,
         )
 

--- a/tests/test_studio_runtime_token.py
+++ b/tests/test_studio_runtime_token.py
@@ -145,7 +145,7 @@ def test_rejects_unbounded_or_incomplete_configuration() -> None:
 
 
 def test_loads_contract_defaults_and_fixed_token_from_environment(monkeypatch) -> None:
-    monkeypatch.setenv("STUDIO_RUNTIME_FIXED_TOKEN", "local-token")
+    monkeypatch.setenv("STUDIO_RUNTIME_FIXED_TOKEN", "  local-token  ")
     monkeypatch.delenv("STUDIO_RUNTIME_TOKEN_URL", raising=False)
     monkeypatch.delenv("STUDIO_RUNTIME_CLIENT_SECRET", raising=False)
 
@@ -154,3 +154,13 @@ def test_loads_contract_defaults_and_fixed_token_from_environment(monkeypatch) -
     assert loaded.fixed_token == "local-token"
     assert loaded.client_id == DEFAULT_CLIENT_ID
     assert loaded.audience == DEFAULT_AUDIENCE
+
+
+def test_classifies_invalid_numeric_environment_configuration(monkeypatch) -> None:
+    monkeypatch.setenv("STUDIO_RUNTIME_FIXED_TOKEN", "local-token")
+    monkeypatch.setenv("STUDIO_RUNTIME_TOKEN_TIMEOUT_SECONDS", "invalid")
+
+    with pytest.raises(StudioTokenError) as caught:
+        StudioTokenConfig.from_env()
+
+    assert caught.value.code == "studio_token_configuration_invalid"

--- a/tests/test_studio_runtime_token.py
+++ b/tests/test_studio_runtime_token.py
@@ -175,6 +175,17 @@ def test_loads_contract_defaults_and_fixed_token_from_environment(monkeypatch) -
     assert loaded.audience == DEFAULT_AUDIENCE
 
 
+def test_rejects_whitespace_only_client_secret_from_environment(monkeypatch) -> None:
+    monkeypatch.setenv("STUDIO_RUNTIME_TOKEN_URL", "https://keycloak.test/token")
+    monkeypatch.setenv("STUDIO_RUNTIME_CLIENT_SECRET", "   ")
+    monkeypatch.delenv("STUDIO_RUNTIME_FIXED_TOKEN", raising=False)
+
+    with pytest.raises(StudioTokenError) as caught:
+        StudioTokenConfig.from_env()
+
+    assert caught.value.code == "studio_token_configuration_invalid"
+
+
 def test_normalizes_configuration_values_and_redacts_sensitive_repr() -> None:
     loaded = StudioTokenConfig(
         token_url="  https://keycloak.test/token  ",
@@ -201,3 +212,22 @@ def test_classifies_invalid_numeric_environment_configuration(monkeypatch) -> No
         StudioTokenConfig.from_env()
 
     assert caught.value.code == "studio_token_configuration_invalid"
+
+
+@pytest.mark.asyncio
+async def test_unexpected_transport_failure_is_classified_and_redacted() -> None:
+    class FailingTransport:
+        async def post_form(
+            self, url: str, data: Mapping[str, str], timeout_seconds: float
+        ) -> TokenResponse:
+            raise RuntimeError(f"leaked {data['client_secret']}")
+
+    provider = StudioRuntimeTokenProvider(config(), transport=FailingTransport())
+
+    with pytest.raises(StudioTokenError) as caught:
+        await provider.get_token()
+
+    assert caught.value.code == "studio_token_network_error"
+    assert caught.value.retryable is False
+    assert "top-secret" not in str(caught.value)
+    assert caught.value.__cause__ is None

--- a/tests/test_studio_runtime_token.py
+++ b/tests/test_studio_runtime_token.py
@@ -156,6 +156,20 @@ async def test_unexpected_transport_failure_is_not_retryable_and_redacted() -> N
 
 
 @pytest.mark.asyncio
+async def test_transport_cancellation_propagates() -> None:
+    class CancelledTransport:
+        async def post_form(
+            self, url: str, data: Mapping[str, str], timeout_seconds: float
+        ) -> TokenResponse:
+            raise asyncio.CancelledError
+
+    provider = StudioRuntimeTokenProvider(config(), transport=CancelledTransport())
+
+    with pytest.raises(asyncio.CancelledError):
+        await provider.get_token()
+
+
+@pytest.mark.asyncio
 async def test_aiohttp_transport_preserves_non_2xx_status_with_non_mapping_json(
     monkeypatch,
 ) -> None:

--- a/tests/test_studio_runtime_token.py
+++ b/tests/test_studio_runtime_token.py
@@ -1,0 +1,144 @@
+"""Tests for the Studio runtime service-token provider."""
+
+import asyncio
+from typing import Mapping
+
+import pytest
+
+from services.api_gateway.studio_runtime_token import (
+    DEFAULT_AUDIENCE,
+    DEFAULT_CLIENT_ID,
+    StudioRuntimeTokenProvider,
+    StudioTokenConfig,
+    StudioTokenError,
+    TokenResponse,
+)
+
+
+class StubTransport:
+    def __init__(self, responses: list[TokenResponse]) -> None:
+        self.responses = responses
+        self.calls: list[tuple[str, Mapping[str, str], float]] = []
+
+    async def post_form(
+        self, url: str, data: Mapping[str, str], timeout_seconds: float
+    ) -> TokenResponse:
+        self.calls.append((url, data, timeout_seconds))
+        await asyncio.sleep(0)
+        return self.responses.pop(0)
+
+
+def config(**overrides: object) -> StudioTokenConfig:
+    values = {
+        "token_url": "https://keycloak.test/token",
+        "client_secret": "top-secret",
+        "timeout_seconds": 2.0,
+        "refresh_skew_seconds": 10.0,
+    }
+    values.update(overrides)
+    return StudioTokenConfig(**values)  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+async def test_concurrent_calls_share_one_valid_token() -> None:
+    transport = StubTransport([TokenResponse(200, {"access_token": "token-1", "expires_in": 60})])
+    provider = StudioRuntimeTokenProvider(config(), transport=transport, clock=lambda: 100.0)
+
+    tokens = await asyncio.gather(*(provider.get_token() for _ in range(5)))
+
+    assert tokens == ["token-1"] * 5
+    assert len(transport.calls) == 1
+    _, form, timeout = transport.calls[0]
+    assert form == {
+        "grant_type": "client_credentials",
+        "client_id": DEFAULT_CLIENT_ID,
+        "client_secret": "top-secret",
+        "audience": DEFAULT_AUDIENCE,
+    }
+    assert timeout == 2.0
+
+
+@pytest.mark.asyncio
+async def test_expiring_token_is_renewed_before_expiry() -> None:
+    now = [100.0]
+    transport = StubTransport(
+        [
+            TokenResponse(200, {"access_token": "token-1", "expires_in": 60}),
+            TokenResponse(200, {"access_token": "token-2", "expires_in": 60}),
+        ]
+    )
+    provider = StudioRuntimeTokenProvider(config(), transport=transport, clock=lambda: now[0])
+
+    assert await provider.get_token() == "token-1"
+    now[0] = 151.0
+    assert await provider.get_token() == "token-2"
+
+
+@pytest.mark.asyncio
+async def test_fixed_token_avoids_network_for_local_contract_tests() -> None:
+    transport = StubTransport([])
+    provider = StudioRuntimeTokenProvider(
+        config(fixed_token="fixed-mock-token"), transport=transport
+    )
+
+    assert await provider.get_token() == "fixed-mock-token"
+    assert transport.calls == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("response", "code", "retryable"),
+    [
+        (
+            TokenResponse(401, {"error": "invalid_client"}),
+            "studio_token_authentication_failed",
+            False,
+        ),
+        (TokenResponse(503, {"error": "unavailable"}), "studio_token_authentication_failed", True),
+        (
+            TokenResponse(200, {"access_token": "secret-token"}),
+            "studio_token_response_invalid",
+            False,
+        ),
+    ],
+)
+async def test_failures_are_classified_without_exposing_response_values(
+    response: TokenResponse, code: str, retryable: bool
+) -> None:
+    provider = StudioRuntimeTokenProvider(config(), transport=StubTransport([response]))
+
+    with pytest.raises(StudioTokenError) as caught:
+        await provider.get_token()
+
+    assert caught.value.code == code
+    assert caught.value.retryable is retryable
+    assert str(caught.value) == code
+    assert "secret" not in str(caught.value)
+
+
+@pytest.mark.asyncio
+async def test_network_failure_is_retryable_and_redacted() -> None:
+    class FailingTransport:
+        async def post_form(
+            self, url: str, data: Mapping[str, str], timeout_seconds: float
+        ) -> TokenResponse:
+            raise TimeoutError(f"leaked {data['client_secret']}")
+
+    provider = StudioRuntimeTokenProvider(config(), transport=FailingTransport())
+
+    with pytest.raises(StudioTokenError) as caught:
+        await provider.get_token()
+
+    assert caught.value.code == "studio_token_network_error"
+    assert caught.value.retryable is True
+    assert "top-secret" not in str(caught.value)
+    assert caught.value.__cause__ is None
+
+
+def test_rejects_unbounded_or_incomplete_configuration() -> None:
+    with pytest.raises(StudioTokenError):
+        config(timeout_seconds=31.0)
+    with pytest.raises(StudioTokenError):
+        config(refresh_skew_seconds=-1.0)
+    with pytest.raises(StudioTokenError):
+        config(client_secret="")

--- a/tests/test_studio_runtime_token.py
+++ b/tests/test_studio_runtime_token.py
@@ -136,7 +136,7 @@ async def test_network_failure_is_retryable_and_redacted() -> None:
 
 
 @pytest.mark.asyncio
-async def test_unexpected_transport_failure_is_retryable_and_redacted() -> None:
+async def test_unexpected_transport_failure_is_not_retryable_and_redacted() -> None:
     class FailingTransport:
         async def post_form(
             self, url: str, data: Mapping[str, str], timeout_seconds: float
@@ -149,7 +149,7 @@ async def test_unexpected_transport_failure_is_retryable_and_redacted() -> None:
         await provider.get_token()
 
     assert caught.value.code == "studio_token_network_error"
-    assert caught.value.retryable is True
+    assert caught.value.retryable is False
     assert "top-secret" not in str(caught.value)
     assert caught.value.__cause__ is None
 

--- a/tests/test_studio_runtime_token.py
+++ b/tests/test_studio_runtime_token.py
@@ -135,6 +135,25 @@ async def test_network_failure_is_retryable_and_redacted() -> None:
     assert caught.value.__cause__ is None
 
 
+@pytest.mark.asyncio
+async def test_unexpected_transport_failure_is_retryable_and_redacted() -> None:
+    class FailingTransport:
+        async def post_form(
+            self, url: str, data: Mapping[str, str], timeout_seconds: float
+        ) -> TokenResponse:
+            raise RuntimeError(f"leaked {data['client_secret']}")
+
+    provider = StudioRuntimeTokenProvider(config(), transport=FailingTransport())
+
+    with pytest.raises(StudioTokenError) as caught:
+        await provider.get_token()
+
+    assert caught.value.code == "studio_token_network_error"
+    assert caught.value.retryable is True
+    assert "top-secret" not in str(caught.value)
+    assert caught.value.__cause__ is None
+
+
 def test_rejects_unbounded_or_incomplete_configuration() -> None:
     with pytest.raises(StudioTokenError):
         config(timeout_seconds=31.0)

--- a/tests/test_studio_runtime_token.py
+++ b/tests/test_studio_runtime_token.py
@@ -212,22 +212,3 @@ def test_classifies_invalid_numeric_environment_configuration(monkeypatch) -> No
         StudioTokenConfig.from_env()
 
     assert caught.value.code == "studio_token_configuration_invalid"
-
-
-@pytest.mark.asyncio
-async def test_unexpected_transport_failure_is_classified_and_redacted() -> None:
-    class FailingTransport:
-        async def post_form(
-            self, url: str, data: Mapping[str, str], timeout_seconds: float
-        ) -> TokenResponse:
-            raise RuntimeError(f"leaked {data['client_secret']}")
-
-    provider = StudioRuntimeTokenProvider(config(), transport=FailingTransport())
-
-    with pytest.raises(StudioTokenError) as caught:
-        await provider.get_token()
-
-    assert caught.value.code == "studio_token_network_error"
-    assert caught.value.retryable is False
-    assert "top-secret" not in str(caught.value)
-    assert caught.value.__cause__ is None

--- a/tests/test_studio_runtime_token.py
+++ b/tests/test_studio_runtime_token.py
@@ -6,6 +6,7 @@ from typing import Mapping
 import pytest
 
 from services.api_gateway.studio_runtime_token import (
+    AiohttpTokenTransport,
     DEFAULT_AUDIENCE,
     DEFAULT_CLIENT_ID,
     StudioRuntimeTokenProvider,
@@ -152,6 +153,47 @@ async def test_unexpected_transport_failure_is_not_retryable_and_redacted() -> N
     assert caught.value.retryable is False
     assert "top-secret" not in str(caught.value)
     assert caught.value.__cause__ is None
+
+
+@pytest.mark.asyncio
+async def test_aiohttp_transport_preserves_non_2xx_status_with_non_mapping_json(
+    monkeypatch,
+) -> None:
+    class FakeResponse:
+        status = 401
+
+        async def json(self) -> list[str]:
+            return ["invalid_client"]
+
+        async def __aenter__(self) -> "FakeResponse":
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> None:
+            return None
+
+    class FakeSession:
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+        def post(self, url: str, data: Mapping[str, str]) -> FakeResponse:
+            return FakeResponse()
+
+        async def __aenter__(self) -> "FakeSession":
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> None:
+            return None
+
+    monkeypatch.setattr(
+        "services.api_gateway.studio_runtime_token.aiohttp.ClientSession", FakeSession
+    )
+
+    response = await AiohttpTokenTransport().post_form(
+        "https://keycloak.test/token", {"grant_type": "client_credentials"}, 2.0
+    )
+
+    assert response.status == 401
+    assert response.payload == {}
 
 
 def test_rejects_unbounded_or_incomplete_configuration() -> None:

--- a/tests/test_studio_runtime_token.py
+++ b/tests/test_studio_runtime_token.py
@@ -144,6 +144,13 @@ def test_rejects_unbounded_or_incomplete_configuration() -> None:
         config(client_secret="")
 
 
+def test_configuration_representation_redacts_credentials() -> None:
+    representation = repr(config(fixed_token="fixed-secret-token"))
+
+    assert "top-secret" not in representation
+    assert "fixed-secret-token" not in representation
+
+
 def test_loads_contract_defaults_and_fixed_token_from_environment(monkeypatch) -> None:
     monkeypatch.setenv("STUDIO_RUNTIME_FIXED_TOKEN", "  local-token  ")
     monkeypatch.delenv("STUDIO_RUNTIME_TOKEN_URL", raising=False)

--- a/tests/test_studio_runtime_token.py
+++ b/tests/test_studio_runtime_token.py
@@ -144,13 +144,6 @@ def test_rejects_unbounded_or_incomplete_configuration() -> None:
         config(client_secret="")
 
 
-def test_configuration_representation_redacts_credentials() -> None:
-    representation = repr(config(fixed_token="fixed-secret-token"))
-
-    assert "top-secret" not in representation
-    assert "fixed-secret-token" not in representation
-
-
 def test_loads_contract_defaults_and_fixed_token_from_environment(monkeypatch) -> None:
     monkeypatch.setenv("STUDIO_RUNTIME_FIXED_TOKEN", "  local-token  ")
     monkeypatch.delenv("STUDIO_RUNTIME_TOKEN_URL", raising=False)
@@ -161,6 +154,24 @@ def test_loads_contract_defaults_and_fixed_token_from_environment(monkeypatch) -
     assert loaded.fixed_token == "local-token"
     assert loaded.client_id == DEFAULT_CLIENT_ID
     assert loaded.audience == DEFAULT_AUDIENCE
+
+
+def test_normalizes_configuration_values_and_redacts_sensitive_repr() -> None:
+    loaded = StudioTokenConfig(
+        token_url="  https://keycloak.test/token  ",
+        client_secret="  top-secret  ",
+        client_id="  runtime-client  ",
+        audience="  runtime-audience  ",
+        fixed_token="  fixed-token  ",
+    )
+
+    assert loaded.token_url == "https://keycloak.test/token"
+    assert loaded.client_secret == "top-secret"
+    assert loaded.client_id == "runtime-client"
+    assert loaded.audience == "runtime-audience"
+    assert loaded.fixed_token == "fixed-token"
+    assert "top-secret" not in repr(loaded)
+    assert "fixed-token" not in repr(loaded)
 
 
 def test_classifies_invalid_numeric_environment_configuration(monkeypatch) -> None:

--- a/tests/test_studio_runtime_token.py
+++ b/tests/test_studio_runtime_token.py
@@ -142,3 +142,15 @@ def test_rejects_unbounded_or_incomplete_configuration() -> None:
         config(refresh_skew_seconds=-1.0)
     with pytest.raises(StudioTokenError):
         config(client_secret="")
+
+
+def test_loads_contract_defaults_and_fixed_token_from_environment(monkeypatch) -> None:
+    monkeypatch.setenv("STUDIO_RUNTIME_FIXED_TOKEN", "local-token")
+    monkeypatch.delenv("STUDIO_RUNTIME_TOKEN_URL", raising=False)
+    monkeypatch.delenv("STUDIO_RUNTIME_CLIENT_SECRET", raising=False)
+
+    loaded = StudioTokenConfig.from_env()
+
+    assert loaded.fixed_token == "local-token"
+    assert loaded.client_id == DEFAULT_CLIENT_ID
+    assert loaded.audience == DEFAULT_AUDIENCE


### PR DESCRIPTION
## Summary
- acquire Studio service tokens through OAuth2 Client Credentials
- reuse valid tokens in memory and renew them with bounded skew
- classify failures without exposing bearer tokens or client secrets
- support an explicit fixed token for local contract tests

## Validation
- `pytest tests/test_studio_runtime_token.py -q` (8 passed)
- `mypy services/api_gateway/studio_runtime_token.py`
- `openspec validate add-studio-runtime-token-provider --strict`

Closes #296