### PR TITLE
feat: add Studio Runtime Configuration V1 client

### DIFF
--- a/openspec/changes/add-studio-runtime-configuration-client/design.md
+++ b/openspec/changes/add-studio-runtime-configuration-client/design.md
@@ -1,0 +1,21 @@
+## Context
+
+Studio Runtime Configuration V1 is a tenant-bound internal API. Token
+acquisition is intentionally injected so this client remains independent of
+the OAuth2 implementation and can be tested against deterministic transports.
+
+## Goals / Non-Goals
+
+- Goals: exact request contract, fail-closed schema and tenant checks, stable error handling.
+- Non-Goals: token acquisition internals, user tokens, sessions, response caching.
+
+## Decisions
+
+- Model known V1 fields with strict Pydantic types and permit unknown optional fields.
+- Keep the endpoint path constant and configure only the Studio base URL.
+- Surface safe error codes and the server-provided retryability value without response bodies.
+
+## Risks / Trade-offs
+
+- Forward-compatible fields are retained but not interpreted until a later contract revision.
+- Invalid success and error bodies fail closed, which can temporarily make configuration unavailable.

--- a/openspec/changes/add-studio-runtime-configuration-client/proposal.md
+++ b/openspec/changes/add-studio-runtime-configuration-client/proposal.md
@@ -1,0 +1,18 @@
+# Change: Add the Studio Runtime Configuration V1 client
+
+## Why
+
+SSF needs a fail-closed consumer for tenant-specific runtime configuration from
+Studio before the mock can be replaced by real control-plane data.
+
+## What Changes
+
+- Add the fixed V1 request path and required service, tenant, and correlation headers.
+- Validate all required response fields, revisions, tenant binding, and semantic constraints.
+- Follow the stable Studio error envelope and its `retryable` value.
+- Accept optional V1 additions while strictly validating known fields.
+
+## Impact
+
+- Affected specs: `studio-runtime-integration` (new)
+- Affected code: API Gateway Studio integration module and focused contract tests

--- a/openspec/changes/add-studio-runtime-configuration-client/specs/studio-runtime-integration/spec.md
+++ b/openspec/changes/add-studio-runtime-configuration-client/specs/studio-runtime-integration/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: Studio Runtime Configuration V1 client
+
+SSF SHALL request Runtime Configuration V1 from the fixed internal Studio path
+with service authorization, the canonical Studio tenant ID, and a correlation
+ID. SSF MUST validate all known fields and both revisions, MUST require the
+response tenant ID to match the request, and MUST allow unknown optional V1
+additions.
+
+#### Scenario: Valid tenant configuration
+
+- **WHEN** Studio returns a valid V1 response for the requested tenant
+- **THEN** SSF accepts the configuration and preserves its configuration and authorization revisions
+
+#### Scenario: Invalid or cross-tenant configuration
+
+- **WHEN** a response has an invalid known field, revision, semantic constraint, or tenant ID
+- **THEN** SSF rejects the response without applying configuration
+
+#### Scenario: Studio returns a stable error
+
+- **WHEN** Studio returns a documented V1 error envelope
+- **THEN** SSF surfaces its stable code, status, and documented `retryable` value without response details

--- a/openspec/changes/add-studio-runtime-configuration-client/tasks.md
+++ b/openspec/changes/add-studio-runtime-configuration-client/tasks.md
@@ -1,0 +1,6 @@
+## 1. Implementation
+
+- [x] 1.1 Add the fixed V1 request contract with injected token and transport dependencies.
+- [x] 1.2 Validate the known success schema, revisions, and tenant binding.
+- [x] 1.3 Validate stable error envelopes and preserve retryability.
+- [x] 1.4 Add focused positive, forward-compatibility, and negative-path tests.

--- a/services/api_gateway/studio_runtime_client.py
+++ b/services/api_gateway/studio_runtime_client.py
@@ -1,0 +1,283 @@
+"""Strict consumer for the Studio Runtime Configuration V1 contract."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable, Mapping, Protocol
+from urllib.parse import urlsplit
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+import aiohttp
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    HttpUrl,
+    ValidationError,
+    field_validator,
+    model_validator,
+)
+
+RUNTIME_PATH = "/internal/plugins/ssf/v1/runtime-configuration"
+REVISION_PATTERN = re.compile(r"^sha256:[0-9a-f]{64}$")
+LOCALE_PATTERN = re.compile(r"^[A-Za-z]{2,3}(?:-[A-Za-z0-9]{2,8}){0,2}$")
+SUPPORTED_ERROR_STATUSES = {400, 401, 403, 404, 409, 503}
+EXPECTED_ERROR_CODES = {
+    401: {"service_authentication_invalid"},
+    403: {"service_action_forbidden"},
+    404: {"tenant_not_found"},
+    409: {"tenant_suspended", "ssf_plugin_inactive", "ssf_tenant_not_ready"},
+    503: {"runtime_configuration_unavailable"},
+}
+
+
+class ContractModel(BaseModel):
+    """Validate known fields while accepting optional V1 extensions."""
+
+    model_config = ConfigDict(extra="allow", strict=True, populate_by_name=True)
+
+
+class MediaAsset(ContractModel):
+    url: HttpUrl
+    alternative_text: str = Field(alias="alternativeText", max_length=500)
+
+
+class Branding(ContractModel):
+    logo: MediaAsset | None
+    icon: MediaAsset | None
+
+
+class Tenant(ContractModel):
+    id: str = Field(min_length=1, max_length=128)
+    display_name: str = Field(alias="displayName", min_length=1, max_length=200)
+    time_zone: str = Field(alias="timeZone", min_length=1, max_length=100)
+
+    @field_validator("time_zone")
+    @classmethod
+    def validate_time_zone(cls, value: str) -> str:
+        try:
+            ZoneInfo(value)
+        except ZoneInfoNotFoundError as error:
+            raise ValueError("timeZone must be an IANA time zone") from error
+        return value
+
+
+class LocaleConfiguration(ContractModel):
+    locale: str = Field(min_length=1, max_length=35)
+    authenticated_home_explanation_html: str = Field(alias="authenticatedHomeExplanationHtml")
+    guest_explanation_html: str = Field(alias="guestExplanationHtml")
+    conversation_content_storage_question_html: str | None = Field(
+        alias="conversationContentStorageQuestionHtml"
+    )
+
+    @field_validator("locale")
+    @classmethod
+    def validate_locale(cls, value: str) -> str:
+        if not LOCALE_PATTERN.fullmatch(value):
+            raise ValueError("locale must be a BCP-47 language tag")
+        return value
+
+    @field_validator(
+        "authenticated_home_explanation_html",
+        "guest_explanation_html",
+        "conversation_content_storage_question_html",
+    )
+    @classmethod
+    def validate_html_size(cls, value: str | None) -> str | None:
+        if value is not None and len(value.encode("utf-8")) > 65_536:
+            raise ValueError("HTML exceeds the V1 byte limit")
+        return value
+
+
+class Localization(ContractModel):
+    default_locale: str = Field(alias="defaultLocale", min_length=1, max_length=35)
+    locales: list[LocaleConfiguration] = Field(min_length=1, max_length=20)
+
+    @model_validator(mode="after")
+    def validate_active_locales(self) -> "Localization":
+        locale_names = [entry.locale for entry in self.locales]
+        if len(locale_names) != len(set(locale_names)):
+            raise ValueError("locales must be unique")
+        if self.default_locale not in locale_names:
+            raise ValueError("defaultLocale must be active")
+        return self
+
+
+class ConversationContentStorage(ContractModel):
+    mode: str = Field(pattern="^(ask|disabled)$")
+
+
+class RuntimeConfiguration(ContractModel):
+    contract_version: str = Field(alias="contractVersion", pattern="^1[.]0$")
+    configuration_revision: str = Field(alias="configurationRevision")
+    authorization_revision: str = Field(alias="authorizationRevision")
+    tenant: Tenant
+    branding: Branding
+    localization: Localization
+    conversation_content_storage: ConversationContentStorage = Field(
+        alias="conversationContentStorage"
+    )
+
+    @field_validator("configuration_revision", "authorization_revision")
+    @classmethod
+    def validate_revision(cls, value: str) -> str:
+        if not REVISION_PATTERN.fullmatch(value):
+            raise ValueError("revision must be a lowercase SHA-256 value")
+        return value
+
+    @model_validator(mode="after")
+    def validate_storage_semantics(self) -> "RuntimeConfiguration":
+        if self.conversation_content_storage.mode == "disabled" and any(
+            entry.conversation_content_storage_question_html is not None
+            for entry in self.localization.locales
+        ):
+            raise ValueError("storage questions must be null when storage is disabled")
+        return self
+
+
+class RuntimeErrorDetails(ContractModel):
+    code: str = Field(min_length=1)
+    message: str = Field(min_length=1, max_length=200)
+    retryable: bool
+    correlation_id: str = Field(alias="correlationId", min_length=1, max_length=128)
+
+
+class RuntimeErrorEnvelope(ContractModel):
+    contract_version: str = Field(alias="contractVersion", pattern="^1[.]0$")
+    error: RuntimeErrorDetails
+
+
+class StudioRuntimeClientError(RuntimeError):
+    """Safe failure surfaced by the Studio runtime client."""
+
+    def __init__(self, code: str, *, retryable: bool, status: int | None = None) -> None:
+        super().__init__(code)
+        self.code = code
+        self.retryable = retryable
+        self.status = status
+
+
+@dataclass(frozen=True)
+class RuntimeHttpResponse:
+    status: int
+    payload: Mapping[str, Any]
+
+
+class RuntimeTransport(Protocol):
+    async def get(
+        self, url: str, headers: Mapping[str, str], timeout_seconds: float
+    ) -> RuntimeHttpResponse: ...
+
+
+class AiohttpRuntimeTransport:
+    async def get(
+        self, url: str, headers: Mapping[str, str], timeout_seconds: float
+    ) -> RuntimeHttpResponse:
+        timeout = aiohttp.ClientTimeout(total=timeout_seconds)
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with session.get(url, headers=headers) as response:
+                try:
+                    payload = await response.json()
+                except (aiohttp.ContentTypeError, json.JSONDecodeError, ValueError):
+                    raise StudioRuntimeClientError(
+                        "studio_runtime_response_invalid", retryable=False, status=response.status
+                    ) from None
+                if not isinstance(payload, Mapping):
+                    raise StudioRuntimeClientError(
+                        "studio_runtime_response_invalid", retryable=False, status=response.status
+                    )
+                return RuntimeHttpResponse(status=response.status, payload=payload)
+
+
+class StudioRuntimeClient:
+    """Fetch and validate one tenant's Studio Runtime Configuration V1."""
+
+    def __init__(
+        self,
+        base_url: str,
+        token_provider: Callable[[], Awaitable[str]],
+        *,
+        transport: RuntimeTransport | None = None,
+        timeout_seconds: float = 5.0,
+    ) -> None:
+        parsed_url = urlsplit(base_url)
+        if (
+            parsed_url.scheme not in {"http", "https"}
+            or not parsed_url.netloc
+            or parsed_url.username is not None
+            or parsed_url.password is not None
+            or parsed_url.path not in {"", "/"}
+        ):
+            raise ValueError("base_url must be an HTTP origin")
+        if parsed_url.query or parsed_url.fragment:
+            raise ValueError("base_url must not contain a query or fragment")
+        if not 0 < timeout_seconds <= 30:
+            raise ValueError("timeout_seconds must be between 0 and 30")
+        self._url = f"{base_url.rstrip('/')}{RUNTIME_PATH}"
+        self._token_provider = token_provider
+        self._transport = transport or AiohttpRuntimeTransport()
+        self._timeout_seconds = timeout_seconds
+
+    async def fetch(self, tenant_id: str, correlation_id: str) -> RuntimeConfiguration:
+        if not tenant_id or len(tenant_id) > 128:
+            raise ValueError("tenant_id must contain between 1 and 128 characters")
+        if (
+            not correlation_id
+            or len(correlation_id) > 128
+            or any(ord(character) < 32 or ord(character) > 126 for character in correlation_id)
+        ):
+            raise ValueError("correlation_id must be printable ASCII with at most 128 characters")
+
+        token = await self._token_provider()
+        if not token:
+            raise StudioRuntimeClientError("studio_runtime_token_invalid", retryable=False)
+        headers = {
+            "Authorization": f"Bearer {token}",
+            "X-Studio-Tenant-Id": tenant_id,
+            "X-Correlation-Id": correlation_id,
+        }
+        try:
+            response = await self._transport.get(self._url, headers, self._timeout_seconds)
+        except StudioRuntimeClientError:
+            raise
+        except (TimeoutError, asyncio.TimeoutError, aiohttp.ClientError):
+            raise StudioRuntimeClientError("studio_runtime_network_error", retryable=True) from None
+
+        if response.status == 200:
+            try:
+                configuration = RuntimeConfiguration.model_validate(response.payload)
+            except ValidationError as error:
+                raise StudioRuntimeClientError(
+                    "studio_runtime_response_invalid", retryable=False, status=200
+                ) from error
+            if configuration.tenant.id != tenant_id:
+                raise StudioRuntimeClientError(
+                    "studio_runtime_tenant_mismatch", retryable=False, status=200
+                )
+            return configuration
+
+        if response.status not in SUPPORTED_ERROR_STATUSES:
+            raise StudioRuntimeClientError(
+                "studio_runtime_unexpected_status",
+                retryable=response.status >= 500,
+                status=response.status,
+            )
+        try:
+            envelope = RuntimeErrorEnvelope.model_validate(response.payload)
+        except ValidationError as error:
+            raise StudioRuntimeClientError(
+                "studio_runtime_error_invalid", retryable=False, status=response.status
+            ) from error
+        expected_codes = EXPECTED_ERROR_CODES.get(response.status)
+        if expected_codes is not None and envelope.error.code not in expected_codes:
+            raise StudioRuntimeClientError(
+                "studio_runtime_error_invalid", retryable=False, status=response.status
+            )
+        raise StudioRuntimeClientError(
+            envelope.error.code,
+            retryable=envelope.error.retryable,
+            status=response.status,
+        )

--- a/services/api_gateway/studio_runtime_client.py
+++ b/services/api_gateway/studio_runtime_client.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import json
 import re
 from dataclasses import dataclass
 from typing import Any, Awaitable, Callable, Mapping, Protocol
@@ -181,7 +180,7 @@ class AiohttpRuntimeTransport:
             async with session.get(url, headers=headers) as response:
                 try:
                     payload = await response.json()
-                except (aiohttp.ContentTypeError, json.JSONDecodeError, ValueError):
+                except (aiohttp.ContentTypeError, ValueError):
                     raise StudioRuntimeClientError(
                         "studio_runtime_response_invalid", retryable=False, status=response.status
                     ) from None
@@ -222,14 +221,7 @@ class StudioRuntimeClient:
         self._timeout_seconds = timeout_seconds
 
     async def fetch(self, tenant_id: str, correlation_id: str) -> RuntimeConfiguration:
-        if not tenant_id or len(tenant_id) > 128:
-            raise ValueError("tenant_id must contain between 1 and 128 characters")
-        if (
-            not correlation_id
-            or len(correlation_id) > 128
-            or any(ord(character) < 32 or ord(character) > 126 for character in correlation_id)
-        ):
-            raise ValueError("correlation_id must be printable ASCII with at most 128 characters")
+        _validate_request_context(tenant_id, correlation_id)
 
         token = await self._token_provider()
         if not token:
@@ -281,3 +273,14 @@ class StudioRuntimeClient:
             retryable=envelope.error.retryable,
             status=response.status,
         )
+
+
+def _validate_request_context(tenant_id: str, correlation_id: str) -> None:
+    if not tenant_id or len(tenant_id) > 128:
+        raise ValueError("tenant_id must contain between 1 and 128 characters")
+    if (
+        not correlation_id
+        or len(correlation_id) > 128
+        or any(ord(character) < 32 or ord(character) > 126 for character in correlation_id)
+    ):
+        raise ValueError("correlation_id must be printable ASCII with at most 128 characters")

--- a/services/api_gateway/studio_runtime_client.py
+++ b/services/api_gateway/studio_runtime_client.py
@@ -25,6 +25,7 @@ REVISION_PATTERN = re.compile(r"^sha256:[0-9a-f]{64}$")
 LOCALE_PATTERN = re.compile(r"^[A-Za-z]{2,3}(?:-[A-Za-z0-9]{2,8}){0,2}$")
 SUPPORTED_ERROR_STATUSES = {400, 401, 403, 404, 409, 503}
 EXPECTED_ERROR_CODES = {
+    400: {"malformed_request"},
     401: {"service_authentication_invalid"},
     403: {"service_action_forbidden"},
     404: {"tenant_not_found"},

--- a/services/api_gateway/studio_runtime_client.py
+++ b/services/api_gateway/studio_runtime_client.py
@@ -241,10 +241,10 @@ class StudioRuntimeClient:
         if response.status == 200:
             try:
                 configuration = RuntimeConfiguration.model_validate(response.payload)
-            except ValidationError as error:
+            except ValidationError:
                 raise StudioRuntimeClientError(
                     "studio_runtime_response_invalid", retryable=False, status=200
-                ) from error
+                ) from None
             if configuration.tenant.id != tenant_id:
                 raise StudioRuntimeClientError(
                     "studio_runtime_tenant_mismatch", retryable=False, status=200
@@ -259,10 +259,10 @@ class StudioRuntimeClient:
             )
         try:
             envelope = RuntimeErrorEnvelope.model_validate(response.payload)
-        except ValidationError as error:
+        except ValidationError:
             raise StudioRuntimeClientError(
                 "studio_runtime_error_invalid", retryable=False, status=response.status
-            ) from error
+            ) from None
         expected_codes = EXPECTED_ERROR_CODES.get(response.status)
         if expected_codes is not None and envelope.error.code not in expected_codes:
             raise StudioRuntimeClientError(
@@ -276,8 +276,12 @@ class StudioRuntimeClient:
 
 
 def _validate_request_context(tenant_id: str, correlation_id: str) -> None:
-    if not tenant_id or len(tenant_id) > 128:
-        raise ValueError("tenant_id must contain between 1 and 128 characters")
+    if (
+        not tenant_id
+        or len(tenant_id) > 128
+        or any(ord(character) < 32 or ord(character) > 126 for character in tenant_id)
+    ):
+        raise ValueError("tenant_id must be printable ASCII with at most 128 characters")
     if (
         not correlation_id
         or len(correlation_id) > 128

--- a/services/api_gateway/studio_runtime_client.py
+++ b/services/api_gateway/studio_runtime_client.py
@@ -225,7 +225,7 @@ class StudioRuntimeClient:
         _validate_request_context(tenant_id, correlation_id)
 
         token = await self._token_provider()
-        if not token:
+        if not token or any(ord(character) < 32 or ord(character) > 126 for character in token):
             raise StudioRuntimeClientError("studio_runtime_token_invalid", retryable=False)
         headers = {
             "Authorization": f"Bearer {token}",

--- a/tests/test_studio_runtime_client.py
+++ b/tests/test_studio_runtime_client.py
@@ -1,0 +1,204 @@
+"""Contract and negative-path tests for the Studio Runtime Configuration V1 client."""
+
+from copy import deepcopy
+from typing import Any, Mapping
+
+import pytest
+
+from services.api_gateway.studio_runtime_client import (
+    RUNTIME_PATH,
+    RuntimeHttpResponse,
+    StudioRuntimeClient,
+    StudioRuntimeClientError,
+)
+
+REVISION = f"sha256:{'a' * 64}"
+
+
+def valid_configuration() -> dict[str, Any]:
+    return {
+        "contractVersion": "1.0",
+        "configurationRevision": REVISION,
+        "authorizationRevision": REVISION,
+        "tenant": {
+            "id": "tenant-kassel",
+            "displayName": "Kassel Test Municipality",
+            "timeZone": "Europe/Berlin",
+        },
+        "branding": {"logo": None, "icon": None},
+        "localization": {
+            "defaultLocale": "de-DE",
+            "locales": [
+                {
+                    "locale": "de-DE",
+                    "authenticatedHomeExplanationHtml": "<p>Authenticated</p>",
+                    "guestExplanationHtml": "<p>Guest</p>",
+                    "conversationContentStorageQuestionHtml": "<p>Store?</p>",
+                }
+            ],
+        },
+        "conversationContentStorage": {"mode": "ask"},
+    }
+
+
+class StubTransport:
+    def __init__(self, response: RuntimeHttpResponse) -> None:
+        self.response = response
+        self.calls: list[tuple[str, Mapping[str, str], float]] = []
+
+    async def get(
+        self, url: str, headers: Mapping[str, str], timeout_seconds: float
+    ) -> RuntimeHttpResponse:
+        self.calls.append((url, headers, timeout_seconds))
+        return self.response
+
+
+def client(response: RuntimeHttpResponse) -> tuple[StudioRuntimeClient, StubTransport]:
+    transport = StubTransport(response)
+
+    async def token_provider() -> str:
+        return "service-token"
+
+    return (
+        StudioRuntimeClient(
+            "https://studio.test", token_provider, transport=transport, timeout_seconds=2.0
+        ),
+        transport,
+    )
+
+
+@pytest.mark.asyncio
+async def test_accepts_valid_response_and_sends_fixed_contract_request() -> None:
+    runtime_client, transport = client(RuntimeHttpResponse(200, valid_configuration()))
+
+    configuration = await runtime_client.fetch("tenant-kassel", "correlation-1")
+
+    assert configuration.tenant.id == "tenant-kassel"
+    assert transport.calls == [
+        (
+            f"https://studio.test{RUNTIME_PATH}",
+            {
+                "Authorization": "Bearer service-token",
+                "X-Studio-Tenant-Id": "tenant-kassel",
+                "X-Correlation-Id": "correlation-1",
+            },
+            2.0,
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_accepts_unknown_optional_v1_fields() -> None:
+    payload = valid_configuration()
+    payload["optionalExtension"] = {"enabled": True}
+    payload["tenant"]["optionalTenantField"] = "value"
+    runtime_client, _ = client(RuntimeHttpResponse(200, payload))
+
+    configuration = await runtime_client.fetch("tenant-kassel", "correlation-1")
+
+    assert configuration.contract_version == "1.0"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        lambda payload: payload.update(configurationRevision="sha256:INVALID"),
+        lambda payload: payload.update(authorizationRevision="missing-prefix"),
+        lambda payload: payload.update(contractVersion="2.0"),
+        lambda payload: payload["tenant"].update(timeZone="Not/A-Timezone"),
+        lambda payload: payload["localization"].update(defaultLocale="en-US"),
+        lambda payload: payload["conversationContentStorage"].update(mode="unsupported"),
+    ],
+)
+async def test_rejects_invalid_known_contract_fields(mutate: Any) -> None:
+    payload = valid_configuration()
+    mutate(payload)
+    runtime_client, _ = client(RuntimeHttpResponse(200, payload))
+
+    with pytest.raises(StudioRuntimeClientError) as caught:
+        await runtime_client.fetch("tenant-kassel", "correlation-1")
+
+    assert caught.value.code == "studio_runtime_response_invalid"
+    assert caught.value.retryable is False
+
+
+@pytest.mark.asyncio
+async def test_rejects_tenant_mismatch() -> None:
+    payload = valid_configuration()
+    payload["tenant"]["id"] = "tenant-fulda"
+    runtime_client, _ = client(RuntimeHttpResponse(200, payload))
+
+    with pytest.raises(StudioRuntimeClientError) as caught:
+        await runtime_client.fetch("tenant-kassel", "correlation-1")
+
+    assert caught.value.code == "studio_runtime_tenant_mismatch"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("status", "code", "retryable"),
+    [
+        (400, "malformed_request", False),
+        (401, "service_authentication_invalid", False),
+        (403, "service_action_forbidden", False),
+        (404, "tenant_not_found", False),
+        (409, "ssf_tenant_not_ready", True),
+        (503, "runtime_configuration_unavailable", True),
+    ],
+)
+async def test_preserves_stable_error_retryability(status: int, code: str, retryable: bool) -> None:
+    payload = {
+        "contractVersion": "1.0",
+        "error": {
+            "code": code,
+            "message": "Runtime configuration is unavailable.",
+            "retryable": retryable,
+            "correlationId": "correlation-1",
+        },
+    }
+    runtime_client, _ = client(RuntimeHttpResponse(status, payload))
+
+    with pytest.raises(StudioRuntimeClientError) as caught:
+        await runtime_client.fetch("tenant-kassel", "correlation-1")
+
+    assert caught.value.code == code
+    assert caught.value.retryable is retryable
+    assert caught.value.status == status
+
+
+@pytest.mark.asyncio
+async def test_rejects_invalid_error_envelope_and_unexpected_status() -> None:
+    invalid_error_client, _ = client(RuntimeHttpResponse(404, {"error": "tenant secret"}))
+    unexpected_client, _ = client(RuntimeHttpResponse(502, {"secret": "do-not-expose"}))
+
+    with pytest.raises(StudioRuntimeClientError) as invalid_error:
+        await invalid_error_client.fetch("tenant-kassel", "correlation-1")
+    with pytest.raises(StudioRuntimeClientError) as unexpected:
+        await unexpected_client.fetch("tenant-kassel", "correlation-1")
+
+    assert str(invalid_error.value) == "studio_runtime_error_invalid"
+    assert str(unexpected.value) == "studio_runtime_unexpected_status"
+    assert unexpected.value.retryable is True
+
+
+@pytest.mark.asyncio
+async def test_rejects_disabled_storage_with_non_null_question() -> None:
+    payload = deepcopy(valid_configuration())
+    payload["conversationContentStorage"]["mode"] = "disabled"
+    runtime_client, _ = client(RuntimeHttpResponse(200, payload))
+
+    with pytest.raises(StudioRuntimeClientError) as caught:
+        await runtime_client.fetch("tenant-kassel", "correlation-1")
+
+    assert caught.value.code == "studio_runtime_response_invalid"
+
+
+def test_rejects_base_url_that_could_change_the_fixed_path() -> None:
+    async def token_provider() -> str:
+        return "service-token"
+
+    with pytest.raises(ValueError):
+        StudioRuntimeClient("https://studio.test/prefix", token_provider)
+    with pytest.raises(ValueError):
+        StudioRuntimeClient("https://user:secret@studio.test", token_provider)

--- a/tests/test_studio_runtime_client.py
+++ b/tests/test_studio_runtime_client.py
@@ -194,6 +194,16 @@ async def test_rejects_disabled_storage_with_non_null_question() -> None:
     assert caught.value.code == "studio_runtime_response_invalid"
 
 
+@pytest.mark.asyncio
+async def test_rejects_header_control_characters_before_transport() -> None:
+    runtime_client, transport = client(RuntimeHttpResponse(200, valid_configuration()))
+
+    with pytest.raises(ValueError):
+        await runtime_client.fetch("tenant-kassel\r\nX-Forged: true", "correlation-1")
+
+    assert transport.calls == []
+
+
 def test_rejects_base_url_that_could_change_the_fixed_path() -> None:
     async def token_provider() -> str:
         return "service-token"

--- a/tests/test_studio_runtime_client.py
+++ b/tests/test_studio_runtime_client.py
@@ -225,11 +225,11 @@ async def test_rejects_header_control_characters_before_transport() -> None:
 async def test_rejects_empty_service_token_before_transport() -> None:
     transport = StubTransport(RuntimeHttpResponse(200, valid_configuration()))
 
-    async def empty_token_provider() -> str:
+    async def invalid_token_provider() -> str:
         return ""
 
     runtime_client = StudioRuntimeClient(
-        "https://studio.test", empty_token_provider, transport=transport
+        "https://studio.test", invalid_token_provider, transport=transport
     )
 
     with pytest.raises(StudioRuntimeClientError) as caught:

--- a/tests/test_studio_runtime_client.py
+++ b/tests/test_studio_runtime_client.py
@@ -241,6 +241,25 @@ async def test_rejects_empty_service_token_before_transport() -> None:
 
 
 @pytest.mark.asyncio
+async def test_rejects_service_token_with_header_control_characters_before_transport() -> None:
+    transport = StubTransport(RuntimeHttpResponse(200, valid_configuration()))
+
+    async def invalid_token_provider() -> str:
+        return "service-token\r\nX-Forged: true"
+
+    runtime_client = StudioRuntimeClient(
+        "https://studio.test", invalid_token_provider, transport=transport
+    )
+
+    with pytest.raises(StudioRuntimeClientError) as caught:
+        await runtime_client.fetch("tenant-kassel", "correlation-1")
+
+    assert caught.value.code == "studio_runtime_token_invalid"
+    assert caught.value.retryable is False
+    assert transport.calls == []
+
+
+@pytest.mark.asyncio
 async def test_classifies_transport_timeout_as_retryable() -> None:
     class TimeoutTransport:
         async def get(

--- a/tests/test_studio_runtime_client.py
+++ b/tests/test_studio_runtime_client.py
@@ -221,6 +221,48 @@ async def test_rejects_header_control_characters_before_transport() -> None:
     assert transport.calls == []
 
 
+@pytest.mark.asyncio
+async def test_rejects_empty_service_token_before_transport() -> None:
+    transport = StubTransport(RuntimeHttpResponse(200, valid_configuration()))
+
+    async def empty_token_provider() -> str:
+        return ""
+
+    runtime_client = StudioRuntimeClient(
+        "https://studio.test", empty_token_provider, transport=transport
+    )
+
+    with pytest.raises(StudioRuntimeClientError) as caught:
+        await runtime_client.fetch("tenant-kassel", "correlation-1")
+
+    assert caught.value.code == "studio_runtime_token_invalid"
+    assert caught.value.retryable is False
+    assert transport.calls == []
+
+
+@pytest.mark.asyncio
+async def test_classifies_transport_timeout_as_retryable() -> None:
+    class TimeoutTransport:
+        async def get(
+            self, url: str, headers: Mapping[str, str], timeout_seconds: float
+        ) -> RuntimeHttpResponse:
+            raise TimeoutError("transport details")
+
+    async def token_provider() -> str:
+        return "service-token"
+
+    runtime_client = StudioRuntimeClient(
+        "https://studio.test", token_provider, transport=TimeoutTransport()
+    )
+
+    with pytest.raises(StudioRuntimeClientError) as caught:
+        await runtime_client.fetch("tenant-kassel", "correlation-1")
+
+    assert caught.value.code == "studio_runtime_network_error"
+    assert caught.value.retryable is True
+    assert caught.value.__cause__ is None
+
+
 def test_rejects_base_url_that_could_change_the_fixed_path() -> None:
     async def token_provider() -> str:
         return "service-token"

--- a/tests/test_studio_runtime_client.py
+++ b/tests/test_studio_runtime_client.py
@@ -170,14 +170,31 @@ async def test_preserves_stable_error_retryability(status: int, code: str, retry
 @pytest.mark.asyncio
 async def test_rejects_invalid_error_envelope_and_unexpected_status() -> None:
     invalid_error_client, _ = client(RuntimeHttpResponse(404, {"error": "tenant secret"}))
+    wrong_code_client, _ = client(
+        RuntimeHttpResponse(
+            400,
+            {
+                "contractVersion": "1.0",
+                "error": {
+                    "code": "unexpected_code",
+                    "message": "Unavailable.",
+                    "retryable": False,
+                    "correlationId": "correlation-1",
+                },
+            },
+        )
+    )
     unexpected_client, _ = client(RuntimeHttpResponse(502, {"secret": "do-not-expose"}))
 
     with pytest.raises(StudioRuntimeClientError) as invalid_error:
         await invalid_error_client.fetch("tenant-kassel", "correlation-1")
+    with pytest.raises(StudioRuntimeClientError) as wrong_code:
+        await wrong_code_client.fetch("tenant-kassel", "correlation-1")
     with pytest.raises(StudioRuntimeClientError) as unexpected:
         await unexpected_client.fetch("tenant-kassel", "correlation-1")
 
     assert str(invalid_error.value) == "studio_runtime_error_invalid"
+    assert str(wrong_code.value) == "studio_runtime_error_invalid"
     assert str(unexpected.value) == "studio_runtime_unexpected_status"
     assert unexpected.value.retryable is True
 


### PR DESCRIPTION
## Summary
- call the fixed Studio Runtime Configuration V1 path with canonical tenant and correlation headers
- validate known fields, both revisions, tenant identity, and cross-field semantics fail-closed
- accept optional V1 additions and preserve documented error retryability
- keep token acquisition and HTTP transport injectable

## Validation
- `pytest tests/test_studio_runtime_client.py -q` (18 passed)
- `mypy services/api_gateway/studio_runtime_client.py`
- `openspec validate add-studio-runtime-configuration-client --strict`

Closes #297