### PR TITLE
feat: integrate tenant-bound Studio runtime flow

### DIFF
--- a/docs/superpowers/plans/2026-09-09-studio-runtime-flow-mvp.md
+++ b/docs/superpowers/plans/2026-09-09-studio-runtime-flow-mvp.md
@@ -1,0 +1,208 @@
+# Studio Runtime Flow MVP Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Compose the existing Studio tenant, token, and V1-client foundations into a fail-closed runtime-configuration dependency for authenticated SSF work.
+
+**Architecture:** Add the signed authorization revision to the existing immutable tenant context. A new runtime-flow service calls the existing client, compares its response revision, and returns a validated value object. A FastAPI dependency resolves a safe correlation ID and exposes this object without a new endpoint.
+
+**Tech Stack:** Python 3.12, FastAPI dependencies, Pydantic, aiohttp, pytest, pytest-asyncio.
+
+**Spec:** `docs/superpowers/specs/2026-09-09-studio-runtime-flow-design.md`
+
+## Global Constraints
+
+- Derive runtime authorization only from validated `studio_tenant_id` and `ssf_authorization_revision` claims.
+- Do not modify the existing token-provider cache, Runtime Configuration V1 client, or client schemas.
+- Never accept a browser tenant selector or return fallback configuration.
+- The existing V1 client alone emits `X-Studio-Tenant-Id` and `X-Correlation-Id`.
+
+---
+
+### Task 1: Extend the trusted tenant context
+
+**Files:**
+- Modify: `services/api_gateway/tenant_context.py:31-53`
+- Test: `tests/test_tenant_context.py`
+
+**Interfaces:** Produces `StudioTenantContext(tenant_id: str, authorization_revision: str)` from validated `require_ssf_user` claims.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+def test_context_requires_a_signed_authorization_revision() -> None:
+    context = studio_tenant_context_from_claims(
+        {"studio_tenant_id": "tenant-kassel", "ssf_authorization_revision": REVISION}
+    )
+    assert context.authorization_revision == REVISION
+
+@pytest.mark.parametrize("revision", [None, "", "sha256:UPPERCASE"])
+def test_context_rejects_invalid_authorization_revisions(revision: object) -> None:
+    with pytest.raises(HTTPException):
+        studio_tenant_context_from_claims(
+            {"studio_tenant_id": "tenant-kassel", "ssf_authorization_revision": revision}
+        )
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_tenant_context.py -q`
+
+Expected: FAIL because `StudioTenantContext` has no `authorization_revision`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+@dataclass(frozen=True)
+class StudioTenantContext:
+    tenant_id: str
+    authorization_revision: str
+
+authorization_revision = claims.get("ssf_authorization_revision")
+if not isinstance(authorization_revision, str) or not REVISION_PATTERN.fullmatch(authorization_revision):
+    raise _invalid_tenant_claim()
+```
+
+Use the V1 SHA-256 format from `studio_runtime_client.REVISION_PATTERN` or a shared dependency-safe pattern. Reject legacy/conflicting claims.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_tenant_context.py -q`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+Commit `services/api_gateway/tenant_context.py` and `tests/test_tenant_context.py` with `feat: require Studio authorization revision`.
+
+### Task 2: Add the fail-closed runtime-flow service
+
+**Files:**
+- Create: `services/api_gateway/studio_runtime_flow.py`
+- Test: `tests/test_studio_runtime_flow.py`
+
+**Interfaces:** Consumes `StudioTenantContext`, `StudioRuntimeClient.fetch(tenant_id, correlation_id)`, and `RuntimeConfiguration`. Produces `ValidatedRuntimeConfiguration(context, configuration, correlation_id)` and `StudioRuntimeFlowError(code, retryable)`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+@pytest.mark.asyncio
+async def test_flow_returns_configuration_only_for_matching_revision() -> None:
+    flow = StudioRuntimeFlow(client=StubClient(configuration_for("tenant-kassel", REVISION)))
+    result = await flow.resolve(context("tenant-kassel", REVISION), "correlation-1")
+    assert result.configuration.tenant.id == "tenant-kassel"
+
+@pytest.mark.asyncio
+async def test_flow_rejects_mismatching_authorization_revision() -> None:
+    flow = StudioRuntimeFlow(client=StubClient(configuration_for("tenant-kassel", OTHER_REVISION)))
+    with pytest.raises(StudioRuntimeFlowError, match="studio_runtime_authorization_mismatch"):
+        await flow.resolve(context("tenant-kassel", REVISION), "correlation-1")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_studio_runtime_flow.py -q`
+
+Expected: FAIL because the module does not exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+@dataclass(frozen=True)
+class ValidatedRuntimeConfiguration:
+    context: StudioTenantContext
+    configuration: RuntimeConfiguration
+    correlation_id: str
+
+async def resolve(self, context: StudioTenantContext, correlation_id: str) -> ValidatedRuntimeConfiguration:
+    configuration = await self._client.fetch(context.tenant_id, correlation_id)
+    if not hmac.compare_digest(configuration.authorization_revision, context.authorization_revision):
+        raise StudioRuntimeFlowError("studio_runtime_authorization_mismatch", retryable=False)
+    return ValidatedRuntimeConfiguration(context, configuration, correlation_id)
+```
+
+Translate existing token/client errors into safe flow errors, without exception bodies or configuration fallback.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_studio_runtime_flow.py -q`
+
+Expected: PASS, including upstream failure and tenant-mismatch propagation.
+
+- [ ] **Step 5: Commit**
+
+Commit `services/api_gateway/studio_runtime_flow.py` and `tests/test_studio_runtime_flow.py` with `feat: add tenant-bound Studio runtime flow`.
+
+### Task 3: Expose the authenticated dependency and correlation behavior
+
+**Files:**
+- Modify: `services/api_gateway/studio_runtime_flow.py`
+- Test: `tests/test_studio_runtime_flow.py`
+
+**Interfaces:** Consumes `Request`, `require_studio_tenant_context`, and `StudioRuntimeFlow`. Produces a `require_validated_runtime_configuration` FastAPI dependency.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+def test_dependency_forwards_valid_correlation_id(client: TestClient) -> None:
+    response = client.get("/runtime-operation", headers={"X-Correlation-Id": "request-123"})
+    assert response.json()["correlation_id"] == "request-123"
+
+def test_dependency_generates_correlation_id_when_absent(client: TestClient) -> None:
+    response = client.get("/runtime-operation")
+    assert UUID(response.json()["correlation_id"])
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_studio_runtime_flow.py -q`
+
+Expected: FAIL because no dependency resolves the flow or correlation ID.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+async def require_validated_runtime_configuration(
+    request: Request,
+    context: Annotated[StudioTenantContext, Depends(require_studio_tenant_context)],
+) -> ValidatedRuntimeConfiguration:
+    correlation_id = request.headers.get("X-Correlation-Id") or str(uuid4())
+    return await runtime_flow_from_environment().resolve(context, correlation_id)
+```
+
+Validate supplied IDs before calling Studio and map unsafe input or runtime failures to safe `HTTPException` responses. Do not add a public route.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_studio_runtime_flow.py tests/test_tenant_context.py -q`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+Commit the flow module and tests with `feat: expose validated Studio runtime dependency`.
+
+### Task 4: Validate the change
+
+**Files:**
+- Modify: `openspec/changes/integrate-studio-runtime-flow/tasks.md`
+
+- [ ] **Step 1: Mark only completed task items**
+
+Update the OpenSpec checklist after its associated code and tests have passed.
+
+- [ ] **Step 2: Run focused verification**
+
+Run: `pytest tests/test_tenant_context.py tests/test_studio_runtime_flow.py tests/test_studio_runtime_client.py tests/test_studio_runtime_token.py -q`
+
+Expected: PASS.
+
+- [ ] **Step 3: Validate OpenSpec**
+
+Run: `openspec validate integrate-studio-runtime-flow --strict`
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit the completed checklist**
+
+Commit the completed OpenSpec checklist with `docs: complete Studio runtime flow change tasks`.

--- a/docs/superpowers/specs/2026-09-09-studio-runtime-flow-design.md
+++ b/docs/superpowers/specs/2026-09-09-studio-runtime-flow-design.md
@@ -1,0 +1,105 @@
+# Studio tenant-bound runtime flow design
+
+## Context
+
+Issue #298 integrates the Studio Runtime Configuration V1 consumer boundary in
+SSF. The contract terminology is fixed: the signed user-token claim is
+`studio_tenant_id`, the outbound header is `X-Studio-Tenant-Id`, the response
+identity is `tenant.id`, and SSF uses `tenant_id` internally. Browser input,
+query parameters, request bodies, and client state are not tenant trust
+boundaries.
+
+The foundations from #294--#297 are now present on `main`: the mock uses the
+canonical header, `StudioTenantContext` rejects browser-controlled tenant
+selectors, `StudioRuntimeTokenProvider` obtains service tokens, and
+`StudioRuntimeClient` validates V1 responses. Issue #298 therefore only wires
+these components together and adds the authorization-revision gate; it does
+not recreate their transport, caching, or schema logic.
+
+## Goals
+
+- Derive one trusted SSF tenant context from a validated Studio-issued user
+  token.
+- Reuse the existing service-token provider and V1 client to fetch the
+  tenant's validated configuration.
+- Compare the configuration `authorizationRevision` with the authenticated
+  user's `ssf_authorization_revision` claim and fail closed on absence or
+  mismatch.
+- Propagate a correlation ID to Studio and return the validated configuration
+  from one integration boundary for a later session or persistence slice.
+- Prove success, tenant isolation, revision mismatch, and upstream failures
+  with mock-backed integration tests.
+
+## Non-goals
+
+- Conversation-content persistence or consent enforcement.
+- Changes to the existing runtime client, token-provider cache, or V1 schema
+  validation.
+- Guest tenant resolution, production Keycloak-client provisioning, and UI
+  language-picker changes.
+
+## Architecture
+
+The gateway owns the trust boundary. Its authentication dependency validates
+the user JWT and constructs an immutable `TenantContext(tenant_id,
+authorization_revision)`. It rejects a missing, malformed, or non-string
+`studio_tenant_id` and a missing or non-string `ssf_authorization_revision`.
+No route accepts a tenant selector as an alternative identity source.
+
+`StudioTenantContext` is extended with `authorization_revision`, derived only
+from the validated `ssf_authorization_revision` claim. A missing, malformed,
+or conflicting claim rejects the tenant-bound operation before Studio is
+called. The existing `StudioRuntimeTokenProvider.get_token` is passed directly
+to the existing `StudioRuntimeClient`.
+
+A small `StudioRuntimeFlow` integration service receives a
+`StudioTenantContext`, correlation ID, and configured client. It calls
+`StudioRuntimeClient.fetch(tenant_id, correlation_id)`, compares the returned
+`authorizationRevision` with the context value using a constant-time string
+comparison, and returns a `ValidatedRuntimeConfiguration`. This type contains
+the trusted context and the already validated client response. A FastAPI
+dependency constructs this object for future authenticated session and
+persistence endpoints; no new public endpoint or persistence behavior is
+introduced in this issue.
+
+## Request flow
+
+1. The gateway validates the bearer JWT signature, issuer, audience, and
+   required SSF role.
+2. It derives `TenantContext` exclusively from `studio_tenant_id` and
+   `ssf_authorization_revision` claims.
+3. The runtime-flow dependency accepts a valid incoming correlation ID or
+   generates a UUID correlation ID, then forwards it to the Studio client.
+4. The existing token provider supplies the service token; the existing runtime
+   client sends it with `X-Studio-Tenant-Id: TenantContext.tenant_id`.
+5. The client validates the successful V1 response and confirms
+   `tenant.id == tenant_id`.
+6. The integration service confirms the authorization revisions match, then
+   returns `ValidatedRuntimeConfiguration` to downstream code.
+
+## Error handling
+
+Every failure is fail-closed. Missing or conflicting identity claims result in
+an authentication/authorization failure before Studio is called. Token
+acquisition, transport, malformed response, Studio error envelope, tenant
+mismatch, missing revision, and revision mismatch result in a stable gateway
+error with the correlation ID, never a default configuration. Diagnostics use
+classified codes and redact bearer tokens, client secrets, and upstream
+response fields that could contain sensitive material.
+
+## Testing
+
+Focused tests extend tenant-context claim parsing for
+`ssf_authorization_revision` and exercise the integration service with the
+existing client/provider seams. Mock-backed integration tests demonstrate that
+a valid Kassel tenant receives Kassel configuration, a browser-provided Fulda
+tenant cannot alter that selection, a returned Fulda configuration for Kassel
+is rejected, and missing or mismatching authorization revisions are rejected.
+They also verify correlation-ID forwarding or generation and absence of a
+fallback configuration for one representative Studio failure.
+
+## Delivery note
+
+The current `main` branch includes the canonical mock correction and the
+tenant-context, token-provider, and runtime-client foundations. #298 should
+remain limited to their composition and revision gate.

--- a/openspec/changes/integrate-studio-runtime-flow/design.md
+++ b/openspec/changes/integrate-studio-runtime-flow/design.md
@@ -1,0 +1,32 @@
+## Context
+
+`StudioTenantContext`, `StudioRuntimeTokenProvider`, and
+`StudioRuntimeClient` already provide validated tenant identity, service-token
+acquisition, and a strict V1 client. This change establishes their single
+composition boundary.
+
+## Goals / Non-Goals
+
+- Goals: fail-closed authorization-revision verification, canonical tenant
+  propagation, correlation handling, and a reusable authenticated dependency.
+- Non-Goals: changing token caching, client schema validation, conversation
+  persistence, guest resolution, configuration caching, or a new public API.
+
+## Decisions
+
+- Add `authorization_revision` to the frozen tenant context and require a
+  valid `ssf_authorization_revision` claim for runtime-bound requests.
+- A `StudioRuntimeFlow` calls the existing client and uses
+  `hmac.compare_digest` to compare authorization revisions.
+- The dependency preserves a printable `X-Correlation-Id` or generates a UUID
+  when absent; invalid supplied values are rejected before upstream access.
+- The returned `ValidatedRuntimeConfiguration` carries only the trusted
+  context, correlation ID, and existing validated configuration model.
+
+## Risks / Trade-offs
+
+- Requiring the new signed claim means tokens issued before the mapper update
+  cannot use tenant-bound operations; this is intentional fail-closed
+  behavior.
+- The dependency is introduced without attaching it to session endpoints, so
+  this change proves the boundary without expanding session scope.

--- a/openspec/changes/integrate-studio-runtime-flow/proposal.md
+++ b/openspec/changes/integrate-studio-runtime-flow/proposal.md
@@ -1,0 +1,27 @@
+# Change: Integrate the tenant-bound Studio runtime flow
+
+## Why
+
+SSF has the separate tenant-context, service-token, and Runtime Configuration
+V1 client foundations, but no composition boundary verifies that a validated
+user's authorization revision authorizes the returned tenant configuration.
+
+## What Changes
+
+- Extend the trusted tenant context with the signed
+  `ssf_authorization_revision` claim.
+- Add a small runtime-flow service that composes the existing token provider
+  and Runtime Configuration V1 client.
+- Forward or generate a correlation ID and compare configuration and token
+  authorization revisions before returning a validated result.
+- Expose that result via an authenticated FastAPI dependency for later session
+  and persistence work.
+- Add mock-backed positive and cross-tenant/authorization-revision negative
+  tests.
+
+## Impact
+
+- Affected specs: `studio-runtime-flow`, `studio-tenant-context`.
+- Affected code: API Gateway tenant context and a new runtime-flow module.
+- Existing `studio_runtime_token.py` and `studio_runtime_client.py` are
+  consumed unchanged.

--- a/openspec/changes/integrate-studio-runtime-flow/specs/studio-runtime-flow/spec.md
+++ b/openspec/changes/integrate-studio-runtime-flow/specs/studio-runtime-flow/spec.md
@@ -1,0 +1,47 @@
+## ADDED Requirements
+
+### Requirement: Tenant-bound runtime authorization gate
+
+For an authenticated tenant-bound runtime operation, SSF SHALL derive both
+`tenant_id` and `authorization_revision` only from the fully validated Studio
+user token, fetch the configuration through the existing V1 client, and return
+it only when its `tenant.id` and `authorizationRevision` match that trusted
+context.
+
+#### Scenario: Matching tenant and authorization revision
+
+- **WHEN** a validated token contains a valid `studio_tenant_id` and
+  `ssf_authorization_revision` and Studio returns matching V1 configuration
+- **THEN** SSF returns one validated runtime configuration bound to that tenant
+
+#### Scenario: Missing or mismatching authorization revision
+
+- **WHEN** the token has no valid `ssf_authorization_revision` or Studio
+  returns a different `authorizationRevision`
+- **THEN** SSF rejects the runtime operation
+- **AND THEN** it does not produce fallback configuration
+
+#### Scenario: Cross-tenant response
+
+- **WHEN** Studio returns a configuration whose `tenant.id` differs from the
+  trusted token tenant
+- **THEN** SSF rejects the runtime operation
+- **AND THEN** it does not apply the returned configuration
+
+### Requirement: Correlated reusable runtime dependency
+
+SSF SHALL provide authenticated downstream code with a reusable dependency
+that returns the validated runtime configuration and its correlation ID. It
+MUST forward a valid incoming `X-Correlation-Id` or generate one when absent.
+
+#### Scenario: Valid incoming correlation ID
+
+- **WHEN** an authenticated runtime operation supplies a valid correlation ID
+- **THEN** SSF forwards that value to Studio and returns it with the validated
+  configuration
+
+#### Scenario: Studio failure
+
+- **WHEN** the token provider or Studio client fails
+- **THEN** the dependency fails closed with a safe classified failure
+- **AND THEN** it does not return a fallback configuration

--- a/openspec/changes/integrate-studio-runtime-flow/tasks.md
+++ b/openspec/changes/integrate-studio-runtime-flow/tasks.md
@@ -1,23 +1,23 @@
 ## 1. Tenant authorization context
 
-- [ ] 1.1 Require and validate `ssf_authorization_revision` alongside the
+- [x] 1.1 Require and validate `ssf_authorization_revision` alongside the
   canonical signed tenant claim.
-- [ ] 1.2 Extend focused tenant-context tests for valid, missing, malformed,
+- [x] 1.2 Extend focused tenant-context tests for valid, missing, malformed,
   and conflicting authorization-revision claims.
 
 ## 2. Runtime-flow integration
 
-- [ ] 2.1 Add a small service that composes the existing token provider and
+- [x] 2.1 Add a small service that composes the existing token provider and
   Runtime Configuration V1 client without changing either component.
-- [ ] 2.2 Forward or generate correlation IDs and return one validated result
+- [x] 2.2 Forward or generate correlation IDs and return one validated result
   type for downstream dependencies.
-- [ ] 2.3 Reject authorization-revision mismatches and all upstream failures
+- [x] 2.3 Reject authorization-revision mismatches and all upstream failures
   without fallback configuration.
 
 ## 3. Gateway dependency and proof
 
-- [ ] 3.1 Expose the runtime-flow result through an authenticated FastAPI
+- [x] 3.1 Expose the runtime-flow result through an authenticated FastAPI
   dependency suitable for later session/persistence routes.
-- [ ] 3.2 Add mock-backed positive, cross-tenant, revision-mismatch, missing
+- [x] 3.2 Add mock-backed positive, cross-tenant, revision-mismatch, missing
   revision, correlation, and upstream-failure tests.
-- [ ] 3.3 Validate this OpenSpec change and the focused gateway test scope.
+- [x] 3.3 Validate this OpenSpec change and the focused gateway test scope.

--- a/openspec/changes/integrate-studio-runtime-flow/tasks.md
+++ b/openspec/changes/integrate-studio-runtime-flow/tasks.md
@@ -1,0 +1,23 @@
+## 1. Tenant authorization context
+
+- [ ] 1.1 Require and validate `ssf_authorization_revision` alongside the
+  canonical signed tenant claim.
+- [ ] 1.2 Extend focused tenant-context tests for valid, missing, malformed,
+  and conflicting authorization-revision claims.
+
+## 2. Runtime-flow integration
+
+- [ ] 2.1 Add a small service that composes the existing token provider and
+  Runtime Configuration V1 client without changing either component.
+- [ ] 2.2 Forward or generate correlation IDs and return one validated result
+  type for downstream dependencies.
+- [ ] 2.3 Reject authorization-revision mismatches and all upstream failures
+  without fallback configuration.
+
+## 3. Gateway dependency and proof
+
+- [ ] 3.1 Expose the runtime-flow result through an authenticated FastAPI
+  dependency suitable for later session/persistence routes.
+- [ ] 3.2 Add mock-backed positive, cross-tenant, revision-mismatch, missing
+  revision, correlation, and upstream-failure tests.
+- [ ] 3.3 Validate this OpenSpec change and the focused gateway test scope.

--- a/services/api_gateway/studio_runtime_flow.py
+++ b/services/api_gateway/studio_runtime_flow.py
@@ -3,12 +3,25 @@
 from __future__ import annotations
 
 import hmac
+import os
 from dataclasses import dataclass
-from typing import Protocol
+from functools import lru_cache
+from typing import Annotated, Protocol
+from uuid import uuid4
 
-from .studio_runtime_client import RuntimeConfiguration, StudioRuntimeClientError
-from .studio_runtime_token import StudioTokenError
-from .tenant_context import StudioTenantContext
+from fastapi import Depends, HTTPException, Request, status
+
+from .studio_runtime_client import (
+    RuntimeConfiguration,
+    StudioRuntimeClient,
+    StudioRuntimeClientError,
+)
+from .studio_runtime_token import (
+    StudioRuntimeTokenProvider,
+    StudioTokenConfig,
+    StudioTokenError,
+)
+from .tenant_context import StudioTenantContext, require_studio_tenant_context
 
 
 class RuntimeConfigurationFetcher(Protocol):
@@ -72,3 +85,56 @@ class StudioRuntimeFlow:
             configuration=configuration,
             correlation_id=correlation_id,
         )
+
+
+@lru_cache(maxsize=1)
+def runtime_flow_from_environment() -> StudioRuntimeFlow:
+    """Build the process-local runtime flow from explicit environment settings."""
+    base_url = os.getenv("STUDIO_RUNTIME_CONFIGURATION_BASE_URL", "").strip()
+    try:
+        token_provider = StudioRuntimeTokenProvider(StudioTokenConfig.from_env())
+        client = StudioRuntimeClient(base_url, token_provider.get_token)
+    except (StudioTokenError, ValueError):
+        raise StudioRuntimeFlowError(
+            "studio_runtime_configuration_invalid", retryable=False
+        ) from None
+    return StudioRuntimeFlow(client)
+
+
+async def require_validated_runtime_configuration(
+    request: Request,
+    context: Annotated[StudioTenantContext, Depends(require_studio_tenant_context)],
+) -> ValidatedRuntimeConfiguration:
+    """Resolve a tenant-bound runtime configuration for a later route dependency."""
+    correlation_id = _correlation_id(request)
+    try:
+        runtime_flow = runtime_flow_from_environment()
+        return await runtime_flow.resolve(context, correlation_id)
+    except StudioRuntimeFlowError as error:
+        raise HTTPException(
+            status_code=(
+                status.HTTP_503_SERVICE_UNAVAILABLE
+                if error.retryable
+                else status.HTTP_502_BAD_GATEWAY
+            ),
+            detail=error.code,
+        ) from None
+
+
+def _correlation_id(request: Request) -> str:
+    """Return a safe caller correlation ID or a gateway-generated UUID."""
+    correlation_id = request.headers.get("X-Correlation-Id")
+    if correlation_id is None:
+        return str(uuid4())
+    if (
+        not correlation_id
+        or len(correlation_id) > 128
+        or any(
+            ord(character) < 32 or ord(character) > 126 for character in correlation_id
+        )
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="A valid X-Correlation-Id is required when supplied",
+        )
+    return correlation_id

--- a/services/api_gateway/studio_runtime_flow.py
+++ b/services/api_gateway/studio_runtime_flow.py
@@ -1,0 +1,74 @@
+"""Tenant-bound composition for Studio Runtime Configuration V1."""
+
+from __future__ import annotations
+
+import hmac
+from dataclasses import dataclass
+from typing import Protocol
+
+from .studio_runtime_client import RuntimeConfiguration, StudioRuntimeClientError
+from .studio_runtime_token import StudioTokenError
+from .tenant_context import StudioTenantContext
+
+
+class RuntimeConfigurationFetcher(Protocol):
+    """The already validated Studio Runtime Configuration V1 client boundary."""
+
+    async def fetch(self, tenant_id: str, correlation_id: str) -> RuntimeConfiguration:
+        raise NotImplementedError
+
+
+class StudioRuntimeFlowError(RuntimeError):
+    """A safe, classified failure from the composed runtime flow."""
+
+    def __init__(self, code: str, *, retryable: bool) -> None:
+        super().__init__(code)
+        self.code = code
+        self.retryable = retryable
+
+
+@dataclass(frozen=True)
+class ValidatedRuntimeConfiguration:
+    """A Studio configuration bound to one validated SSF tenant context."""
+
+    context: StudioTenantContext
+    configuration: RuntimeConfiguration
+    correlation_id: str
+
+
+class StudioRuntimeFlow:
+    """Fetch Runtime Configuration V1 only for its validated tenant context."""
+
+    def __init__(self, client: RuntimeConfigurationFetcher) -> None:
+        self._client = client
+
+    async def resolve(
+        self,
+        context: StudioTenantContext,
+        correlation_id: str,
+    ) -> ValidatedRuntimeConfiguration:
+        """Return a configuration only when tenant and revision both match."""
+        try:
+            configuration = await self._client.fetch(context.tenant_id, correlation_id)
+        except (StudioRuntimeClientError, StudioTokenError) as error:
+            raise StudioRuntimeFlowError(
+                error.code, retryable=error.retryable
+            ) from None
+
+        if configuration.tenant.id != context.tenant_id:
+            raise StudioRuntimeFlowError(
+                "studio_runtime_tenant_mismatch", retryable=False
+            )
+        if not hmac.compare_digest(
+            configuration.authorization_revision,
+            context.authorization_revision,
+        ):
+            raise StudioRuntimeFlowError(
+                "studio_runtime_authorization_mismatch", retryable=False
+            )
+
+        return ValidatedRuntimeConfiguration(
+            context=context,
+            configuration=configuration,
+            correlation_id=correlation_id,
+        )

--- a/services/api_gateway/tenant_context.py
+++ b/services/api_gateway/tenant_context.py
@@ -11,6 +11,7 @@ from fastapi import Depends, HTTPException, Request, status
 from .auth import require_ssf_user
 
 _TENANT_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+_AUTHORIZATION_REVISION_PATTERN = re.compile(r"^sha256:[0-9a-f]{64}$")
 _LEGACY_CLAIM_NAMES = frozenset({"tenant_id", "studio_instance_id"})
 _SELECTOR_NAMES = frozenset(
     {
@@ -22,7 +23,9 @@ _SELECTOR_NAMES = frozenset(
         "instanceid",
     }
 )
-_SELECTOR_HEADER_NAMES = frozenset({"x-studio-instance-id", "x-studio-tenant-id", "x-tenant-id"})
+_SELECTOR_HEADER_NAMES = frozenset(
+    {"x-studio-instance-id", "x-studio-tenant-id", "x-tenant-id"}
+)
 
 
 @dataclass(frozen=True)
@@ -30,6 +33,7 @@ class StudioTenantContext:
     """One trusted tenant identity represented with SSF terminology."""
 
     tenant_id: str
+    authorization_revision: str
 
 
 def studio_tenant_context_from_claims(
@@ -43,7 +47,16 @@ def studio_tenant_context_from_claims(
     if not isinstance(tenant_id, str) or not _TENANT_ID_PATTERN.fullmatch(tenant_id):
         raise _invalid_tenant_claim()
 
-    return StudioTenantContext(tenant_id=tenant_id)
+    authorization_revision = claims.get("ssf_authorization_revision")
+    if not isinstance(
+        authorization_revision, str
+    ) or not _AUTHORIZATION_REVISION_PATTERN.fullmatch(authorization_revision):
+        raise _invalid_tenant_claim()
+
+    return StudioTenantContext(
+        tenant_id=tenant_id,
+        authorization_revision=authorization_revision,
+    )
 
 
 async def require_studio_tenant_context(
@@ -64,7 +77,9 @@ def _request_has_tenant_selector(request: Request, body: object) -> bool:
         return True
     if _has_selector_name(request.cookies.keys()):
         return True
-    if _SELECTOR_HEADER_NAMES.intersection(name.lower() for name in request.headers.keys()):
+    if _SELECTOR_HEADER_NAMES.intersection(
+        name.lower() for name in request.headers.keys()
+    ):
         return True
     return _contains_tenant_selector(body)
 
@@ -83,11 +98,15 @@ def _contains_tenant_selector(value: object) -> bool:
 
 
 def _has_selector_name(names: Iterable[object]) -> bool:
-    return any(isinstance(name, str) and name.lower() in _SELECTOR_NAMES for name in names)
+    return any(
+        isinstance(name, str) and name.lower() in _SELECTOR_NAMES for name in names
+    )
 
 
 async def _json_body(request: Request) -> object:
-    media_type = request.headers.get("content-type", "").partition(";")[0].strip().lower()
+    media_type = (
+        request.headers.get("content-type", "").partition(";")[0].strip().lower()
+    )
     if media_type != "application/json" and not media_type.endswith("+json"):
         return None
     try:

--- a/tests/test_studio_runtime_flow.py
+++ b/tests/test_studio_runtime_flow.py
@@ -1,5 +1,10 @@
 """Behavior tests for the tenant-bound Studio runtime integration."""
 
+import hashlib
+import json
+from collections.abc import Mapping
+from urllib.parse import urlsplit
+
 import pytest
 from fastapi import Depends, FastAPI
 from fastapi.testclient import TestClient
@@ -8,6 +13,8 @@ import services.api_gateway.studio_runtime_flow as runtime_flow_module
 from services.api_gateway.auth import require_ssf_user
 from services.api_gateway.studio_runtime_client import (
     RuntimeConfiguration,
+    RuntimeHttpResponse,
+    StudioRuntimeClient,
     StudioRuntimeClientError,
 )
 from services.api_gateway.studio_runtime_flow import (
@@ -16,7 +23,9 @@ from services.api_gateway.studio_runtime_flow import (
     ValidatedRuntimeConfiguration,
     require_validated_runtime_configuration,
 )
+from services.api_gateway.studio_runtime_token import StudioTokenError
 from services.api_gateway.tenant_context import StudioTenantContext
+from services.studio_mock.app import app as studio_mock_app
 
 REVISION = f"sha256:{'a' * 64}"
 OTHER_REVISION = f"sha256:{'b' * 64}"
@@ -114,6 +123,91 @@ async def test_preserves_safe_upstream_failure_without_a_configuration() -> None
 
     assert caught.value.code == "runtime_configuration_unavailable"
     assert caught.value.retryable is True
+
+
+@pytest.mark.asyncio
+async def test_preserves_safe_service_token_failure_without_a_configuration() -> None:
+    flow = StudioRuntimeFlow(
+        StubRuntimeClient(StudioTokenError("studio_token_network_error", retryable=True))
+    )
+
+    with pytest.raises(StudioRuntimeFlowError) as caught:
+        await flow.resolve(_context(), "correlation-1")
+
+    assert caught.value.code == "studio_token_network_error"
+    assert caught.value.retryable is True
+
+
+class MockStudioTransport:
+    """Run the V1 client against the local Studio mock at its HTTP boundary."""
+
+    def __init__(self) -> None:
+        self.client = TestClient(studio_mock_app)
+
+    async def get(
+        self,
+        url: str,
+        headers: Mapping[str, str],
+        timeout_seconds: float,
+    ) -> RuntimeHttpResponse:
+        response = self.client.get(urlsplit(url).path, headers=dict(headers))
+        return RuntimeHttpResponse(status=response.status_code, payload=response.json())
+
+
+def _mock_authorization_revision(tenant_id: str) -> str:
+    authorization = {
+        "permissions": ["ssf.runtime-configuration.read"],
+        "tenantId": tenant_id,
+    }
+    encoded = json.dumps(authorization, separators=(",", ":"), sort_keys=True).encode()
+    return f"sha256:{hashlib.sha256(encoded).hexdigest()}"
+
+
+@pytest.mark.asyncio
+async def test_mock_backed_flow_accepts_only_the_matching_tenant_revision() -> None:
+    tenant_id = "tenant-kassel"
+    authorization_revision = _mock_authorization_revision(tenant_id)
+
+    async def service_token() -> str:
+        return "studio-mock-authorized-token"
+
+    flow = StudioRuntimeFlow(
+        StudioRuntimeClient(
+            "http://studio-mock.test",
+            service_token,
+            transport=MockStudioTransport(),
+        )
+    )
+
+    result = await flow.resolve(
+        StudioTenantContext(tenant_id, authorization_revision),
+        "mock-flow-correlation",
+    )
+
+    assert result.configuration.tenant.id == tenant_id
+    assert result.configuration.authorization_revision == authorization_revision
+
+
+@pytest.mark.asyncio
+async def test_mock_backed_flow_rejects_a_token_revision_that_does_not_match() -> None:
+    async def service_token() -> str:
+        return "studio-mock-authorized-token"
+
+    flow = StudioRuntimeFlow(
+        StudioRuntimeClient(
+            "http://studio-mock.test",
+            service_token,
+            transport=MockStudioTransport(),
+        )
+    )
+
+    with pytest.raises(StudioRuntimeFlowError) as caught:
+        await flow.resolve(
+            StudioTenantContext("tenant-kassel", OTHER_REVISION),
+            "mock-flow-correlation",
+        )
+
+    assert caught.value.code == "studio_runtime_authorization_mismatch"
 
 
 class StubRuntimeFlow:

--- a/tests/test_studio_runtime_flow.py
+++ b/tests/test_studio_runtime_flow.py
@@ -1,0 +1,110 @@
+"""Behavior tests for the tenant-bound Studio runtime integration."""
+
+import pytest
+
+from services.api_gateway.studio_runtime_client import (
+    RuntimeConfiguration,
+    StudioRuntimeClientError,
+)
+from services.api_gateway.studio_runtime_flow import (
+    StudioRuntimeFlow,
+    StudioRuntimeFlowError,
+)
+from services.api_gateway.tenant_context import StudioTenantContext
+
+REVISION = f"sha256:{'a' * 64}"
+OTHER_REVISION = f"sha256:{'b' * 64}"
+
+
+def _configuration(tenant_id: str, authorization_revision: str) -> RuntimeConfiguration:
+    return RuntimeConfiguration.model_validate(
+        {
+            "contractVersion": "1.0",
+            "configurationRevision": REVISION,
+            "authorizationRevision": authorization_revision,
+            "tenant": {
+                "id": tenant_id,
+                "displayName": "Kassel Test Municipality",
+                "timeZone": "Europe/Berlin",
+            },
+            "branding": {"logo": None, "icon": None},
+            "localization": {
+                "defaultLocale": "de-DE",
+                "locales": [
+                    {
+                        "locale": "de-DE",
+                        "authenticatedHomeExplanationHtml": "<p>Authenticated</p>",
+                        "guestExplanationHtml": "<p>Guest</p>",
+                        "conversationContentStorageQuestionHtml": "<p>Store?</p>",
+                    }
+                ],
+            },
+            "conversationContentStorage": {"mode": "ask"},
+        }
+    )
+
+
+class StubRuntimeClient:
+    def __init__(self, outcome: RuntimeConfiguration | Exception) -> None:
+        self.outcome = outcome
+        self.requests: list[tuple[str, str]] = []
+
+    async def fetch(self, tenant_id: str, correlation_id: str) -> RuntimeConfiguration:
+        self.requests.append((tenant_id, correlation_id))
+        if isinstance(self.outcome, Exception):
+            raise self.outcome
+        return self.outcome
+
+
+def _context(tenant_id: str = "tenant-kassel") -> StudioTenantContext:
+    return StudioTenantContext(tenant_id=tenant_id, authorization_revision=REVISION)
+
+
+@pytest.mark.asyncio
+async def test_returns_configuration_only_when_tenant_and_revision_match() -> None:
+    client = StubRuntimeClient(_configuration("tenant-kassel", REVISION))
+    flow = StudioRuntimeFlow(client)
+
+    result = await flow.resolve(_context(), "correlation-1")
+
+    assert result.context == _context()
+    assert result.configuration.tenant.id == "tenant-kassel"
+    assert result.correlation_id == "correlation-1"
+    assert client.requests == [("tenant-kassel", "correlation-1")]
+
+
+@pytest.mark.asyncio
+async def test_rejects_configuration_with_a_different_tenant() -> None:
+    flow = StudioRuntimeFlow(StubRuntimeClient(_configuration("tenant-fulda", REVISION)))
+
+    with pytest.raises(StudioRuntimeFlowError) as caught:
+        await flow.resolve(_context(), "correlation-1")
+
+    assert caught.value.code == "studio_runtime_tenant_mismatch"
+    assert caught.value.retryable is False
+
+
+@pytest.mark.asyncio
+async def test_rejects_configuration_with_a_different_authorization_revision() -> None:
+    flow = StudioRuntimeFlow(StubRuntimeClient(_configuration("tenant-kassel", OTHER_REVISION)))
+
+    with pytest.raises(StudioRuntimeFlowError) as caught:
+        await flow.resolve(_context(), "correlation-1")
+
+    assert caught.value.code == "studio_runtime_authorization_mismatch"
+    assert caught.value.retryable is False
+
+
+@pytest.mark.asyncio
+async def test_preserves_safe_upstream_failure_without_a_configuration() -> None:
+    flow = StudioRuntimeFlow(
+        StubRuntimeClient(
+            StudioRuntimeClientError("runtime_configuration_unavailable", retryable=True)
+        )
+    )
+
+    with pytest.raises(StudioRuntimeFlowError) as caught:
+        await flow.resolve(_context(), "correlation-1")
+
+    assert caught.value.code == "runtime_configuration_unavailable"
+    assert caught.value.retryable is True

--- a/tests/test_studio_runtime_flow.py
+++ b/tests/test_studio_runtime_flow.py
@@ -1,7 +1,11 @@
 """Behavior tests for the tenant-bound Studio runtime integration."""
 
 import pytest
+from fastapi import Depends, FastAPI
+from fastapi.testclient import TestClient
 
+import services.api_gateway.studio_runtime_flow as runtime_flow_module
+from services.api_gateway.auth import require_ssf_user
 from services.api_gateway.studio_runtime_client import (
     RuntimeConfiguration,
     StudioRuntimeClientError,
@@ -9,6 +13,8 @@ from services.api_gateway.studio_runtime_client import (
 from services.api_gateway.studio_runtime_flow import (
     StudioRuntimeFlow,
     StudioRuntimeFlowError,
+    ValidatedRuntimeConfiguration,
+    require_validated_runtime_configuration,
 )
 from services.api_gateway.tenant_context import StudioTenantContext
 
@@ -108,3 +114,87 @@ async def test_preserves_safe_upstream_failure_without_a_configuration() -> None
 
     assert caught.value.code == "runtime_configuration_unavailable"
     assert caught.value.retryable is True
+
+
+class StubRuntimeFlow:
+    def __init__(self, outcome: ValidatedRuntimeConfiguration | Exception) -> None:
+        self.outcome = outcome
+        self.requests: list[tuple[StudioTenantContext, str]] = []
+
+    async def resolve(
+        self,
+        context: StudioTenantContext,
+        correlation_id: str,
+    ) -> ValidatedRuntimeConfiguration:
+        self.requests.append((context, correlation_id))
+        if isinstance(self.outcome, Exception):
+            raise self.outcome
+        return ValidatedRuntimeConfiguration(
+            context=context,
+            configuration=self.outcome.configuration,
+            correlation_id=correlation_id,
+        )
+
+
+def _dependency_client(
+    monkeypatch: pytest.MonkeyPatch,
+    runtime_flow: StubRuntimeFlow,
+) -> TestClient:
+    app = FastAPI()
+    app.dependency_overrides[require_ssf_user] = lambda: {
+        "sub": "user-1",
+        "studio_tenant_id": "tenant-kassel",
+        "ssf_authorization_revision": REVISION,
+    }
+    monkeypatch.setattr(runtime_flow_module, "runtime_flow_from_environment", lambda: runtime_flow)
+
+    @app.get("/runtime-operation")
+    async def runtime_operation(
+        result: ValidatedRuntimeConfiguration = Depends(require_validated_runtime_configuration),
+    ) -> dict[str, str]:
+        return {
+            "tenant_id": result.context.tenant_id,
+            "correlation_id": result.correlation_id,
+        }
+
+    return TestClient(app)
+
+
+def test_dependency_forwards_valid_correlation_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    context = _context()
+    flow = StubRuntimeFlow(
+        ValidatedRuntimeConfiguration(context, _configuration("tenant-kassel", REVISION), "unused")
+    )
+
+    response = _dependency_client(monkeypatch, flow).get(
+        "/runtime-operation", headers={"X-Correlation-Id": "request-123"}
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"tenant_id": "tenant-kassel", "correlation_id": "request-123"}
+    assert flow.requests == [(context, "request-123")]
+
+
+def test_dependency_generates_correlation_id_when_absent(monkeypatch: pytest.MonkeyPatch) -> None:
+    context = _context()
+    flow = StubRuntimeFlow(
+        ValidatedRuntimeConfiguration(context, _configuration("tenant-kassel", REVISION), "unused")
+    )
+
+    response = _dependency_client(monkeypatch, flow).get("/runtime-operation")
+
+    assert response.status_code == 200
+    correlation_id = response.json()["correlation_id"]
+    assert len(correlation_id) == 36
+    assert flow.requests == [(context, correlation_id)]
+
+
+def test_dependency_returns_safe_error_without_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    flow = StubRuntimeFlow(
+        StudioRuntimeFlowError("runtime_configuration_unavailable", retryable=True)
+    )
+
+    response = _dependency_client(monkeypatch, flow).get("/runtime-operation")
+
+    assert response.status_code == 503
+    assert response.json() == {"detail": "runtime_configuration_unavailable"}

--- a/tests/test_tenant_context.py
+++ b/tests/test_tenant_context.py
@@ -11,13 +11,21 @@ from services.api_gateway.tenant_context import (
     studio_tenant_context_from_claims,
 )
 
+REVISION = f"sha256:{'a' * 64}"
+
 
 def test_canonical_validated_claim_creates_one_internal_tenant_context() -> None:
     context = studio_tenant_context_from_claims(
-        {"sub": "user-1", "studio_tenant_id": "tenant-kassel"}
+        {
+            "sub": "user-1",
+            "studio_tenant_id": "tenant-kassel",
+            "ssf_authorization_revision": REVISION,
+        }
     )
 
-    assert context == StudioTenantContext(tenant_id="tenant-kassel")
+    assert context == StudioTenantContext(
+        tenant_id="tenant-kassel", authorization_revision=REVISION
+    )
 
 
 @pytest.mark.parametrize(
@@ -30,6 +38,12 @@ def test_canonical_validated_claim_creates_one_internal_tenant_context() -> None
         {"tenant_id": "tenant-kassel"},
         {"studio_instance_id": "tenant-kassel"},
         {"studio_tenant_id": "tenant-kassel", "tenant_id": "tenant-berlin"},
+        {"studio_tenant_id": "tenant-kassel"},
+        {"studio_tenant_id": "tenant-kassel", "ssf_authorization_revision": ""},
+        {
+            "studio_tenant_id": "tenant-kassel",
+            "ssf_authorization_revision": "sha256:UPPERCASE",
+        },
     ],
 )
 def test_missing_malformed_or_legacy_claims_fail_closed(claims: dict[str, Any]) -> None:
@@ -44,6 +58,7 @@ def _tenant_test_client() -> TestClient:
     app.dependency_overrides[require_ssf_user] = lambda: {
         "sub": "user-1",
         "studio_tenant_id": "tenant-kassel",
+        "ssf_authorization_revision": REVISION,
     }
 
     @app.api_route("/tenant-operation", methods=["GET", "POST"])


### PR DESCRIPTION
## Description

Implements the MVP integration gate for SSF #298. Authenticated tenant-bound runtime work now derives both tenant identity and authorization revision from validated Studio-issued claims, retrieves the V1 configuration through the existing client, and returns it only when both bindings match.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 📝 Documentation update
- [x] ✅ Test update
- [x] 🔒 Security fix

## Related Issues

Closes #298

## Changes Made

- Require a signed `ssf_authorization_revision` alongside `studio_tenant_id` in the immutable tenant context.
- Add a fail-closed runtime-flow service that composes the existing Studio token provider and V1 client, verifies tenant and authorization-revision binding, and returns no fallback configuration.
- Provide an authenticated FastAPI dependency that forwards a valid `X-Correlation-Id` or generates one when absent.
- Add mock-backed success/revision-mismatch coverage plus tenant, upstream-failure, and dependency tests.
- Add the approved OpenSpec change and MVP design/implementation plan.

## Testing

### Test Coverage

- [x] All existing tests pass (`pytest`)
- [x] New tests added for this change
- [x] Manual testing completed
- [x] Integration tests pass
- [ ] Load tests pass (if applicable)

### How to Test

```bash
pytest tests/test_tenant_context.py \
       tests/test_studio_runtime_flow.py \
       tests/test_studio_runtime_client.py \
       tests/test_studio_runtime_token.py -q
openspec validate integrate-studio-runtime-flow --strict
```

The full `pytest -q` suite was also run in a temporary virtual environment with the pinned OpenTelemetry dependencies installed; the source worktree and dependency files were unchanged.

## Checklist

### Code Quality

- [x] Code follows the project's style guidelines
- [x] Self-review of code completed
- [x] Code is commented where necessary
- [x] No new warnings generated
- [x] Pre-commit hooks pass

### Testing

- [x] Tests added/updated for new functionality
- [x] All tests pass locally
- [x] Test coverage maintained or improved

### Documentation

- [x] Documentation updated (README, docs/, docstrings)
- [ ] API documentation updated (not applicable; no public endpoint)
- [ ] CHANGELOG.md updated (not applicable)
- [ ] Migration guide added (not applicable; fail-closed claim requirement is documented in OpenSpec)

### Dependencies

- [x] No new dependencies added
- [ ] OR: New dependencies justified and documented
- [x] requirements.txt / requirements-dev.txt updated (not applicable)

### Security

- [x] No sensitive data exposed
- [x] Security best practices followed
- [x] Input validation added where needed

## Performance Impact

- [x] No performance impact

## Breaking Changes

Tenant-bound runtime operations now require the signed `ssf_authorization_revision` token claim and fail closed when it is absent or malformed. Studio token issuance must include this claim before routes adopt the new dependency.

## Deployment Notes

- [x] Requires configuration changes
- [x] Requires service restart

Configure `STUDIO_RUNTIME_CONFIGURATION_BASE_URL` plus the existing Studio runtime token settings (or `STUDIO_RUNTIME_FIXED_TOKEN` for the local mock). Ensure the Studio user-token mapper emits `ssf_authorization_revision` before attaching this dependency to production routes.