### PR TITLE
fix(cors): accept the configured HTTPS frontend origin

### DIFF
--- a/docs/DEVELOPER_GUIDE.en.md
+++ b/docs/DEVELOPER_GUIDE.en.md
@@ -265,7 +265,7 @@ Variable groups currently interpolated by Compose include:
 In the current Compose stack, `REDIS_URL`, `REDIS_NAMESPACE`, and `CLIENT_BASE_URL` are assigned in `docker-compose.yml` rather than interpolated from `.env`. The `AUDIO_*` variables are likewise documented and passed by Compose, but the gateway currently reads only `SSF_AUDIO_BASE_DIR`; it uses a fixed 24-hour retention period and an hourly cleanup interval. Do not rely on `.env` changes to the `AUDIO_*` variables to change runtime audio-storage behaviour. The following values document those fixed settings:
 
 - `REDIS_URL` and `REDIS_NAMESPACE` for session storage.
-- `CLIENT_BASE_URL` for generated customer links.
+- `CLIENT_BASE_URL` for generated customer links and one additional exact production browser origin for HTTP CORS and WebSocket connections. For a standalone frontend, set it to an HTTPS origin such as `https://dialog.kassel.de` in the effective API container environment. Credentials, wildcard hosts, paths other than `/`, query strings, and fragments are not accepted as browser origins. Existing production origins remain available; an unset or invalid value adds no origin. Configure the frontend Keycloak URL and the Keycloak client redirect URIs separately.
 
 Pull the optional refinement model after the stack starts:
 

--- a/services/api_gateway/app.py
+++ b/services/api_gateway/app.py
@@ -19,6 +19,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from prometheus_client import CollectorRegistry, Counter
 
+from .client_origin import configured_client_origin
 from .pipeline_admission import (
     PipelineAdmission,
     PipelineAdmissionConfig,
@@ -450,7 +451,8 @@ def setup_cors_for_websockets():
         allow_origin_regex = None
     else:
         # Production: strict validation
-        allow_origins = []
+        client_origin = configured_client_origin()
+        allow_origins = [client_origin] if client_origin else []
         allow_origin_regex = production_pattern
 
     app.add_middleware(

--- a/services/api_gateway/client_origin.py
+++ b/services/api_gateway/client_origin.py
@@ -1,0 +1,30 @@
+"""Exact additional browser origin for a standalone SSF frontend."""
+
+import os
+from urllib.parse import urlsplit
+
+
+def configured_client_origin() -> str | None:
+    """Accept an HTTPS CLIENT_BASE_URL without credentials, query or fragment."""
+    value = os.environ.get("CLIENT_BASE_URL", "").strip()
+    try:
+        url = urlsplit(value)
+        if (
+            url.scheme != "https"
+            or not url.hostname
+            or url.username is not None
+            or url.password is not None
+            or url.path not in ("", "/")
+            or url.query
+            or url.fragment
+            or any(char.isspace() for char in value)
+            or "*" in value
+        ):
+            return None
+        # Accessing port validates malformed and out-of-range values.
+        port = url.port
+    except ValueError:
+        return None
+    hostname = f"[{url.hostname}]" if ":" in url.hostname else url.hostname
+    authority = f"{hostname}:{port}" if port not in (None, 443) else hostname
+    return f"https://{authority}"

--- a/services/api_gateway/websocket.py
+++ b/services/api_gateway/websocket.py
@@ -29,6 +29,7 @@ from fastapi import (
     WebSocketDisconnect,
 )
 
+from .client_origin import configured_client_origin
 from .log_safety import sanitize_log_value
 from .session_manager import ClientType, SessionManager, SessionStatus
 from .websocket_fallback import FallbackReason, fallback_manager
@@ -88,6 +89,9 @@ async def validate_websocket_origin(origin: Optional[str]) -> bool:
     # Production environment - strict validation
     if not origin:
         return False  # Reject connections without Origin header in production
+
+    if origin == configured_client_origin():
+        return True
 
     # ✅ FIX: Korrektes Regex-Pattern (* → .*)
     production_pattern = r"https://.*\.figma\.site|https://.*\.smart-village\.solutions"

--- a/services/api_gateway/websocket.py
+++ b/services/api_gateway/websocket.py
@@ -95,7 +95,7 @@ async def validate_websocket_origin(origin: Optional[str]) -> bool:
 
     # ✅ FIX: Korrektes Regex-Pattern (* → .*)
     production_pattern = r"https://.*\.figma\.site|https://.*\.smart-village\.solutions"
-    return bool(re.match(production_pattern, origin))
+    return bool(re.fullmatch(production_pattern, origin))
 
 
 # RFC 6455 close codes, mapped onto the wire reasons DisconnectReason.from_wire

--- a/tests/test_client_origin.py
+++ b/tests/test_client_origin.py
@@ -1,0 +1,84 @@
+"""Configured production frontend origins must match exactly in HTTP and WS."""
+
+import importlib
+
+import pytest
+from starlette.middleware.cors import CORSMiddleware
+
+from services.api_gateway.client_origin import configured_client_origin
+from services.api_gateway.websocket import validate_websocket_origin
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "",
+        "http://dialog.kassel.de",
+        "https://*.kassel.de",
+        "https://user:password@dialog.kassel.de",
+        "https://dialog.kassel.de/path",
+        "https://dialog.kassel.de?query",
+        "https://dialog.kassel.de#fragment",
+        "https://dialog.kassel.de:99999",
+        "https://dialog.kassel.de:bad",
+        "https://[invalid",
+        "https://dia\tlog.kassel.de",
+    ],
+)
+def test_invalid_client_origin_is_not_allowed(monkeypatch, value):
+    monkeypatch.setenv("CLIENT_BASE_URL", value)
+    assert configured_client_origin() is None
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("https://Dialog.Kassel.de/", "https://dialog.kassel.de"),
+        ("https://dialog.kassel.de:443", "https://dialog.kassel.de"),
+        ("https://dialog.kassel.de:8443", "https://dialog.kassel.de:8443"),
+    ],
+)
+def test_client_origin_normalization(monkeypatch, value, expected):
+    monkeypatch.setenv("CLIENT_BASE_URL", value)
+    assert configured_client_origin() == expected
+
+
+@pytest.mark.asyncio
+async def test_production_http_and_websocket_use_exact_configured_origin(monkeypatch):
+    app_module = importlib.import_module("services.api_gateway.app")
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setenv("CLIENT_BASE_URL", "https://dialog.kassel.de/")
+    captured = {}
+    monkeypatch.setattr(
+        app_module.app, "add_middleware", lambda cls, **kwargs: captured.update(kwargs)
+    )
+    app_module.setup_cors_for_websockets()
+    cors = CORSMiddleware(app_module.app, **captured)
+    for origin, allowed in [
+        ("https://dialog.kassel.de", True),
+        ("https://translate.smart-village.solutions", True),
+        ("https://evil.dialog.kassel.de", False),
+        ("https://dialog.kassel.de.evil.invalid", False),
+        ("https://dialog.kassel.de:8443", False),
+        ("http://dialog.kassel.de", False),
+    ]:
+        assert cors.is_allowed_origin(origin) is allowed
+        assert await validate_websocket_origin(origin) is allowed
+    assert await validate_websocket_origin(None) is False
+
+
+@pytest.mark.asyncio
+async def test_unconfigured_origin_keeps_existing_production_defaults(monkeypatch):
+    app_module = importlib.import_module("services.api_gateway.app")
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.delenv("CLIENT_BASE_URL", raising=False)
+    captured = {}
+    monkeypatch.setattr(
+        app_module.app, "add_middleware", lambda cls, **kwargs: captured.update(kwargs)
+    )
+    app_module.setup_cors_for_websockets()
+    cors = CORSMiddleware(app_module.app, **captured)
+    assert not cors.is_allowed_origin("https://dialog.kassel.de")
+    assert not await validate_websocket_origin("https://dialog.kassel.de")
+    assert cors.is_allowed_origin("https://translate.smart-village.solutions")
+    assert await validate_websocket_origin("https://translate.smart-village.solutions")

--- a/tests/test_client_origin.py
+++ b/tests/test_client_origin.py
@@ -59,6 +59,8 @@ async def test_production_http_and_websocket_use_exact_configured_origin(monkeyp
         ("https://translate.smart-village.solutions", True),
         ("https://evil.dialog.kassel.de", False),
         ("https://dialog.kassel.de.evil.invalid", False),
+        ("https://translate.smart-village.solutions.evil.invalid", False),
+        ("https://example.figma.site.evil.invalid", False),
         ("https://dialog.kassel.de:8443", False),
         ("http://dialog.kassel.de", False),
     ]:
@@ -82,3 +84,13 @@ async def test_unconfigured_origin_keeps_existing_production_defaults(monkeypatc
     assert not await validate_websocket_origin("https://dialog.kassel.de")
     assert cors.is_allowed_origin("https://translate.smart-village.solutions")
     assert await validate_websocket_origin("https://translate.smart-village.solutions")
+
+
+@pytest.mark.asyncio
+async def test_existing_websocket_subdomain_policy_is_preserved(monkeypatch):
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.delenv("CLIENT_BASE_URL", raising=False)
+    assert await validate_websocket_origin("https://existing.smart-village.solutions")
+    assert not await validate_websocket_origin(
+        "https://existing.smart-village.solutions.evil.invalid"
+    )


### PR DESCRIPTION
Production HTTP CORS and WebSocket validation currently reject a standalone frontend at `https://dialog.kassel.de`, even when `CLIENT_BASE_URL` points there. Use that existing setting as one additional exact HTTPS origin while preserving the established production defaults.

The shared parser rejects credentials, wildcard hosts, non-root paths, query strings, fragments and invalid ports. HTTP and WebSocket consumers use the same parsed origin. This does not change authentication or authorize subdomains of the configured frontend.

Validation: `pytest -q tests/test_client_origin.py` (16 passed), Black and isort checks for the new files, and `git diff --check`. Tests exercise both production consumers, absent configuration, deceptive sibling hosts, protocol/port differences and malformed settings.

Deployment context: companion to smart-village-solutions/sva-studio#1298 for the standalone SSF installation. Only this bounded patch is intended for a derivative of the installed API image; unrelated changes on SSF main are outside that rollout.
