### PR TITLE
feat: add Studio-backed tenant login directory

### DIFF
--- a/deploy/production/docker-compose.production.yml
+++ b/deploy/production/docker-compose.production.yml
@@ -114,9 +114,15 @@ services:
     - MESSAGE_RATE_WINDOW_SECONDS=${MESSAGE_RATE_WINDOW_SECONDS:-10}
     - ENVIRONMENT=${ENVIRONMENT:-production}
     - DEVELOPMENT_CORS_ORIGINS=${DEVELOPMENT_CORS_ORIGINS:-http://localhost:5173,http://localhost:5174}
-    - KEYCLOAK_ISSUER=${KEYCLOAK_ISSUER:-https://auth.kassel.smartspeechflow.de/realms/ssf}
+    - KEYCLOAK_BASE_URL=${KEYCLOAK_BASE_URL:-https://auth.dialog.kassel.de}
     - KEYCLOAK_AUDIENCE=${KEYCLOAK_AUDIENCE:-ssf-frontend}
     - KEYCLOAK_REQUIRED_ROLE=${KEYCLOAK_REQUIRED_ROLE:-ssf-user}
+    - STUDIO_RUNTIME_CONFIGURATION_BASE_URL=${STUDIO_RUNTIME_CONFIGURATION_BASE_URL:-https://studio.dialog.kassel.de}
+    - STUDIO_RUNTIME_TOKEN_URL=${STUDIO_RUNTIME_TOKEN_URL:?required}
+    - STUDIO_RUNTIME_CLIENT_ID=${STUDIO_RUNTIME_CLIENT_ID:-ssf-runtime}
+    - STUDIO_RUNTIME_AUDIENCE=${STUDIO_RUNTIME_AUDIENCE:-sva-studio-ssf-runtime}
+    - STUDIO_RUNTIME_CLIENT_SECRET=${STUDIO_RUNTIME_CLIENT_SECRET:?required}
+    - STUDIO_LOGIN_DIRECTORY_CACHE_SECONDS=${STUDIO_LOGIN_DIRECTORY_CACHE_SECONDS:-60}
     - SSF_ENABLE_LEGACY_ADMIN_ACCESS=${SSF_ENABLE_LEGACY_ADMIN_ACCESS:-false}
     - SSF_LEGACY_ADMIN_ACCESS_CODE=${SSF_LEGACY_ADMIN_ACCESS_CODE:-}
     - SSF_QUALITY_TELEMETRY_MODE=${SSF_QUALITY_TELEMETRY_MODE:-disabled}
@@ -252,7 +258,6 @@ services:
     command:
     - start
     - --optimized
-    - --import-realm
     restart: unless-stopped
     expose:
     - '8080'
@@ -268,8 +273,6 @@ services:
       KC_PROXY_HEADERS: xforwarded
       KC_HTTP_ENABLED: 'true'
       KC_HEALTH_ENABLED: 'true'
-    volumes:
-    - ./keycloak/ssf-realm.json:/opt/keycloak/data/import/ssf-realm.json:ro
     depends_on:
       keycloak-postgres:
         condition: service_healthy

--- a/deploy/production/docker-compose.production.yml
+++ b/deploy/production/docker-compose.production.yml
@@ -90,7 +90,7 @@ services:
     environment:
     - REDIS_URL=redis://redis:6379/0
     - REDIS_NAMESPACE=ssf
-    - CLIENT_BASE_URL=https://translate.smart-village.solutions
+    - CLIENT_BASE_URL=https://dialog.kassel.de
     - AUDIO_STORAGE_PATH=/data/audio
     - AUDIO_RETENTION_HOURS=24
     - AUDIO_TEMP_PATH=/tmp/audio
@@ -269,7 +269,7 @@ services:
       KC_DB_PASSWORD: ${KEYCLOAK_DB_PASSWORD:?required}
       KC_BOOTSTRAP_ADMIN_USERNAME: ${KEYCLOAK_BOOTSTRAP_ADMIN_USERNAME:?required}
       KC_BOOTSTRAP_ADMIN_PASSWORD: ${KEYCLOAK_BOOTSTRAP_ADMIN_PASSWORD:?required}
-      KC_HOSTNAME: https://auth.kassel.smartspeechflow.de
+      KC_HOSTNAME: https://auth.dialog.kassel.de
       KC_PROXY_HEADERS: xforwarded
       KC_HTTP_ENABLED: 'true'
       KC_HEALTH_ENABLED: 'true'
@@ -287,7 +287,7 @@ services:
       start_period: 60s
     labels:
     - traefik.enable=true
-    - traefik.http.routers.keycloak.rule=Host(`auth.kassel.smartspeechflow.de`)
+    - traefik.http.routers.keycloak.rule=Host(`auth.dialog.kassel.de`)
     - traefik.http.routers.keycloak.entrypoints=websecure
     - traefik.http.routers.keycloak.tls.certresolver=le
     - traefik.http.services.keycloak.loadbalancer.server.port=8080
@@ -308,7 +308,7 @@ services:
     - default
     labels:
     - traefik.enable=true
-    - traefik.http.routers.frontend.rule=Host(`translate.smart-village.solutions`)
+    - traefik.http.routers.frontend.rule=Host(`dialog.kassel.de`)
     - traefik.http.routers.frontend.entrypoints=websecure
     - traefik.http.routers.frontend.tls.certresolver=le
     - traefik.http.services.frontend.loadbalancer.server.port=8080

--- a/deploy/production/production.env.example
+++ b/deploy/production/production.env.example
@@ -4,9 +4,18 @@ KEYCLOAK_DB_USER=change-me
 KEYCLOAK_DB_PASSWORD=change-me
 KEYCLOAK_BOOTSTRAP_ADMIN_USERNAME=change-me
 KEYCLOAK_BOOTSTRAP_ADMIN_PASSWORD=change-me
-KEYCLOAK_ISSUER=https://auth.kassel.smartspeechflow.de/realms/ssf
+KEYCLOAK_BASE_URL=https://auth.dialog.kassel.de
 KEYCLOAK_AUDIENCE=ssf-frontend
 KEYCLOAK_REQUIRED_ROLE=ssf-user
+# Studio owns the production tenant directory and realm provisioning.
+STUDIO_RUNTIME_CONFIGURATION_BASE_URL=https://studio.dialog.kassel.de
+# Set this to the deployed OAuth2 client-credentials token endpoint.
+STUDIO_RUNTIME_TOKEN_URL=
+STUDIO_RUNTIME_CLIENT_ID=ssf-runtime
+STUDIO_RUNTIME_AUDIENCE=sva-studio-ssf-runtime
+# Required deployment secret; intentionally empty in this checked-in example.
+STUDIO_RUNTIME_CLIENT_SECRET=
+STUDIO_LOGIN_DIRECTORY_CACHE_SECONDS=60
 # Temporary migration switch. The access code is intentionally not a secret.
 SSF_ENABLE_LEGACY_ADMIN_ACCESS=false
 SSF_LEGACY_ADMIN_ACCESS_CODE=change-me

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -289,7 +289,9 @@ services:
     build:
       context: ./services/keycloak
       dockerfile: Dockerfile
-    command: ["start", "--optimized"]
+    # The fixed realm is a local-development fixture only. Production realms
+    # are provisioned by Studio and are never imported by production Compose.
+    command: ["start", "--optimized", "--import-realm"]
     restart: always
     expose:
       - "8080"
@@ -305,6 +307,8 @@ services:
       KC_PROXY_HEADERS: xforwarded
       KC_HTTP_ENABLED: "true"
       KC_HEALTH_ENABLED: "true"
+    volumes:
+      - ./deploy/production/keycloak/ssf-realm.json:/opt/keycloak/data/import/ssf-realm.json:ro
     depends_on:
       keycloak-postgres:
         condition: service_healthy
@@ -346,6 +350,7 @@ services:
         VITE_API_BASE_URL: https://ssf.smart-village.solutions
         VITE_WS_BASE_URL: wss://ssf.smart-village.solutions
         VITE_KEYCLOAK_URL: https://auth.dialog.kassel.de
+        VITE_KEYCLOAK_CLIENT_ID: ssf-frontend
         VITE_DEMO_ACCESS_CODE: ${FRONTEND_DEMO_PASSWORD:-ssf2025kassel}
     networks:
       - default

--- a/openspec/changes/add-keycloak-admin-authentication/tasks.md
+++ b/openspec/changes/add-keycloak-admin-authentication/tasks.md
@@ -66,7 +66,7 @@
 ## 4. Verification and documentation
 
 - [x] 4.1 Run frontend lint, type checks, and focused frontend tests.
-- [ ] 4.2 Run gateway formatting/type checks and focused authorization tests.
+- [x] 4.2 Run gateway formatting/type checks and focused authorization tests.
 - [ ] 4.3 Verify production-like login, logout, authorized and denied requests,
   cross-tenant isolation for at least two realms, and unchanged customer/QR-code
   flow.

--- a/openspec/changes/add-keycloak-admin-authentication/tasks.md
+++ b/openspec/changes/add-keycloak-admin-authentication/tasks.md
@@ -6,7 +6,7 @@
 - [ ] 1.2 Verify each client is public with Standard Flow and PKCE S256;
   restrict `/login/*` redirect URIs and web origin to the frontend production
   origin; keep implicit flow and direct-access grants disabled.
-- [ ] 1.3 Replace the fixed-realm frontend and gateway OIDC settings with the
+- [x] 1.3 Replace the fixed-realm frontend and gateway OIDC settings with the
   trusted Keycloak base URL, public client ID, audience, role, and cache
   settings; retain the documented temporary legacy switch.
 - [ ] 1.4 Provision rollout administrators in at least two tenant realms and
@@ -14,61 +14,61 @@
 
 ## 1a. Studio tenant-login directory
 
-- [ ] 1a.1 Add a strict client for
+- [x] 1a.1 Add a strict client for
   `GET /internal/plugins/ssf/v1/admin-login-tenants` using the injected Studio
   service-token provider and correlation IDs.
-- [ ] 1a.2 Validate contract version, directory revision, tenant IDs, public
+- [x] 1a.2 Validate contract version, directory revision, tenant IDs, public
   names, realm identifiers, uniqueness, and stable Studio errors.
-- [ ] 1a.3 Add public read-only `GET /api/login/tenants`, returning only the
+- [x] 1a.3 Add public read-only `GET /api/login/tenants`, returning only the
   validated directory fields and never exposing the service token.
-- [ ] 1a.4 Add bounded caching and fail closed after cached directory data
+- [x] 1a.4 Add bounded caching and fail closed after cached directory data
   expires.
 
 ## 1b. Node 24 LTS toolchain
 
-- [ ] 1b.1 Declare Node 24 LTS as the frontend development requirement.
-- [ ] 1b.2 Upgrade the frontend Docker builder and relevant CI jobs to Node 24.
-- [ ] 1b.3 Reinstall dependencies and verify the frontend test suite under
+- [x] 1b.1 Declare Node 24 LTS as the frontend development requirement.
+- [x] 1b.2 Upgrade the frontend Docker builder and relevant CI jobs to Node 24.
+- [x] 1b.3 Reinstall dependencies and verify the frontend test suite under
   Node 24.
 
 ## 2. API gateway authorization
 
-- [ ] 2.1 Add typed Keycloak/OIDC configuration for the trusted base URL,
+- [x] 2.1 Add typed Keycloak/OIDC configuration for the trusted base URL,
   audience, public client ID, role, discovery, JWKS, and directory cache
   settings.
-- [ ] 2.2 Implement an allowlisted multi-realm FastAPI dependency that validates
+- [x] 2.2 Implement an allowlisted multi-realm FastAPI dependency that validates
   bearer-JWT signature, issuer, audience, expiry, the `ssf-user` realm role,
   and the realm-to-`studio_tenant_id` binding.
-- [ ] 2.3 Apply the dependency to every `/api/admin/**` operation without
+- [x] 2.3 Apply the dependency to every `/api/admin/**` operation without
   changing customer-facing routes.
-- [ ] 2.4 Add unit and integration tests for two allowed realms, unknown and
+- [x] 2.4 Add unit and integration tests for two allowed realms, unknown and
   stale issuers, tenant mismatch, 401 missing/invalid credentials, 403 missing
   role, and successful tenant-bound access.
 
 ## 3. Frontend OIDC integration
 
-- [ ] 3.1 Refactor `keycloak-js` initialization to accept only a tenant and realm
+- [x] 3.1 Refactor `keycloak-js` initialization to accept only a tenant and realm
   resolved from the validated directory while preserving in-memory tokens.
-- [ ] 3.2 Add the alphabetically sorted tenant chooser at `/login` and the
+- [x] 3.2 Add the alphabetically sorted tenant chooser at `/login` and the
   tenant-qualified login/dashboard route at `/login/:tenantId`; retain
   `AdminLoginScreen` and `useAdminAuth` at `/admin` only for the transition.
-- [ ] 3.3 Attach refreshed access tokens to administrative API requests; handle
+- [x] 3.3 Attach refreshed access tokens to administrative API requests; handle
   refresh failure and realm logout, and return to `/login`.
 - [x] 3.4 Remove `VITE_ADMIN_DEV_ENTRY` and `/admin/dev`; retain the simulated
   legacy login and `VITE_APP_PASSWORD` only for the explicitly enabled transition.
-- [ ] 3.5 Add frontend tests for directory loading, German sorting, empty and
+- [x] 3.5 Add frontend tests for directory loading, German sorting, empty and
   retry states, tenant selection, existing realm sessions, redirects,
   callbacks, unknown tenants, logout, the legacy transition, and 404 for
   `/admin/dev`.
-- [ ] 3.6 Replace the start-page administrative links with the single `Login`
+- [x] 3.6 Replace the start-page administrative links with the single `Login`
   text link to `/login`; do not advertise `/admin` or SVA Studio.
 
 ## 4. Verification and documentation
 
-- [ ] 4.1 Run frontend lint, type checks, and focused frontend tests.
+- [x] 4.1 Run frontend lint, type checks, and focused frontend tests.
 - [ ] 4.2 Run gateway formatting/type checks and focused authorization tests.
 - [ ] 4.3 Verify production-like login, logout, authorized and denied requests,
   cross-tenant isolation for at least two realms, and unchanged customer/QR-code
   flow.
-- [ ] 4.4 Update operator documentation for Studio-managed staff identities,
+- [x] 4.4 Update operator documentation for Studio-managed staff identities,
   directory readiness, and authentication rollout testing.

--- a/services/api_gateway/README.md
+++ b/services/api_gateway/README.md
@@ -1,5 +1,56 @@
 # API Gateway Service
 
+## Studio-backed login directory
+
+`GET /api/login/tenants` is an anonymous, read-only facade over Studio's
+validated login directory. Studio is the source of truth for ready tenant
+realms. The gateway uses one trusted `KEYCLOAK_BASE_URL`, admits only issuers
+derived from current directory entries, and binds a validated token to its
+signed `studio_tenant_id` and `ssf_authorization_revision` claims.
+
+Production requires these settings:
+
+```text
+KEYCLOAK_BASE_URL=https://auth.dialog.kassel.de
+KEYCLOAK_AUDIENCE=ssf-frontend
+KEYCLOAK_REQUIRED_ROLE=ssf-user
+STUDIO_RUNTIME_CONFIGURATION_BASE_URL=https://studio.dialog.kassel.de
+STUDIO_RUNTIME_TOKEN_URL=<OAuth2 token endpoint>
+STUDIO_RUNTIME_CLIENT_ID=ssf-runtime
+STUDIO_RUNTIME_AUDIENCE=sva-studio-ssf-runtime
+STUDIO_RUNTIME_CLIENT_SECRET=<deployment secret>
+STUDIO_LOGIN_DIRECTORY_CACHE_SECONDS=60
+```
+
+The client secret must come from the deployment environment or secret store;
+it must never be embedded in an image, browser bundle, or checked-in file.
+Production Compose intentionally does not import the fixed local `ssf` realm.
+Studio owns production realm provisioning.
+
+## Multi-tenant rollout gate
+
+Directory-based login establishes a trusted tenant identity, but it does not
+make conversation persistence tenant-isolated. Before exposing real
+conversations through multi-realm login, operators must complete all of the
+following:
+
+1. Confirm the Studio directory returns at least two ready tenant entries.
+2. Confirm every listed realm has the common public client, PKCE S256, the
+   exact application origin and `/login/*` redirects, the configured audience
+   and role, and signed tenant-ID and authorization-revision claims.
+3. Set `SSF_ENABLE_LEGACY_ADMIN_ACCESS=false` before multi-realm production
+   enablement.
+4. Complete the separate OpenSpec change `add-multi-tenant-operations` and pass
+   its isolation tests for session creation, history, lookup, termination,
+   messages, audio, and customer joins. This is an independent release gate,
+   not part of the tenant-login-directory implementation.
+5. Manually verify login, existing SSO, logout, unknown-tenant handling, a
+   Studio outage after cache expiry, and cross-tenant negative paths in the
+   deployed environment.
+
+If any gate is incomplete, keep real multi-tenant conversations disabled. A
+healthy directory or successful login alone is not production approval.
+
 ## Beschreibung
 
 Das API Gateway ist der zentrale Einstiegspunkt fuer Smart Speech Flow. Es verbindet die Fachservices fuer ASR, Translation und TTS mit der sessionbasierten Admin/Customer-Kommunikation im Frontend.

--- a/services/api_gateway/app.py
+++ b/services/api_gateway/app.py
@@ -501,11 +501,12 @@ app.add_middleware(RateLimitMiddleware)
 
 # === Module Imports (AFTER app initialization) ===
 from . import websocket, websocket_monitoring_routes, websocket_polling_routes
-from .routes import admin, circuit_breaker, customer, session
+from .routes import admin, circuit_breaker, customer, login, session
 from .routes.metrics import metrics
 
 # === Session-Routen registrieren ===
 app.include_router(session.router, prefix="/api", tags=["sessions"])
+app.include_router(login.router)
 app.include_router(admin.router, tags=["admin"])
 app.include_router(customer.router, tags=["customer"])
 app.include_router(websocket_monitoring_routes.router, tags=["websocket-monitoring"])

--- a/services/api_gateway/auth.py
+++ b/services/api_gateway/auth.py
@@ -3,29 +3,62 @@
 import hmac
 import json
 import os
+import re
 import time
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Annotated, Any
+from urllib.parse import urlsplit
+from uuid import uuid4
 
 import jwt
 import requests
-from fastapi import HTTPException, Request, status
+from fastapi import Depends, HTTPException, Request, status
 from jwt.algorithms import RSAAlgorithm
-from jwt.exceptions import InvalidTokenError
+from jwt.exceptions import InvalidKeyError, InvalidTokenError
+from starlette.concurrency import run_in_threadpool
+
+from .studio_login_directory import (
+    StudioLoginDirectoryConfigurationError,
+    StudioLoginDirectoryService,
+    get_studio_login_directory_service,
+)
+from .studio_login_directory_client import StudioLoginDirectoryClientError
+from .studio_runtime_token import StudioTokenError
+
+_AUTHORIZATION_REVISION_PATTERN = re.compile(r"^sha256:[0-9a-f]{64}$")
 
 
 @dataclass(frozen=True)
 class KeycloakSettings:
-    issuer: str
+    base_url: str
     audience: str
     required_role: str
 
+    def issuer_for(self, realm: str) -> str:
+        return f"{self.base_url}/realms/{realm}"
+
     @classmethod
     def from_environment(cls) -> "KeycloakSettings":
+        base_url = os.environ.get(
+            "KEYCLOAK_BASE_URL", "https://auth.kassel.smartspeechflow.de"
+        ).strip()
+        parsed = urlsplit(base_url)
+        if (
+            parsed.scheme not in {"http", "https"}
+            or not parsed.hostname
+            or parsed.username is not None
+            or parsed.password is not None
+            or parsed.path not in {"", "/"}
+            or parsed.query
+            or parsed.fragment
+            or any(character.isspace() for character in base_url)
+        ):
+            raise ValueError("KEYCLOAK_BASE_URL must be an origin-only URL")
+        # Accessing port also rejects malformed or out-of-range port numbers.
+        _ = parsed.port
         return cls(
-            issuer=os.environ.get(
-                "KEYCLOAK_ISSUER", "https://auth.kassel.smartspeechflow.de/realms/ssf"
-            ).rstrip("/"),
+            base_url=f"{parsed.scheme}://{parsed.netloc.lower()}",
             audience=os.environ.get("KEYCLOAK_AUDIENCE", "ssf-frontend"),
             required_role=os.environ.get("KEYCLOAK_REQUIRED_ROLE", "ssf-user"),
         )
@@ -39,10 +72,26 @@ class OidcKeyCache:
         cached = self.entries.get(issuer)
         if cached and cached[0] > time.monotonic():
             return cached[1]
-        metadata = requests.get(f"{issuer}/.well-known/openid-configuration", timeout=5)
+        metadata = requests.get(
+            f"{issuer}/.well-known/openid-configuration",
+            timeout=5,
+            allow_redirects=False,
+        )
         metadata.raise_for_status()
-        key_response = requests.get(metadata.json()["jwks_uri"], timeout=5)
+        if metadata.is_redirect:
+            raise ValueError("OIDC discovery redirects are not accepted")
+        expected_jwks_uri = f"{issuer}/protocol/openid-connect/certs"
+        document = metadata.json()
+        if (
+            not isinstance(document, dict)
+            or document.get("issuer") != issuer
+            or document.get("jwks_uri") != expected_jwks_uri
+        ):
+            raise ValueError("OIDC metadata does not match the admitted issuer")
+        key_response = requests.get(expected_jwks_uri, timeout=5, allow_redirects=False)
         key_response.raise_for_status()
+        if key_response.is_redirect:
+            raise ValueError("OIDC key redirects are not accepted")
         keys = {key["kid"]: key for key in key_response.json()["keys"]}
         self.entries[issuer] = (time.monotonic() + 300, keys)
         return keys
@@ -59,7 +108,18 @@ def _unauthorized() -> HTTPException:
     )
 
 
-def require_ssf_user(request: Request) -> dict[str, Any]:
+def get_auth_login_directory_provider() -> Callable[[], StudioLoginDirectoryService]:
+    """Defer directory configuration until after the legacy authentication branch."""
+    return get_studio_login_directory_service
+
+
+async def require_ssf_user(
+    request: Request,
+    directory_provider: Annotated[
+        Callable[[], StudioLoginDirectoryService],
+        Depends(get_auth_login_directory_provider),
+    ],
+) -> dict[str, Any]:
     """Validate an administrative bearer token and return its claims."""
     legacy_enabled = os.environ.get("SSF_ENABLE_LEGACY_ADMIN_ACCESS", "false") == "true"
     legacy_code = os.environ.get("SSF_LEGACY_ADMIN_ACCESS_CODE", "")
@@ -75,22 +135,73 @@ def require_ssf_user(request: Request) -> dict[str, Any]:
     if scheme.lower() != "bearer" or not token:
         raise _unauthorized()
 
-    settings = KeycloakSettings.from_environment()
+    try:
+        settings = KeycloakSettings.from_environment()
+        unverified_claims = jwt.decode(token, options={"verify_signature": False})
+        issuer = unverified_claims.get("iss")
+        if not isinstance(issuer, str):
+            raise _unauthorized()
+    except (InvalidTokenError, ValueError):
+        raise _unauthorized() from None
+
+    try:
+        directory = await directory_provider().get(str(uuid4()))
+    except (
+        StudioLoginDirectoryClientError,
+        StudioLoginDirectoryConfigurationError,
+        StudioTokenError,
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="The login directory is temporarily unavailable",
+        ) from None
+
+    matched_tenant = next(
+        (
+            tenant
+            for tenant in directory.tenants
+            if settings.issuer_for(tenant.realm) == issuer
+        ),
+        None,
+    )
+    if matched_tenant is None:
+        raise _unauthorized()
+
     try:
         header = jwt.get_unverified_header(token)
-        signing_key = _key_cache.keys_for(settings.issuer)[header["kid"]]
+        if header.get("alg") != "RS256" or not isinstance(header.get("kid"), str):
+            raise _unauthorized()
+        keys = await run_in_threadpool(_key_cache.keys_for, issuer)
+        signing_key = keys[header["kid"]]
         claims = jwt.decode(
             token,
             RSAAlgorithm.from_jwk(json.dumps(signing_key)),
             algorithms=["RS256"],
             audience=settings.audience,
-            issuer=settings.issuer,
+            issuer=issuer,
+            options={"require": ["exp", "iss", "aud"]},
         )
-    except (InvalidTokenError, KeyError, requests.RequestException, ValueError):
+    except (
+        InvalidKeyError,
+        InvalidTokenError,
+        KeyError,
+        requests.RequestException,
+        TypeError,
+        ValueError,
+    ):
         raise _unauthorized() from None
 
-    roles = claims.get("realm_access", {}).get("roles", [])
-    if settings.required_role not in roles:
+    revision = claims.get("ssf_authorization_revision")
+    if (
+        claims.get("studio_tenant_id") != matched_tenant.id
+        or not isinstance(revision, str)
+        or not _AUTHORIZATION_REVISION_PATTERN.fullmatch(revision)
+    ):
+        raise _unauthorized()
+
+    realm_access = claims.get("realm_access")
+    roles = realm_access.get("roles") if isinstance(realm_access, dict) else None
+    if not isinstance(roles, list) or settings.required_role not in roles:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="The bearer token lacks the required role",

--- a/services/api_gateway/auth.py
+++ b/services/api_gateway/auth.py
@@ -13,6 +13,7 @@ from uuid import uuid4
 
 import jwt
 import requests
+from cryptography.hazmat.primitives.asymmetric import rsa
 from fastapi import Depends, HTTPException, Request, status
 from jwt.algorithms import RSAAlgorithm
 from jwt.exceptions import InvalidKeyError, InvalidTokenError
@@ -124,11 +125,7 @@ async def require_ssf_user(
     legacy_enabled = os.environ.get("SSF_ENABLE_LEGACY_ADMIN_ACCESS", "false") == "true"
     legacy_code = os.environ.get("SSF_LEGACY_ADMIN_ACCESS_CODE", "")
     legacy_header = request.headers.get("X-SSF-Legacy-Access", "")
-    if (
-        legacy_enabled
-        and legacy_code
-        and hmac.compare_digest(legacy_header, legacy_code)
-    ):
+    if legacy_enabled and legacy_code and hmac.compare_digest(legacy_header, legacy_code):
         return {"sub": "legacy-admin", "auth_method": "legacy-transition"}
 
     scheme, _, token = request.headers.get("Authorization", "").partition(" ")
@@ -157,11 +154,7 @@ async def require_ssf_user(
         ) from None
 
     matched_tenant = next(
-        (
-            tenant
-            for tenant in directory.tenants
-            if settings.issuer_for(tenant.realm) == issuer
-        ),
+        (tenant for tenant in directory.tenants if settings.issuer_for(tenant.realm) == issuer),
         None,
     )
     if matched_tenant is None:
@@ -173,9 +166,12 @@ async def require_ssf_user(
             raise _unauthorized()
         keys = await run_in_threadpool(_key_cache.keys_for, issuer)
         signing_key = keys[header["kid"]]
+        public_key = RSAAlgorithm.from_jwk(json.dumps(signing_key))
+        if not isinstance(public_key, rsa.RSAPublicKey):
+            raise InvalidKeyError("OIDC signing key must be an RSA public key")
         claims = jwt.decode(
             token,
-            RSAAlgorithm.from_jwk(json.dumps(signing_key)),
+            public_key,
             algorithms=["RS256"],
             audience=settings.audience,
             issuer=issuer,

--- a/services/api_gateway/routes/login.py
+++ b/services/api_gateway/routes/login.py
@@ -1,0 +1,68 @@
+"""Anonymous browser-safe routes for selecting a Studio tenant."""
+
+from typing import Annotated
+from uuid import uuid4
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from pydantic import BaseModel, ConfigDict, Field
+
+from ..studio_login_directory import (
+    StudioLoginDirectoryConfigurationError,
+    StudioLoginDirectoryService,
+    get_studio_login_directory_service,
+)
+from ..studio_login_directory_client import StudioLoginDirectoryClientError
+from ..studio_runtime_token import StudioTokenError
+
+UNAVAILABLE_DETAIL = "The login directory is temporarily unavailable"
+
+router = APIRouter(prefix="/api/login", tags=["login"])
+
+
+class LoginTenantResponse(BaseModel):
+    """The browser-safe fields needed to start one tenant's login flow."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    id: str
+    display_name: str = Field(alias="displayName")
+    realm: str
+
+
+class LoginTenantDirectoryResponse(BaseModel):
+    """The public tenant chooser response."""
+
+    tenants: list[LoginTenantResponse]
+
+
+@router.get("/tenants", response_model=LoginTenantDirectoryResponse)
+async def list_login_tenants(
+    request: Request,
+    directory: Annotated[
+        StudioLoginDirectoryService,
+        Depends(get_studio_login_directory_service),
+    ],
+) -> LoginTenantDirectoryResponse:
+    """Return only validated fields that are safe for an anonymous browser."""
+    correlation_id = request.headers.get("X-Correlation-Id") or str(uuid4())
+    try:
+        result = await directory.get(correlation_id)
+    except (
+        StudioLoginDirectoryClientError,
+        StudioTokenError,
+        StudioLoginDirectoryConfigurationError,
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=UNAVAILABLE_DETAIL,
+        ) from None
+    return LoginTenantDirectoryResponse(
+        tenants=[
+            LoginTenantResponse(
+                id=tenant.id,
+                displayName=tenant.display_name,
+                realm=tenant.realm,
+            )
+            for tenant in result.tenants
+        ]
+    )

--- a/services/api_gateway/routes/login.py
+++ b/services/api_gateway/routes/login.py
@@ -35,6 +35,20 @@ class LoginTenantDirectoryResponse(BaseModel):
     tenants: list[LoginTenantResponse]
 
 
+def _correlation_id(request: Request) -> str:
+    correlation_id = request.headers.get("X-Correlation-Id")
+    if not correlation_id:
+        return str(uuid4())
+    if len(correlation_id) > 128 or any(
+        ord(character) < 32 or ord(character) > 126 for character in correlation_id
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="A valid X-Correlation-Id is required when supplied",
+        )
+    return correlation_id
+
+
 @router.get("/tenants", response_model=LoginTenantDirectoryResponse)
 async def list_login_tenants(
     request: Request,
@@ -44,7 +58,7 @@ async def list_login_tenants(
     ],
 ) -> LoginTenantDirectoryResponse:
     """Return only validated fields that are safe for an anonymous browser."""
-    correlation_id = request.headers.get("X-Correlation-Id") or str(uuid4())
+    correlation_id = _correlation_id(request)
     try:
         result = await directory.get(correlation_id)
     except (

--- a/services/api_gateway/studio_login_directory.py
+++ b/services/api_gateway/studio_login_directory.py
@@ -11,15 +11,8 @@ from typing import Protocol
 
 from fastapi import HTTPException, status
 
-from .studio_login_directory_client import (
-    StudioLoginDirectory,
-    StudioLoginDirectoryClient,
-)
-from .studio_runtime_token import (
-    StudioRuntimeTokenProvider,
-    StudioTokenConfig,
-    StudioTokenError,
-)
+from .studio_login_directory_client import StudioLoginDirectory, StudioLoginDirectoryClient
+from .studio_runtime_token import StudioRuntimeTokenProvider, StudioTokenConfig, StudioTokenError
 
 
 class LoginDirectoryFetcher(Protocol):
@@ -92,9 +85,7 @@ def _build_studio_login_directory_service() -> StudioLoginDirectoryService:
     base_url = os.getenv("STUDIO_RUNTIME_CONFIGURATION_BASE_URL", "").strip()
     try:
         cache_seconds = float(os.getenv("STUDIO_LOGIN_DIRECTORY_CACHE_SECONDS", "60"))
-        timeout_seconds = float(
-            os.getenv("STUDIO_LOGIN_DIRECTORY_TIMEOUT_SECONDS", "5")
-        )
+        timeout_seconds = float(os.getenv("STUDIO_LOGIN_DIRECTORY_TIMEOUT_SECONDS", "5"))
         if not 1 <= cache_seconds <= 300 or not 0 < timeout_seconds <= 30:
             raise ValueError
         token_provider = StudioRuntimeTokenProvider(StudioTokenConfig.from_env())

--- a/services/api_gateway/studio_login_directory.py
+++ b/services/api_gateway/studio_login_directory.py
@@ -1,0 +1,109 @@
+"""Bounded in-memory cache for the validated Studio login directory."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+from collections.abc import Callable
+from functools import lru_cache
+from typing import Protocol
+
+from fastapi import HTTPException, status
+
+from .studio_login_directory_client import (
+    StudioLoginDirectory,
+    StudioLoginDirectoryClient,
+)
+from .studio_runtime_token import (
+    StudioRuntimeTokenProvider,
+    StudioTokenConfig,
+    StudioTokenError,
+)
+
+
+class LoginDirectoryFetcher(Protocol):
+    """Boundary implemented by the validated Studio directory client."""
+
+    async def fetch(self, correlation_id: str) -> StudioLoginDirectory:
+        raise NotImplementedError
+
+
+class StudioLoginDirectoryConfigurationError(RuntimeError):
+    """Safe failure raised when the directory dependency cannot be configured."""
+
+
+class StudioLoginDirectoryService:
+    """Reuse a validated directory for a bounded period within one process."""
+
+    def __init__(
+        self,
+        client: LoginDirectoryFetcher,
+        *,
+        cache_seconds: float,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        if not 1 <= cache_seconds <= 300:
+            raise ValueError("cache_seconds must be between 1 and 300")
+        self._client = client
+        self._cache_seconds = cache_seconds
+        self._clock = clock
+        self._directory: StudioLoginDirectory | None = None
+        self._expires_at = 0.0
+        self._lock = asyncio.Lock()
+
+    async def get(self, correlation_id: str) -> StudioLoginDirectory:
+        """Return a current directory, refreshing it once for concurrent callers."""
+        if self._is_current():
+            assert self._directory is not None
+            return self._directory
+
+        async with self._lock:
+            if self._is_current():
+                assert self._directory is not None
+                return self._directory
+            directory = await self._client.fetch(correlation_id)
+            self._directory = directory
+            self._expires_at = self._clock() + self._cache_seconds
+            return directory
+
+    def _is_current(self) -> bool:
+        return self._directory is not None and self._clock() < self._expires_at
+
+
+@lru_cache(maxsize=1)
+def _build_studio_login_directory_service() -> StudioLoginDirectoryService:
+    """Construct the process-local service from explicit environment settings."""
+    base_url = os.getenv("STUDIO_RUNTIME_CONFIGURATION_BASE_URL", "").strip()
+    try:
+        cache_seconds = float(os.getenv("STUDIO_LOGIN_DIRECTORY_CACHE_SECONDS", "60"))
+        timeout_seconds = float(
+            os.getenv("STUDIO_LOGIN_DIRECTORY_TIMEOUT_SECONDS", "5")
+        )
+        if not 1 <= cache_seconds <= 300 or not 0 < timeout_seconds <= 30:
+            raise ValueError
+        token_provider = StudioRuntimeTokenProvider(StudioTokenConfig.from_env())
+        client = StudioLoginDirectoryClient(
+            base_url,
+            token_provider,
+            timeout_seconds=timeout_seconds,
+        )
+        return StudioLoginDirectoryService(
+            client,
+            cache_seconds=cache_seconds,
+        )
+    except (StudioTokenError, ValueError):
+        raise StudioLoginDirectoryConfigurationError(
+            "studio_login_directory_configuration_invalid"
+        ) from None
+
+
+def get_studio_login_directory_service() -> StudioLoginDirectoryService:
+    """Provide the singleton service or a neutral dependency-boundary failure."""
+    try:
+        return _build_studio_login_directory_service()
+    except StudioLoginDirectoryConfigurationError:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="The login directory is temporarily unavailable",
+        ) from None

--- a/services/api_gateway/studio_login_directory.py
+++ b/services/api_gateway/studio_login_directory.py
@@ -51,6 +51,7 @@ class StudioLoginDirectoryService:
         self._directory: StudioLoginDirectory | None = None
         self._expires_at = 0.0
         self._lock = asyncio.Lock()
+        self._refresh_task: asyncio.Task[StudioLoginDirectory] | None = None
 
     async def get(self, correlation_id: str) -> StudioLoginDirectory:
         """Return a current directory, refreshing it once for concurrent callers."""
@@ -62,13 +63,27 @@ class StudioLoginDirectoryService:
             if self._is_current():
                 assert self._directory is not None
                 return self._directory
-            directory = await self._client.fetch(correlation_id)
-            self._directory = directory
-            self._expires_at = self._clock() + self._cache_seconds
-            return directory
+            refresh_task = self._refresh_task
+            if refresh_task is None or refresh_task.done():
+                refresh_task = asyncio.create_task(self._refresh(correlation_id))
+                self._refresh_task = refresh_task
+
+        try:
+            return await asyncio.shield(refresh_task)
+        finally:
+            if refresh_task.done():
+                async with self._lock:
+                    if self._refresh_task is refresh_task:
+                        self._refresh_task = None
 
     def _is_current(self) -> bool:
         return self._directory is not None and self._clock() < self._expires_at
+
+    async def _refresh(self, correlation_id: str) -> StudioLoginDirectory:
+        directory = await self._client.fetch(correlation_id)
+        self._directory = directory
+        self._expires_at = self._clock() + self._cache_seconds
+        return directory
 
 
 @lru_cache(maxsize=1)

--- a/services/api_gateway/studio_login_directory_client.py
+++ b/services/api_gateway/studio_login_directory_client.py
@@ -9,14 +9,7 @@ from typing import Any, Mapping, Protocol
 from urllib.parse import urlsplit
 
 import aiohttp
-from pydantic import (
-    BaseModel,
-    ConfigDict,
-    Field,
-    ValidationError,
-    field_validator,
-    model_validator,
-)
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator, model_validator
 
 from services.api_gateway.studio_runtime_token import StudioRuntimeTokenProvider
 
@@ -35,9 +28,7 @@ EXPECTED_ERROR_CODES = {
 class StudioLoginTenant(BaseModel):
     """One publicly displayable Studio tenant and its provisioned realm."""
 
-    model_config = ConfigDict(
-        extra="ignore", frozen=True, strict=True, populate_by_name=True
-    )
+    model_config = ConfigDict(extra="ignore", frozen=True, strict=True, populate_by_name=True)
 
     id: str
     display_name: str = Field(alias="displayName", min_length=1, max_length=200)
@@ -61,9 +52,7 @@ class StudioLoginTenant(BaseModel):
 class StudioLoginDirectory(BaseModel):
     """The validated tenant-unbound Studio login directory."""
 
-    model_config = ConfigDict(
-        extra="ignore", frozen=True, strict=True, populate_by_name=True
-    )
+    model_config = ConfigDict(extra="ignore", frozen=True, strict=True, populate_by_name=True)
 
     contract_version: str = Field(alias="contractVersion", pattern=r"^1[.]0$")
     directory_revision: str = Field(alias="directoryRevision")
@@ -110,9 +99,7 @@ class DirectoryErrorEnvelope(BaseModel):
 class StudioLoginDirectoryClientError(RuntimeError):
     """Safe failure surfaced by the Studio login-directory client."""
 
-    def __init__(
-        self, code: str, *, retryable: bool, status: int | None = None
-    ) -> None:
+    def __init__(self, code: str, *, retryable: bool, status: int | None = None) -> None:
         super().__init__(code)
         self.code = code
         self.retryable = retryable
@@ -201,9 +188,7 @@ class StudioLoginDirectoryClient:
             "X-Correlation-Id": correlation_id,
         }
         try:
-            response = await self._transport.get(
-                self._url, headers, self._timeout_seconds
-            )
+            response = await self._transport.get(self._url, headers, self._timeout_seconds)
         except StudioLoginDirectoryClientError:
             raise
         except (TimeoutError, asyncio.TimeoutError, aiohttp.ClientError):

--- a/services/api_gateway/studio_login_directory_client.py
+++ b/services/api_gateway/studio_login_directory_client.py
@@ -1,0 +1,257 @@
+"""Strict consumer for the Studio administrative login-directory V1 contract."""
+
+from __future__ import annotations
+
+import asyncio
+import re
+from dataclasses import dataclass
+from typing import Any, Mapping, Protocol
+from urllib.parse import urlsplit
+
+import aiohttp
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    ValidationError,
+    field_validator,
+    model_validator,
+)
+
+from services.api_gateway.studio_runtime_token import StudioRuntimeTokenProvider
+
+DIRECTORY_PATH = "/internal/plugins/ssf/v1/admin-login-tenants"
+TENANT_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+REALM_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+REVISION_PATTERN = re.compile(r"^sha256:[0-9a-f]{64}$")
+SUPPORTED_ERROR_STATUSES = {401, 403, 503}
+EXPECTED_ERROR_CODES = {
+    401: {"service_authentication_invalid"},
+    403: {"service_action_forbidden"},
+    503: {"admin_login_directory_unavailable"},
+}
+
+
+class StudioLoginTenant(BaseModel):
+    """One publicly displayable Studio tenant and its provisioned realm."""
+
+    model_config = ConfigDict(extra="allow", strict=True, populate_by_name=True)
+
+    id: str
+    display_name: str = Field(alias="displayName", min_length=1, max_length=200)
+    realm: str
+
+    @field_validator("id")
+    @classmethod
+    def validate_id(cls, value: str) -> str:
+        if not TENANT_ID_PATTERN.fullmatch(value):
+            raise ValueError("id must be a safe Studio tenant identifier")
+        return value
+
+    @field_validator("realm")
+    @classmethod
+    def validate_realm(cls, value: str) -> str:
+        if not REALM_PATTERN.fullmatch(value):
+            raise ValueError("realm must be a safe Keycloak realm identifier")
+        return value
+
+
+class StudioLoginDirectory(BaseModel):
+    """The validated tenant-unbound Studio login directory."""
+
+    model_config = ConfigDict(extra="allow", strict=True, populate_by_name=True)
+
+    contract_version: str = Field(alias="contractVersion", pattern=r"^1[.]0$")
+    directory_revision: str = Field(alias="directoryRevision")
+    tenants: list[StudioLoginTenant] = Field(max_length=10_000)
+
+    @field_validator("directory_revision")
+    @classmethod
+    def validate_directory_revision(cls, value: str) -> str:
+        if not REVISION_PATTERN.fullmatch(value):
+            raise ValueError("directoryRevision must be a lowercase SHA-256 value")
+        return value
+
+    @model_validator(mode="after")
+    def validate_unique_tenants(self) -> "StudioLoginDirectory":
+        ids = [tenant.id for tenant in self.tenants]
+        realms = [tenant.realm for tenant in self.tenants]
+        if len(ids) != len(set(ids)):
+            raise ValueError("tenant IDs must be unique")
+        if len(realms) != len(set(realms)):
+            raise ValueError("tenant realms must be unique")
+        return self
+
+
+class DirectoryErrorDetails(BaseModel):
+    """The stable nested error object in Studio's V1 error envelope."""
+
+    model_config = ConfigDict(extra="allow", strict=True, populate_by_name=True)
+
+    code: str = Field(min_length=1)
+    message: str = Field(min_length=1, max_length=200)
+    retryable: bool
+    correlation_id: str = Field(alias="correlationId", min_length=1, max_length=128)
+
+
+class DirectoryErrorEnvelope(BaseModel):
+    """The stable Studio V1 error response shape."""
+
+    model_config = ConfigDict(extra="allow", strict=True, populate_by_name=True)
+
+    contract_version: str = Field(alias="contractVersion", pattern=r"^1[.]0$")
+    error: DirectoryErrorDetails
+
+
+class StudioLoginDirectoryClientError(RuntimeError):
+    """Safe failure surfaced by the Studio login-directory client."""
+
+    def __init__(
+        self, code: str, *, retryable: bool, status: int | None = None
+    ) -> None:
+        super().__init__(code)
+        self.code = code
+        self.retryable = retryable
+        self.status = status
+
+
+@dataclass(frozen=True)
+class DirectoryHttpResponse:
+    """The response shape shared by the HTTP transport and client."""
+
+    status: int
+    payload: Mapping[str, Any]
+
+
+class DirectoryTransport(Protocol):
+    async def get(
+        self, url: str, headers: Mapping[str, str], timeout_seconds: float
+    ) -> DirectoryHttpResponse:
+        pass
+
+
+class AiohttpDirectoryTransport:
+    """Default async transport for the Studio login-directory endpoint."""
+
+    async def get(
+        self, url: str, headers: Mapping[str, str], timeout_seconds: float
+    ) -> DirectoryHttpResponse:
+        timeout = aiohttp.ClientTimeout(total=timeout_seconds)
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with session.get(url, headers=headers) as response:
+                try:
+                    payload = await response.json()
+                except (aiohttp.ContentTypeError, ValueError):
+                    raise StudioLoginDirectoryClientError(
+                        "studio_login_directory_response_invalid",
+                        retryable=False,
+                        status=response.status,
+                    ) from None
+                if not isinstance(payload, Mapping):
+                    raise StudioLoginDirectoryClientError(
+                        "studio_login_directory_response_invalid",
+                        retryable=False,
+                        status=response.status,
+                    )
+                return DirectoryHttpResponse(status=response.status, payload=payload)
+
+
+class StudioLoginDirectoryClient:
+    """Fetch and validate the Studio administrative login-directory V1 contract."""
+
+    def __init__(
+        self,
+        base_url: str,
+        token_provider: StudioRuntimeTokenProvider,
+        *,
+        transport: DirectoryTransport | None = None,
+        timeout_seconds: float = 5.0,
+    ) -> None:
+        parsed_url = urlsplit(base_url)
+        if (
+            parsed_url.scheme not in {"http", "https"}
+            or not parsed_url.netloc
+            or parsed_url.username is not None
+            or parsed_url.password is not None
+            or parsed_url.path not in {"", "/"}
+            or parsed_url.query
+            or parsed_url.fragment
+        ):
+            raise ValueError("base_url must be an HTTP origin")
+        if not 0 < timeout_seconds <= 30:
+            raise ValueError("timeout_seconds must be between 0 and 30")
+        self._url = f"{base_url.rstrip('/')}{DIRECTORY_PATH}"
+        self._token_provider = token_provider
+        self._transport = transport or AiohttpDirectoryTransport()
+        self._timeout_seconds = timeout_seconds
+
+    async def fetch(self, correlation_id: str) -> StudioLoginDirectory:
+        _validate_printable_ascii(correlation_id, "correlation_id")
+        token = await self._token_provider.get_token()
+        if not _is_printable_ascii(token):
+            raise StudioLoginDirectoryClientError(
+                "studio_login_directory_token_invalid", retryable=False
+            )
+        headers = {
+            "Authorization": f"Bearer {token}",
+            "X-Correlation-Id": correlation_id,
+        }
+        try:
+            response = await self._transport.get(
+                self._url, headers, self._timeout_seconds
+            )
+        except StudioLoginDirectoryClientError:
+            raise
+        except (TimeoutError, asyncio.TimeoutError, aiohttp.ClientError):
+            raise StudioLoginDirectoryClientError(
+                "studio_login_directory_network_error", retryable=True
+            ) from None
+
+        if response.status == 200:
+            try:
+                return StudioLoginDirectory.model_validate(response.payload)
+            except ValidationError:
+                raise StudioLoginDirectoryClientError(
+                    "studio_login_directory_response_invalid",
+                    retryable=False,
+                    status=200,
+                ) from None
+
+        if response.status not in SUPPORTED_ERROR_STATUSES:
+            raise StudioLoginDirectoryClientError(
+                "studio_login_directory_unexpected_status",
+                retryable=response.status >= 500,
+                status=response.status,
+            )
+        try:
+            envelope = DirectoryErrorEnvelope.model_validate(response.payload)
+        except ValidationError:
+            raise StudioLoginDirectoryClientError(
+                "studio_login_directory_error_invalid",
+                retryable=False,
+                status=response.status,
+            ) from None
+        if envelope.error.code not in EXPECTED_ERROR_CODES[response.status]:
+            raise StudioLoginDirectoryClientError(
+                "studio_login_directory_error_invalid",
+                retryable=False,
+                status=response.status,
+            )
+        raise StudioLoginDirectoryClientError(
+            envelope.error.code,
+            retryable=envelope.error.retryable,
+            status=response.status,
+        )
+
+
+def _is_printable_ascii(value: object) -> bool:
+    return (
+        isinstance(value, str)
+        and bool(value)
+        and all(32 <= ord(character) <= 126 for character in value)
+    )
+
+
+def _validate_printable_ascii(value: str, name: str) -> None:
+    if not _is_printable_ascii(value) or len(value) > 128:
+        raise ValueError(f"{name} must be printable ASCII with at most 128 characters")

--- a/services/api_gateway/studio_login_directory_client.py
+++ b/services/api_gateway/studio_login_directory_client.py
@@ -35,7 +35,9 @@ EXPECTED_ERROR_CODES = {
 class StudioLoginTenant(BaseModel):
     """One publicly displayable Studio tenant and its provisioned realm."""
 
-    model_config = ConfigDict(extra="allow", strict=True, populate_by_name=True)
+    model_config = ConfigDict(
+        extra="ignore", frozen=True, strict=True, populate_by_name=True
+    )
 
     id: str
     display_name: str = Field(alias="displayName", min_length=1, max_length=200)
@@ -59,11 +61,13 @@ class StudioLoginTenant(BaseModel):
 class StudioLoginDirectory(BaseModel):
     """The validated tenant-unbound Studio login directory."""
 
-    model_config = ConfigDict(extra="allow", strict=True, populate_by_name=True)
+    model_config = ConfigDict(
+        extra="ignore", frozen=True, strict=True, populate_by_name=True
+    )
 
     contract_version: str = Field(alias="contractVersion", pattern=r"^1[.]0$")
     directory_revision: str = Field(alias="directoryRevision")
-    tenants: list[StudioLoginTenant] = Field(max_length=10_000)
+    tenants: tuple[StudioLoginTenant, ...] = Field(max_length=10_000, strict=False)
 
     @field_validator("directory_revision")
     @classmethod

--- a/services/api_gateway/tenant_context.py
+++ b/services/api_gateway/tenant_context.py
@@ -73,6 +73,8 @@ async def require_studio_tenant_context(
 
 
 def _request_has_tenant_selector(request: Request, body: object) -> bool:
+    if _has_selector_name(request.path_params.keys()):
+        return True
     if _has_selector_name(request.query_params.keys()):
         return True
     if _has_selector_name(request.cookies.keys()):

--- a/services/api_gateway/tests/test_customer.py
+++ b/services/api_gateway/tests/test_customer.py
@@ -8,6 +8,7 @@ if str(ROOT_DIR) not in sys.path:
     sys.path.insert(0, str(ROOT_DIR))
 
 from services.api_gateway.app import app
+from services.api_gateway.auth import require_ssf_user
 from services.api_gateway.session_manager import session_manager
 
 client = TestClient(app)
@@ -16,7 +17,11 @@ client = TestClient(app)
 class TestCustomerRoutes:
     def setup_method(self):
         """Reset session manager before each test"""
+        app.dependency_overrides[require_ssf_user] = lambda: {"sub": "test-admin"}
         session_manager.reset(clear_persistence=True)
+
+    def teardown_method(self):
+        app.dependency_overrides.pop(require_ssf_user, None)
 
     def test_activate_session_success(self):
         """Test successful session activation"""

--- a/services/frontend/DEPLOYMENT.md
+++ b/services/frontend/DEPLOYMENT.md
@@ -1,5 +1,54 @@
 # Frontend Deployment Guide
 
+## Tenant login production gate
+
+The tenant chooser and multi-realm login must not be enabled for production
+conversations until every item below is complete:
+
+1. The Studio login directory returns at least two ready tenant entries.
+2. Studio has provisioned every listed realm with the common public
+   `ssf-frontend` client, PKCE S256, the exact application origin and
+   `/login/*` redirects, the `ssf-frontend` audience, the `ssf-user` role, and
+   the signed `studio_tenant_id` and `ssf_authorization_revision` claims.
+3. `SSF_ENABLE_LEGACY_ADMIN_ACCESS=false` is active before multi-realm login is
+   enabled.
+4. The separate OpenSpec change `add-multi-tenant-operations` has implemented
+   and passed its tenant-isolation tests for session creation, history, lookup,
+   termination, messages, audio, and customer joins. The login-directory work
+   establishes identity context only; it does not prove conversation storage
+   isolation.
+5. Operators have manually verified login, reuse of an existing SSO session,
+   logout, an unknown tenant route, a Studio outage, and cross-tenant negative
+   access paths in the deployed environment.
+
+Build the frontend image with the trusted Keycloak origin and common public
+client ID. These values are public browser configuration, not credentials:
+
+```bash
+docker build \
+  --build-arg VITE_API_BASE_URL=https://ssf.smart-village.solutions \
+  --build-arg VITE_WS_BASE_URL=wss://ssf.smart-village.solutions \
+  --build-arg VITE_KEYCLOAK_URL=https://auth.dialog.kassel.de \
+  --build-arg VITE_KEYCLOAK_CLIENT_ID=ssf-frontend \
+  -f services/frontend/Dockerfile \
+  services/frontend
+```
+
+### Tenant login smoke procedure
+
+- Open `/login` and confirm at least two Studio-provided organisations appear.
+- Select each tenant with and without an existing SSO session; confirm the
+  callback remains under `/login/<tenant-id>` and opens only that tenant's
+  administration view.
+- Log out from each realm and confirm the browser returns to `/login`.
+- Open an unknown `/login/<tenant-id>` and confirm no Keycloak client is
+  initialized and only a neutral unavailable message is shown.
+- Make the Studio directory temporarily unavailable after the configured cache
+  expires and confirm new login selection and issuer admission fail closed.
+- Run cross-tenant negative checks from `add-multi-tenant-operations` and
+  confirm one tenant cannot create, read, update, terminate, or join another
+  tenant's conversations or access its messages and audio.
+
 ## ✅ Production-Ready Checklist
 
 Das Frontend ist vollständig implementiert und bereit für Deployment unter **translate.smart-village.solutions**
@@ -203,9 +252,10 @@ docker compose ps frontend
 docker compose logs frontend | head -20
 ```
 
-## 🎯 Ready for Production!
+## 🎯 Legacy single-tenant baseline
 
-Das Frontend ist vollständig implementiert und getestet. Alle Kernfunktionen sind vorhanden:
+The items below describe the existing single-tenant baseline. They do not
+override the multi-tenant production gate above.
 
 - ✅ Session Management
 - ✅ Messaging (Text + Audio)

--- a/services/frontend/Dockerfile
+++ b/services/frontend/Dockerfile
@@ -27,6 +27,7 @@ COPY vite.config.ts ./
 ARG VITE_API_BASE_URL
 ARG VITE_WS_BASE_URL
 ARG VITE_KEYCLOAK_URL
+ARG VITE_KEYCLOAK_CLIENT_ID
 # This value is intentionally public because Vite embeds it in browser code.
 # It is a demo UI gate, not an authentication secret.
 ARG VITE_DEMO_ACCESS_CODE
@@ -49,6 +50,7 @@ RUN if [ -z "${VITE_API_BASE_URL}" ] || [ -z "${VITE_WS_BASE_URL}" ]; then \
 RUN VITE_API_BASE_URL="${VITE_API_BASE_URL}" \
     VITE_WS_BASE_URL="${VITE_WS_BASE_URL}" \
     VITE_KEYCLOAK_URL="${VITE_KEYCLOAK_URL}" \
+    VITE_KEYCLOAK_CLIENT_ID="${VITE_KEYCLOAK_CLIENT_ID}" \
     VITE_APP_PASSWORD="${VITE_DEMO_ACCESS_CODE}" \
     npm run build
 

--- a/services/frontend/src/app/auth/__tests__/keycloak.test.ts
+++ b/services/frontend/src/app/auth/__tests__/keycloak.test.ts
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { readConfig } from '@/app/config/env';
+
+const { construct, clients } = vi.hoisted(() => ({
+  construct: vi.fn(),
+  clients: [] as Array<{
+    authenticated: boolean;
+    token?: string;
+    loginRequired: boolean;
+    init: ReturnType<typeof vi.fn>;
+    updateToken: ReturnType<typeof vi.fn>;
+    clearToken: ReturnType<typeof vi.fn>;
+    logout: ReturnType<typeof vi.fn>;
+  }>,
+}));
+
+vi.mock('keycloak-js', () => ({
+  default: class {
+    constructor(options: unknown) {
+      construct(options);
+      const client = {
+        authenticated: true,
+        token: 'access-token',
+        loginRequired: true,
+        init: vi.fn().mockResolvedValue(true),
+        updateToken: vi.fn().mockResolvedValue(true),
+        clearToken: vi.fn(() => {
+          client.authenticated = false;
+          client.token = '';
+        }),
+        logout: vi.fn().mockResolvedValue(undefined),
+      };
+      clients.push(client);
+      return client;
+    }
+  },
+}));
+
+const config = readConfig({ VITE_KEYCLOAK_URL: 'https://auth.dialog.kassel.de' });
+const kassel = { id: 'tenant-kassel', displayName: 'Stadt Kassel', realm: 'kassel-ssf-2025' };
+const fulda = { id: 'tenant-fulda', displayName: 'Amt Fulda', realm: 'fulda-ssf-2025' };
+
+describe('tenant Keycloak session', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    construct.mockClear();
+    clients.length = 0;
+  });
+
+  it('uses the directory realm and exact tenant callback with PKCE S256', async () => {
+    const auth = await import('../keycloak');
+    expect(await auth.requireKeycloakLogin(config, kassel)).toBe(true);
+    expect(construct).toHaveBeenCalledWith({
+      url: 'https://auth.dialog.kassel.de',
+      realm: 'kassel-ssf-2025',
+      clientId: 'ssf-frontend',
+    });
+    expect(clients[0].init).toHaveBeenCalledWith({
+      onLoad: 'login-required',
+      pkceMethod: 'S256',
+      redirectUri: `${window.location.origin}/login/tenant-kassel`,
+    });
+  });
+
+  it('shares initialization for repeated concurrent calls', async () => {
+    const auth = await import('../keycloak');
+    const first = auth.requireKeycloakLogin(config, kassel);
+    clients[0].authenticated = false;
+    const second = auth.requireKeycloakLogin(config, kassel);
+    expect(await first).toBe(true);
+    expect(await second).toBe(true);
+    expect(construct).toHaveBeenCalledTimes(1);
+    expect(clients[0].init).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears the previous tenant without redirecting back to its realm', async () => {
+    const auth = await import('../keycloak');
+    await auth.requireKeycloakLogin(config, kassel);
+    await auth.requireKeycloakLogin(config, fulda);
+    expect(clients[0].loginRequired).toBe(false);
+    expect(clients[0].clearToken).toHaveBeenCalledOnce();
+    expect(construct).toHaveBeenLastCalledWith({
+      url: 'https://auth.dialog.kassel.de',
+      realm: 'fulda-ssf-2025',
+      clientId: 'ssf-frontend',
+    });
+    clients[1].token = 'fulda-token';
+    expect(await auth.getAdminAccessToken()).toBe('fulda-token');
+  });
+
+  it('replaces the client if the directory remaps the same tenant', async () => {
+    const auth = await import('../keycloak');
+    await auth.requireKeycloakLogin(config, kassel);
+    await auth.requireKeycloakLogin(config, { ...kassel, realm: 'new-kassel' });
+    expect(construct).toHaveBeenCalledTimes(2);
+    expect(clients[0].clearToken).toHaveBeenCalledOnce();
+  });
+
+  it('encodes the tenant ID in the callback and never persists tokens', async () => {
+    const storage = vi.spyOn(Storage.prototype, 'setItem');
+    const auth = await import('../keycloak');
+    await auth.requireKeycloakLogin(config, { ...kassel, id: 'tenant:kassel' });
+    expect(clients[0].init).toHaveBeenCalledWith(
+      expect.objectContaining({
+        redirectUri: `${window.location.origin}/login/tenant%3Akassel`,
+      })
+    );
+    await auth.getAdminAccessToken();
+    expect(storage).not.toHaveBeenCalled();
+    storage.mockRestore();
+  });
+
+  it('refreshes before returning a token and clears failed refreshes', async () => {
+    const auth = await import('../keycloak');
+    expect(await auth.getAdminAccessToken()).toBeNull();
+    await auth.requireKeycloakLogin(config, kassel);
+    clients[0].updateToken.mockImplementation(async () => {
+      clients[0].token = 'fresh';
+    });
+    expect(await auth.getAdminAccessToken()).toBe('fresh');
+    expect(clients[0].updateToken).toHaveBeenCalledWith(30);
+    clients[0].updateToken.mockRejectedValue(new Error('expired'));
+    expect(await auth.getAdminAccessToken()).toBeNull();
+    expect(clients[0].clearToken).toHaveBeenCalledOnce();
+  });
+
+  it('never returns a token from a tenant replaced during refresh', async () => {
+    const auth = await import('../keycloak');
+    await auth.requireKeycloakLogin(config, kassel);
+    let finish!: () => void;
+    clients[0].updateToken.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          finish = resolve;
+        })
+    );
+    const pending = auth.getAdminAccessToken();
+    await auth.requireKeycloakLogin(config, fulda);
+    finish();
+    expect(await pending).toBeNull();
+  });
+
+  it('logs out to the chooser and discards the in-memory token', async () => {
+    const auth = await import('../keycloak');
+    await auth.requireKeycloakLogin(config, kassel);
+    await auth.logoutFromKeycloak();
+    expect(clients[0].logout).toHaveBeenCalledWith({
+      redirectUri: `${window.location.origin}/login`,
+    });
+    expect(await auth.getAdminAccessToken()).toBeNull();
+  });
+});

--- a/services/frontend/src/app/auth/__tests__/keycloak.test.ts
+++ b/services/frontend/src/app/auth/__tests__/keycloak.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { readConfig } from '@/app/config/env';
+import { http, HttpResponse } from 'msw';
+import { server } from '@/test/setup';
 
 const { construct, clients } = vi.hoisted(() => ({
   construct: vi.fn(),
@@ -112,6 +114,8 @@ describe('tenant Keycloak session', () => {
 
   it('refreshes before returning a token and clears failed refreshes', async () => {
     const auth = await import('../keycloak');
+    const onExpired = vi.fn();
+    const unsubscribe = auth.subscribeToKeycloakExpiration(onExpired);
     expect(await auth.getAdminAccessToken()).toBeNull();
     await auth.requireKeycloakLogin(config, kassel);
     clients[0].updateToken.mockImplementation(async () => {
@@ -120,8 +124,31 @@ describe('tenant Keycloak session', () => {
     expect(await auth.getAdminAccessToken()).toBe('fresh');
     expect(clients[0].updateToken).toHaveBeenCalledWith(30);
     clients[0].updateToken.mockRejectedValue(new Error('expired'));
-    expect(await auth.getAdminAccessToken()).toBeNull();
+    await expect(auth.getAdminAccessToken()).rejects.toThrow('Keycloak session expired');
+    expect(onExpired).toHaveBeenCalledOnce();
+    unsubscribe();
     expect(clients[0].clearToken).toHaveBeenCalledOnce();
+    expect(await auth.requireKeycloakLogin(config, kassel)).toBe(true);
+    expect(construct).toHaveBeenCalledTimes(2);
+    expect(await auth.getAdminAccessToken()).toBe('access-token');
+  });
+
+  it('never sends legacy credentials after a refresh failure', async () => {
+    const auth = await import('../keycloak');
+    const { createHttpClient } = await import('@/core/http/client');
+    await auth.requireKeycloakLogin(config, kassel);
+    clients[0].updateToken.mockRejectedValue(new Error('expired'));
+    let requests = 0;
+    server.use(
+      http.get('*/api/admin/probe', () => {
+        requests += 1;
+        return HttpResponse.json({ ok: true });
+      })
+    );
+    const client = createHttpClient(config, () => 'en');
+    await expect(client.get('/api/admin/probe')).rejects.toThrow();
+    await expect(client.get('/api/admin/probe')).rejects.toThrow();
+    expect(requests).toBe(0);
   });
 
   it('never returns a token from a tenant replaced during refresh', async () => {
@@ -137,7 +164,7 @@ describe('tenant Keycloak session', () => {
     const pending = auth.getAdminAccessToken();
     await auth.requireKeycloakLogin(config, fulda);
     finish();
-    expect(await pending).toBeNull();
+    await expect(pending).rejects.toThrow('Keycloak session changed');
   });
 
   it('logs out to the chooser and discards the in-memory token', async () => {

--- a/services/frontend/src/app/auth/keycloak.ts
+++ b/services/frontend/src/app/auth/keycloak.ts
@@ -11,6 +11,24 @@ interface ActiveKeycloakSession {
 }
 
 let active: ActiveKeycloakSession | null = null;
+let expired = false;
+const expirationListeners = new Set<() => void>();
+
+export function subscribeToKeycloakExpiration(listener: () => void): () => void {
+  expirationListeners.add(listener);
+  return () => {
+    expirationListeners.delete(listener);
+  };
+}
+
+function expireSession(session: ActiveKeycloakSession): void {
+  clearSession(session);
+  if (active === session) {
+    active = null;
+    expired = true;
+    for (const listener of expirationListeners) listener();
+  }
+}
 
 function clearSession(session: ActiveKeycloakSession): void {
   // clearToken otherwise starts another login when init used login-required.
@@ -50,6 +68,7 @@ export async function requireKeycloakLogin(
       return false;
     }
     session.initialized = true;
+    expired = false;
     return authenticated;
   } catch (error) {
     clearSession(session);
@@ -60,19 +79,30 @@ export async function requireKeycloakLogin(
 
 export async function getAdminAccessToken(): Promise<string | null> {
   const session = active;
-  if (session === null || !session.client.authenticated) return null;
-  try {
-    await session.client.updateToken(30);
-    return active === session ? (session.client.token ?? null) : null;
-  } catch {
-    clearSession(session);
+  if (session === null) {
+    if (expired) throw new Error('Keycloak session expired');
     return null;
   }
+  if (!session.initialized) throw new Error('Keycloak session not ready');
+  try {
+    if (!session.client.authenticated) throw new Error('Keycloak session expired');
+    await session.client.updateToken(30);
+  } catch {
+    expireSession(session);
+    throw new Error('Keycloak session expired');
+  }
+  if (active !== session) throw new Error('Keycloak session changed');
+  if (!session.client.token) {
+    expireSession(session);
+    throw new Error('Keycloak session expired');
+  }
+  return session.client.token;
 }
 
 export async function logoutFromKeycloak(): Promise<void> {
   const session = active;
   active = null;
+  expired = false;
   if (session !== null) {
     try {
       await session.client.logout({ redirectUri: `${window.location.origin}/login` });

--- a/services/frontend/src/app/auth/keycloak.ts
+++ b/services/frontend/src/app/auth/keycloak.ts
@@ -1,46 +1,83 @@
 import Keycloak from 'keycloak-js';
 import type { AppConfig } from '@/app/config/env';
+import type { LoginTenant } from '@/domain/login-tenant/loginTenant.types';
 
-let client: Keycloak | null = null;
-let initialized = false;
-
-function configured(config: AppConfig): Keycloak {
-  if (client === null) {
-    client = new Keycloak({
-      url: config.keycloakUrl,
-      realm: config.keycloakRealm,
-      clientId: config.keycloakClientId,
-    });
-  }
-  return client;
+interface ActiveKeycloakSession {
+  tenantId: string;
+  realm: string;
+  client: Keycloak;
+  initialized: boolean;
+  initialization: Promise<boolean> | null;
 }
 
-export async function requireKeycloakLogin(config: AppConfig): Promise<boolean> {
-  const keycloak = configured(config);
-  if (!initialized) {
-    initialized = true;
-    return keycloak.init({
-      onLoad: 'login-required',
-      pkceMethod: 'S256',
-      redirectUri: `${window.location.origin}/login`,
-    });
+let active: ActiveKeycloakSession | null = null;
+
+function clearSession(session: ActiveKeycloakSession): void {
+  // clearToken otherwise starts another login when init used login-required.
+  session.client.loginRequired = false;
+  session.client.clearToken();
+}
+
+export async function requireKeycloakLogin(
+  config: AppConfig,
+  tenant: LoginTenant
+): Promise<boolean> {
+  if (active === null || active.tenantId !== tenant.id || active.realm !== tenant.realm) {
+    if (active !== null) clearSession(active);
+    active = {
+      tenantId: tenant.id,
+      realm: tenant.realm,
+      client: new Keycloak({
+        url: config.keycloakUrl,
+        realm: tenant.realm,
+        clientId: config.keycloakClientId,
+      }),
+      initialized: false,
+      initialization: null,
+    };
   }
-  return keycloak.authenticated === true;
+  const session = active;
+  if (session.initialized) return session.client.authenticated === true;
+  session.initialization ??= session.client.init({
+    onLoad: 'login-required',
+    pkceMethod: 'S256',
+    redirectUri: `${window.location.origin}/login/${encodeURIComponent(tenant.id)}`,
+  });
+  try {
+    const authenticated = await session.initialization;
+    if (active !== session) {
+      clearSession(session);
+      return false;
+    }
+    session.initialized = true;
+    return authenticated;
+  } catch (error) {
+    clearSession(session);
+    if (active === session) active = null;
+    throw error;
+  }
 }
 
 export async function getAdminAccessToken(): Promise<string | null> {
-  if (client === null || !client.authenticated) return null;
+  const session = active;
+  if (session === null || !session.client.authenticated) return null;
   try {
-    await client.updateToken(30);
-    return client.token ?? null;
+    await session.client.updateToken(30);
+    return active === session ? (session.client.token ?? null) : null;
   } catch {
-    client.clearToken();
+    clearSession(session);
     return null;
   }
 }
 
 export async function logoutFromKeycloak(): Promise<void> {
-  if (client !== null) {
-    await client.logout({ redirectUri: window.location.origin });
+  const session = active;
+  active = null;
+  if (session !== null) {
+    try {
+      await session.client.logout({ redirectUri: `${window.location.origin}/login` });
+    } finally {
+      clearSession(session);
+    }
   }
 }

--- a/services/frontend/src/app/config/__tests__/env.test.ts
+++ b/services/frontend/src/app/config/__tests__/env.test.ts
@@ -1,6 +1,43 @@
 import { describe, expect, it } from 'vitest';
 import { readConfig } from '@/app/config/env';
 
+describe('Keycloak configuration', () => {
+  it('uses a shared origin and client without a fixed realm', () => {
+    const config = readConfig({
+      VITE_KEYCLOAK_URL: 'https://auth.dialog.kassel.de/',
+      VITE_KEYCLOAK_CLIENT_ID: 'ssf-frontend',
+      VITE_KEYCLOAK_REALM: 'untrusted-fixed-realm',
+    });
+    expect(config.keycloakUrl).toBe('https://auth.dialog.kassel.de');
+    expect(config.keycloakClientId).toBe('ssf-frontend');
+    expect(config).not.toHaveProperty('keycloakRealm');
+  });
+
+  it.each([
+    'ftp://auth.test',
+    'https://user:pass@auth.test',
+    'https://auth.test/realms/ssf',
+    'https://auth.test?realm=ssf',
+    'https://auth.test#ssf',
+    'https://auth.test//',
+    'https://auth.test?',
+    'https://auth.test#',
+    ' https://auth.test',
+  ])('rejects a non-origin Keycloak URL: %s', (url) => {
+    expect(() => readConfig({ VITE_KEYCLOAK_URL: url })).toThrow('Invalid environment');
+  });
+
+  it('allows an HTTP development origin with a port', () => {
+    expect(readConfig({ VITE_KEYCLOAK_URL: 'http://localhost:8080/' }).keycloakUrl).toBe(
+      'http://localhost:8080'
+    );
+  });
+
+  it.each(['', '   '])('rejects an empty public client ID: %j', (clientId) => {
+    expect(() => readConfig({ VITE_KEYCLOAK_CLIENT_ID: clientId })).toThrow('Invalid environment');
+  });
+});
+
 describe('the interim admin password', () => {
   it('falls back to the legacy password when none is set', () => {
     expect(readConfig({}).adminPassword).toBe('ssf2025kassel');

--- a/services/frontend/src/app/config/env.ts
+++ b/services/frontend/src/app/config/env.ts
@@ -2,15 +2,29 @@ import { z } from 'zod';
 
 export type BrandId = 'ssf' | 'kassel';
 
+function isHttpOrigin(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return (
+      (url.protocol === 'https:' || url.protocol === 'http:') &&
+      (value === url.origin || value === `${url.origin}/`)
+    );
+  } catch {
+    return false;
+  }
+}
+
 const envSchema = z.object({
   /** Empty in development: the Vite proxy forwards /api to the gateway. */
   VITE_API_BASE_URL: z.string().default(''),
   /** Empty means "derive from window.location". */
   VITE_WS_BASE_URL: z.string().default(''),
   VITE_BRAND: z.enum(['ssf', 'kassel']).default('ssf'),
-  VITE_KEYCLOAK_URL: z.string().url().default('https://auth.kassel.smartspeechflow.de'),
-  VITE_KEYCLOAK_REALM: z.string().min(1).default('ssf'),
-  VITE_KEYCLOAK_CLIENT_ID: z.string().min(1).default('ssf-frontend'),
+  VITE_KEYCLOAK_URL: z
+    .string()
+    .refine(isHttpOrigin, 'Expected an HTTP(S) origin')
+    .default('https://auth.kassel.smartspeechflow.de'),
+  VITE_KEYCLOAK_CLIENT_ID: z.string().trim().min(1).default('ssf-frontend'),
   VITE_APP_PASSWORD: z.string().default('ssf2025kassel'),
   /**
    * Temporary legacy `/admin` password. `z.string()` with a default, not a
@@ -31,7 +45,6 @@ export interface AppConfig {
   wsBaseUrl: string;
   brand: BrandId;
   keycloakUrl: string;
-  keycloakRealm: string;
   keycloakClientId: string;
   adminPassword: string;
   requestTimeoutMs: number;
@@ -56,8 +69,7 @@ export function readConfig(source: Record<string, unknown> = import.meta.env): A
     apiBaseUrl: env.VITE_API_BASE_URL,
     wsBaseUrl: env.VITE_WS_BASE_URL || defaultWsBaseUrl(),
     brand: env.VITE_BRAND,
-    keycloakUrl: env.VITE_KEYCLOAK_URL,
-    keycloakRealm: env.VITE_KEYCLOAK_REALM,
+    keycloakUrl: env.VITE_KEYCLOAK_URL.replace(/\/$/, ''),
     keycloakClientId: env.VITE_KEYCLOAK_CLIENT_ID,
     adminPassword: env.VITE_APP_PASSWORD,
     requestTimeoutMs: env.VITE_REQUEST_TIMEOUT_MS,

--- a/services/frontend/src/app/providers/__tests__/AppProvidersInner.test.tsx
+++ b/services/frontend/src/app/providers/__tests__/AppProvidersInner.test.tsx
@@ -43,6 +43,12 @@ function setup() {
 const click = (name: string) => userEvent.click(screen.getByRole('button', { name }));
 
 describe('AppProvidersInner', () => {
+  it('provides the login tenant directory repository to screens', () => {
+    const [services] = setup();
+
+    expect(services.loginTenant.list).toBeTypeOf('function');
+  });
+
   // The services own the socket factory and the repositories. Rebuilding them
   // tore down the live conversation socket and refetched history the moment the
   // session's language arrived, which is on every load of the conversation.

--- a/services/frontend/src/app/providers/services.ts
+++ b/services/frontend/src/app/providers/services.ts
@@ -19,6 +19,8 @@ import { createHealthRepository } from '@/domain/health/health.repository';
 import type { HealthRepository } from '@/domain/health/health.repository';
 import { createStaticBrandSource } from '@/domain/brand/StaticBrandSource';
 import type { BrandSource } from '@/domain/brand/brand.port';
+import { createLoginTenantRepository } from '@/domain/login-tenant/loginTenant.repository';
+import type { LoginTenantRepository } from '@/domain/login-tenant/loginTenant.repository';
 
 export interface Services {
   config: AppConfig;
@@ -27,6 +29,7 @@ export interface Services {
   message: MessageRepository;
   health: HealthRepository;
   admin: AdminRepository;
+  loginTenant: LoginTenantRepository;
   feedback: FeedbackSink;
   consent: ConsentSink;
   brand: BrandSource;
@@ -49,6 +52,7 @@ export function createServices(config: AppConfig, getLocale: () => string): Serv
     consent: createStubConsentSink(),
     health: createHealthRepository(http),
     admin: createAdminRepository(http),
+    loginTenant: createLoginTenantRepository(http),
     brand: createStaticBrandSource(config.brand),
     createRealtime: () => createWebSocketTransport({ wsBaseUrl: config.wsBaseUrl }),
   };

--- a/services/frontend/src/app/router/AppRoutes.tsx
+++ b/services/frontend/src/app/router/AppRoutes.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, type ReactNode } from 'react';
+import { QueryClient, QueryClientProvider, useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import { Navigate, Route, Routes, useNavigate, useParams } from 'react-router-dom';
 import { RequireSession } from './RequireSession';
@@ -13,7 +14,11 @@ import ProtectedRoute from '@/components/ProtectedRoute';
 import { useServices } from '@/app/providers/services';
 import { AdminDashboardScreen } from '@/features/admin/AdminDashboardScreen';
 import { AdminSessionScreen } from '@/features/admin/AdminSessionScreen';
-import { logoutFromKeycloak, requireKeycloakLogin } from '@/app/auth/keycloak';
+import {
+  logoutFromKeycloak,
+  requireKeycloakLogin,
+  subscribeToKeycloakExpiration,
+} from '@/app/auth/keycloak';
 import { AdminLoginScreen } from '@/features/admin/AdminLoginScreen';
 import { useAdminAuth } from '@/features/admin/useAdminAuth';
 import { TenantLoginScreen } from '@/features/login/TenantLoginScreen';
@@ -26,7 +31,24 @@ function JoinRedirect() {
 
 function TenantLoginEntry() {
   const { tenantId = '' } = useParams<{ tenantId: string }>();
-  return <TenantLoginSession key={tenantId} tenantId={tenantId} />;
+  return (
+    <AdminQueryBoundary key={tenantId}>
+      <TenantLoginSession tenantId={tenantId} />
+    </AdminQueryBoundary>
+  );
+}
+
+/** Each administrative entry owns its entire query cache, including session queries. */
+function AdminQueryBoundary({ children }: { children: ReactNode }) {
+  const parent = useQueryClient();
+  const [client] = useState(() => new QueryClient({ defaultOptions: parent.getDefaultOptions() }));
+  useEffect(
+    () => () => {
+      client.clear();
+    },
+    [client]
+  );
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
 }
 
 /** Resolve the route ID through the validated directory before using a realm. */
@@ -38,6 +60,14 @@ function TenantLoginSession({ tenantId }: { tenantId: string }) {
   );
   const [sessionId, setSessionId] = useState<string | null>(null);
   const navigate = useNavigate();
+
+  useEffect(
+    () =>
+      subscribeToKeycloakExpiration(() => {
+        void navigate('/login', { replace: true });
+      }),
+    [navigate]
+  );
 
   useEffect(() => {
     let cancelled = false;
@@ -115,7 +145,14 @@ export function AppRoutes() {
 
       <Route path="/login" element={<TenantLoginScreen />} />
       <Route path="/login/:tenantId" element={<TenantLoginEntry />} />
-      <Route path="/admin" element={<LegacyAdminEntry />} />
+      <Route
+        path="/admin"
+        element={
+          <AdminQueryBoundary>
+            <LegacyAdminEntry />
+          </AdminQueryBoundary>
+        }
+      />
 
       <Route
         path="/customer"

--- a/services/frontend/src/app/router/AppRoutes.tsx
+++ b/services/frontend/src/app/router/AppRoutes.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Navigate, Route, Routes, useNavigate, useParams } from 'react-router-dom';
 import { RequireSession } from './RequireSession';
 import { AccessCodeScreen } from '@/features/access-code/AccessCodeScreen';
@@ -15,6 +16,7 @@ import { AdminSessionScreen } from '@/features/admin/AdminSessionScreen';
 import { logoutFromKeycloak, requireKeycloakLogin } from '@/app/auth/keycloak';
 import { AdminLoginScreen } from '@/features/admin/AdminLoginScreen';
 import { useAdminAuth } from '@/features/admin/useAdminAuth';
+import { TenantLoginScreen } from '@/features/login/TenantLoginScreen';
 
 /** QR deep link: /join/:sessionId lands straight on the language picker. */
 function JoinRedirect() {
@@ -22,31 +24,56 @@ function JoinRedirect() {
   return <Navigate to={`/s/${sessionId}/language`} replace />;
 }
 
-/** Keycloak-protected administrative entrypoint. */
-function LoginEntry() {
-  const { config } = useServices();
-  const [authenticated, setAuthenticated] = useState(false);
-  const [ready, setReady] = useState(false);
+function TenantLoginEntry() {
+  const { tenantId = '' } = useParams<{ tenantId: string }>();
+  return <TenantLoginSession key={tenantId} tenantId={tenantId} />;
+}
+
+/** Resolve the route ID through the validated directory before using a realm. */
+function TenantLoginSession({ tenantId }: { tenantId: string }) {
+  const { config, loginTenant } = useServices();
+  const { t } = useTranslation();
+  const [status, setStatus] = useState<'loading' | 'authenticated' | 'missing' | 'error'>(
+    'loading'
+  );
   const [sessionId, setSessionId] = useState<string | null>(null);
   const navigate = useNavigate();
 
   useEffect(() => {
-    void requireKeycloakLogin(config).then((value) => {
-      setAuthenticated(value);
-      setReady(true);
-    });
-  }, [config]);
+    let cancelled = false;
+    void loginTenant
+      .list()
+      .then(async (tenants) => {
+        if (cancelled) return;
+        const tenant = tenants.find((entry) => entry.id === tenantId);
+        if (!tenant) {
+          setStatus('missing');
+          return;
+        }
+        const authenticated = await requireKeycloakLogin(config, tenant);
+        if (!cancelled && authenticated) setStatus('authenticated');
+      })
+      .catch(() => {
+        if (!cancelled) setStatus('error');
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [config, loginTenant, tenantId]);
 
   const leave = () => setSessionId(null);
 
-  // Return to the public entry after Keycloak sign-out.
   const out = () => {
     setSessionId(null);
-    void logoutFromKeycloak();
-    void navigate('/');
+    void logoutFromKeycloak().catch(() => {
+      /* The local session is already cleared. */
+    });
+    void navigate('/login');
   };
 
-  if (!ready || !authenticated) return null;
+  if (status === 'missing') return <NotFoundPage />;
+  if (status === 'error') return <p role="alert">{t('admin.tenantLogin.unavailable')}</p>;
+  if (status !== 'authenticated') return null;
 
   if (sessionId === null) {
     return <AdminDashboardScreen onEnterSession={setSessionId} onSignOut={out} />;
@@ -69,7 +96,9 @@ function LegacyAdminEntry() {
   if (sessionId === null) {
     return <AdminDashboardScreen onEnterSession={setSessionId} onSignOut={out} />;
   }
-  return <AdminSessionScreen sessionId={sessionId} onLeave={() => setSessionId(null)} onSignOut={out} />;
+  return (
+    <AdminSessionScreen sessionId={sessionId} onLeave={() => setSessionId(null)} onSignOut={out} />
+  );
 }
 
 export function AppRoutes() {
@@ -84,7 +113,8 @@ export function AppRoutes() {
         <Route path="live" element={<ConversationScreen />} />
       </Route>
 
-      <Route path="/login" element={<LoginEntry />} />
+      <Route path="/login" element={<TenantLoginScreen />} />
+      <Route path="/login/:tenantId" element={<TenantLoginEntry />} />
       <Route path="/admin" element={<LegacyAdminEntry />} />
 
       <Route

--- a/services/frontend/src/app/router/__tests__/AppRoutes.test.tsx
+++ b/services/frontend/src/app/router/__tests__/AppRoutes.test.tsx
@@ -5,11 +5,18 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderWithProviders } from '@/test/renderWithProviders';
 import { AppRoutes } from '@/app/router/AppRoutes';
 import { requireKeycloakLogin, logoutFromKeycloak } from '@/app/auth/keycloak';
+import type { AdminSession } from '@/domain/admin/admin.types';
+
+const { expirationListeners } = vi.hoisted(() => ({ expirationListeners: new Set<() => void>() }));
 
 vi.mock('@/app/auth/keycloak', () => ({
   requireKeycloakLogin: vi.fn(),
   logoutFromKeycloak: vi.fn(),
   getAdminAccessToken: vi.fn().mockResolvedValue('tenant-token'),
+  subscribeToKeycloakExpiration: (listener: () => void) => {
+    expirationListeners.add(listener);
+    return () => expirationListeners.delete(listener);
+  },
 }));
 
 const kassel = { id: 'tenant-kassel', displayName: 'Stadt Kassel', realm: 'kassel-ssf-2025' };
@@ -100,6 +107,84 @@ describe('tenant login routes', () => {
     await userEvent.click(screen.getByRole('button', { name: 'Abmelden' }));
     expect(await screen.findByRole('link', { name: 'Stadt Kassel' })).toBeInTheDocument();
     expect(logoutFromKeycloak).toHaveBeenCalledOnce();
+  });
+
+  it('returns to the chooser when the authenticated session expires', async () => {
+    renderWithProviders(<AppRoutes />, { route: '/login/tenant-kassel' });
+    await screen.findByRole('button', { name: 'Neues Gespräch starten' });
+    act(() => {
+      for (const listener of expirationListeners) listener();
+    });
+    expect(await screen.findByRole('link', { name: 'Stadt Kassel' })).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Neues Gespräch starten' })
+    ).not.toBeInTheDocument();
+  });
+
+  it.each(['cached', 'pending'])('isolates %s tenant A history from tenant B', async (state) => {
+    const row = (id: string): AdminSession => ({
+      id,
+      status: 'open',
+      customerLanguage: null,
+      createdAt: '2026-09-10T10:00:00Z',
+      terminatedAt: null,
+    });
+    let finishA!: (rows: AdminSession[]) => void;
+    let finishB!: (rows: AdminSession[]) => void;
+    const listSessions = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        state === 'cached'
+          ? Promise.resolve([row('TENANTA1')])
+          : new Promise<AdminSession[]>((resolve) => {
+              finishA = resolve;
+            })
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise<AdminSession[]>((resolve) => {
+            finishB = resolve;
+          })
+      );
+    renderWithProviders(
+      <>
+        <AppRoutes />
+        <Link to="/login/tenant-fulda">Switch tenant</Link>
+      </>,
+      {
+        route: '/login/tenant-kassel',
+        services: {
+          admin: {
+            listSessions,
+            createSession: vi.fn(),
+            terminateSession: vi.fn(),
+          },
+        },
+      }
+    );
+    await waitFor(() => expect(listSessions).toHaveBeenCalledTimes(1));
+    if (state === 'cached')
+      await screen.findByRole('button', { name: 'Gespräch TENANTA1 fortsetzen' });
+    await userEvent.click(screen.getByRole('link', { name: 'Switch tenant' }));
+    await waitFor(() =>
+      expect(requireKeycloakLogin).toHaveBeenLastCalledWith(expect.any(Object), {
+        id: 'tenant-fulda',
+        displayName: 'Amt Fulda',
+        realm: 'fulda-ssf-2025',
+      })
+    );
+    if (state === 'pending') await act(async () => finishA([row('TENANTA1')]));
+    expect(
+      screen.queryByRole('button', { name: 'Gespräch TENANTA1 fortsetzen' })
+    ).not.toBeInTheDocument();
+    await waitFor(() => expect(listSessions).toHaveBeenCalledTimes(2));
+    await act(async () => finishB([row('TENANTB1')]));
+    expect(
+      await screen.findByRole('button', { name: 'Gespräch TENANTB1 fortsetzen' })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Gespräch TENANTA1 fortsetzen' })
+    ).not.toBeInTheDocument();
   });
 
   it('cannot expose a previous dashboard after navigating to an unknown tenant', async () => {

--- a/services/frontend/src/app/router/__tests__/AppRoutes.test.tsx
+++ b/services/frontend/src/app/router/__tests__/AppRoutes.test.tsx
@@ -1,7 +1,152 @@
-import { screen } from '@testing-library/react';
-import { afterEach, describe, expect, it } from 'vitest';
+import { act, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Link, useLocation } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderWithProviders } from '@/test/renderWithProviders';
 import { AppRoutes } from '@/app/router/AppRoutes';
+import { requireKeycloakLogin, logoutFromKeycloak } from '@/app/auth/keycloak';
+
+vi.mock('@/app/auth/keycloak', () => ({
+  requireKeycloakLogin: vi.fn(),
+  logoutFromKeycloak: vi.fn(),
+  getAdminAccessToken: vi.fn().mockResolvedValue('tenant-token'),
+}));
+
+const kassel = { id: 'tenant-kassel', displayName: 'Stadt Kassel', realm: 'kassel-ssf-2025' };
+function Location() {
+  return <output aria-label="Location">{useLocation().pathname}</output>;
+}
+
+describe('tenant login routes', () => {
+  beforeEach(() => {
+    vi.mocked(requireKeycloakLogin).mockReset().mockResolvedValue(true);
+    vi.mocked(logoutFromKeycloak).mockReset().mockResolvedValue(undefined);
+    sessionStorage.clear();
+  });
+
+  it('shows the chooser without initializing Keycloak', async () => {
+    renderWithProviders(<AppRoutes />, { route: '/login' });
+    expect(await screen.findByRole('link', { name: 'Stadt Kassel' })).toHaveAttribute(
+      'href',
+      '/login/tenant-kassel'
+    );
+    expect(requireKeycloakLogin).not.toHaveBeenCalled();
+  });
+
+  it('resolves the full directory entry and shows the dashboard on the tenant callback', async () => {
+    renderWithProviders(
+      <>
+        <AppRoutes />
+        <Location />
+      </>,
+      { route: '/login/tenant-kassel?realm=evil' }
+    );
+    expect(
+      await screen.findByRole('button', { name: 'Neues Gespräch starten' })
+    ).toBeInTheDocument();
+    expect(requireKeycloakLogin).toHaveBeenCalledWith(expect.any(Object), kassel);
+    expect(screen.getByLabelText('Location')).toHaveTextContent('/login/tenant-kassel');
+  });
+
+  it('does not render the dashboard while Keycloak redirects', async () => {
+    vi.mocked(requireKeycloakLogin).mockResolvedValue(false);
+    renderWithProviders(<AppRoutes />, { route: '/login/tenant-kassel' });
+    await waitFor(() => expect(requireKeycloakLogin).toHaveBeenCalled());
+    expect(
+      screen.queryByRole('button', { name: 'Neues Gespräch starten' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('rejects unknown IDs without interpreting them as realms', async () => {
+    renderWithProviders(<AppRoutes />, { route: '/login/kassel-ssf-2025' });
+    expect(await screen.findByText(/404/)).toBeInTheDocument();
+    expect(requireKeycloakLogin).not.toHaveBeenCalled();
+  });
+
+  it('uses the router-decoded ID exactly once', async () => {
+    const tenant = { ...kassel, id: 'tenant:kassel' };
+    renderWithProviders(<AppRoutes />, {
+      route: '/login/tenant%3Akassel',
+      services: { loginTenant: { list: async () => [tenant] } },
+    });
+    await waitFor(() =>
+      expect(requireKeycloakLogin).toHaveBeenCalledWith(expect.any(Object), tenant)
+    );
+  });
+
+  it.each(['directory', 'authentication'])('fails neutrally on %s errors', async (source) => {
+    if (source === 'authentication')
+      vi.mocked(requireKeycloakLogin).mockRejectedValue(new Error('private details'));
+    renderWithProviders(<AppRoutes />, {
+      route: '/login/tenant-kassel',
+      services: {
+        loginTenant: {
+          list: async () => {
+            if (source === 'directory') throw new Error('private details');
+            return [kassel];
+          },
+        },
+      },
+    });
+    expect(await screen.findByRole('alert')).toBeInTheDocument();
+    expect(screen.queryByText('private details')).not.toBeInTheDocument();
+    if (source === 'directory') expect(requireKeycloakLogin).not.toHaveBeenCalled();
+  });
+
+  it('returns to the chooser on logout', async () => {
+    renderWithProviders(<AppRoutes />, { route: '/login/tenant-kassel' });
+    await screen.findByRole('button', { name: 'Neues Gespräch starten' });
+    await userEvent.click(screen.getByRole('button', { name: 'Benutzerkonto' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Abmelden' }));
+    expect(await screen.findByRole('link', { name: 'Stadt Kassel' })).toBeInTheDocument();
+    expect(logoutFromKeycloak).toHaveBeenCalledOnce();
+  });
+
+  it('cannot expose a previous dashboard after navigating to an unknown tenant', async () => {
+    renderWithProviders(
+      <>
+        <AppRoutes />
+        <Link to="/login/unknown">Unknown tenant</Link>
+      </>,
+      { route: '/login/tenant-kassel' }
+    );
+    await screen.findByRole('button', { name: 'Neues Gespräch starten' });
+    await userEvent.click(screen.getByRole('link', { name: 'Unknown tenant' }));
+    expect(
+      screen.queryByRole('button', { name: 'Neues Gespräch starten' })
+    ).not.toBeInTheDocument();
+    expect(await screen.findByText(/404/)).toBeInTheDocument();
+  });
+
+  it('ignores authentication completion after leaving the tenant route', async () => {
+    let finish!: (value: boolean) => void;
+    vi.mocked(requireKeycloakLogin).mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          finish = resolve;
+        })
+    );
+    renderWithProviders(
+      <>
+        <AppRoutes />
+        <Link to="/login/unknown">Unknown tenant</Link>
+      </>,
+      { route: '/login/tenant-kassel' }
+    );
+    await waitFor(() => expect(requireKeycloakLogin).toHaveBeenCalled());
+    await userEvent.click(screen.getByRole('link', { name: 'Unknown tenant' }));
+    await act(async () => finish(true));
+    expect(
+      screen.queryByRole('button', { name: 'Neues Gespräch starten' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('keeps the legacy password screen isolated at /admin', async () => {
+    renderWithProviders(<AppRoutes />, { route: '/admin' });
+    expect(await screen.findByLabelText('Passwort')).toBeInTheDocument();
+    expect(requireKeycloakLogin).not.toHaveBeenCalled();
+  });
+});
 
 describe('AppRoutes', () => {
   afterEach(() => {

--- a/services/frontend/src/core/http/__tests__/client.test.ts
+++ b/services/frontend/src/core/http/__tests__/client.test.ts
@@ -1,13 +1,50 @@
 import { http, HttpResponse } from 'msw';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { server } from '@/test/setup';
 import { AppError } from '@/core/http/AppError';
 import { createHttpClient } from '@/core/http/client';
 import { readConfig } from '@/app/config/env';
+import { getAdminAccessToken } from '@/app/auth/keycloak';
+
+vi.mock('@/app/auth/keycloak', () => ({ getAdminAccessToken: vi.fn() }));
 
 const config = readConfig({ VITE_API_BASE_URL: 'http://api.test' });
 
 describe('createHttpClient', () => {
+  beforeEach(() => vi.mocked(getAdminAccessToken).mockReset().mockResolvedValue(null));
+
+  it.each([
+    ['tenant-token', 'Bearer tenant-token', null],
+    [null, null, 'ssf2025kassel'],
+  ])('selects only the permitted credential for token %s', async (token, bearer, legacy) => {
+    vi.mocked(getAdminAccessToken).mockResolvedValue(token);
+    let seen: Headers | undefined;
+    server.use(
+      http.get('http://api.test/api/admin/history', ({ request }) => {
+        seen = request.headers;
+        return HttpResponse.json([]);
+      })
+    );
+    await createHttpClient(config, () => 'en').get('/api/admin/history');
+    expect(seen?.get('Authorization')).toBe(bearer);
+    expect(seen?.get('X-SSF-Legacy-Access')).toBe(legacy);
+  });
+
+  it('keeps the directory anonymous even with an active Keycloak session', async () => {
+    vi.mocked(getAdminAccessToken).mockResolvedValue('tenant-token');
+    let seen: Headers | undefined;
+    server.use(
+      http.get('http://api.test/api/login/tenants', ({ request }) => {
+        seen = request.headers;
+        return HttpResponse.json({ tenants: [] });
+      })
+    );
+    await createHttpClient(config, () => 'en').get('/api/login/tenants');
+    expect(seen?.get('Authorization')).toBeNull();
+    expect(seen?.get('X-SSF-Legacy-Access')).toBeNull();
+    expect(getAdminAccessToken).not.toHaveBeenCalled();
+  });
+
   it('attaches a correlation id and the active locale to every request', async () => {
     let seen: Record<string, string> = {};
     server.use(

--- a/services/frontend/src/domain/login-tenant/__tests__/loginTenant.test.ts
+++ b/services/frontend/src/domain/login-tenant/__tests__/loginTenant.test.ts
@@ -1,0 +1,90 @@
+import { http, HttpResponse } from 'msw';
+import { describe, expect, it } from 'vitest';
+import { readConfig } from '@/app/config/env';
+import { createHttpClient } from '@/core/http/client';
+import { toLoginTenants } from '@/domain/login-tenant/loginTenant.mapper';
+import { createLoginTenantRepository } from '@/domain/login-tenant/loginTenant.repository';
+import { server } from '@/test/setup';
+
+const validDirectory = {
+  tenants: [
+    { id: 'tenant-fulda', displayName: 'Amt Fulda', realm: 'fulda-ssf-2025' },
+    { id: 'tenant-kassel', displayName: 'Stadt Kassel', realm: 'kassel-ssf-2025' },
+  ],
+};
+
+describe('toLoginTenants', () => {
+  it('maps valid entries without changing the Studio directory order', () => {
+    expect(toLoginTenants(validDirectory)).toEqual([
+      { id: 'tenant-fulda', displayName: 'Amt Fulda', realm: 'fulda-ssf-2025' },
+      { id: 'tenant-kassel', displayName: 'Stadt Kassel', realm: 'kassel-ssf-2025' },
+    ]);
+  });
+
+  it('keeps domain entries limited to their public fields', () => {
+    expect(
+      toLoginTenants({
+        tenants: [
+          {
+            id: 'tenant-fulda',
+            displayName: 'Amt Fulda',
+            realm: 'fulda-ssf-2025',
+            futureStudioField: 'ignored',
+          },
+        ],
+      })
+    ).toEqual([{ id: 'tenant-fulda', displayName: 'Amt Fulda', realm: 'fulda-ssf-2025' }]);
+  });
+
+  it.each([
+    ['a blank tenant ID', { tenants: [{ id: ' ', displayName: 'Amt Fulda', realm: 'fulda-ssf-2025' }] }],
+    [
+      'duplicate tenant IDs',
+      {
+        tenants: [
+          { id: 'tenant-fulda', displayName: 'Amt Fulda', realm: 'fulda-ssf-2025' },
+          { id: 'tenant-fulda', displayName: 'Stadt Kassel', realm: 'kassel-ssf-2025' },
+        ],
+      },
+    ],
+    ['a blank realm', { tenants: [{ id: 'tenant-fulda', displayName: 'Amt Fulda', realm: ' ' }] }],
+    [
+      'duplicate realms',
+      {
+        tenants: [
+          { id: 'tenant-fulda', displayName: 'Amt Fulda', realm: 'fulda-ssf-2025' },
+          { id: 'tenant-kassel', displayName: 'Stadt Kassel', realm: 'fulda-ssf-2025' },
+        ],
+      },
+    ],
+    [
+      'a blank display name',
+      { tenants: [{ id: 'tenant-fulda', displayName: ' ', realm: 'fulda-ssf-2025' }] },
+    ],
+    [
+      'invalid realm characters',
+      { tenants: [{ id: 'tenant-fulda', displayName: 'Amt Fulda', realm: 'fulda/ssf' }] },
+    ],
+    ['a non-array tenants field', { tenants: {} }],
+    ['a non-object tenant entry', { tenants: ['tenant-fulda'] }],
+  ])('rejects %s', (_description, directory) => {
+    expect(() => toLoginTenants(directory)).toThrow('Invalid login tenant directory response');
+  });
+});
+
+describe('login tenant repository', () => {
+  it('gets the anonymous tenant directory without an Authorization header', async () => {
+    let authorization: string | null = 'not requested';
+    server.use(
+      http.get('http://api.test/api/login/tenants', ({ request }) => {
+        authorization = request.headers.get('Authorization');
+        return HttpResponse.json(validDirectory);
+      })
+    );
+    const httpClient = createHttpClient(readConfig({ VITE_API_BASE_URL: 'http://api.test' }), () => 'de');
+    const repository = createLoginTenantRepository(httpClient);
+
+    await expect(repository.list()).resolves.toEqual(validDirectory.tenants);
+    expect(authorization).toBeNull();
+  });
+});

--- a/services/frontend/src/domain/login-tenant/loginTenant.mapper.ts
+++ b/services/frontend/src/domain/login-tenant/loginTenant.mapper.ts
@@ -1,0 +1,57 @@
+import type { LoginTenant } from './loginTenant.types';
+
+export interface LoginTenantDirectoryDto {
+  tenants?: unknown;
+}
+
+const REALM_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+const INVALID_DIRECTORY_ERROR = 'Invalid login tenant directory response';
+
+function isNonBlankString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isLoginTenantDirectoryDto(value: unknown): value is LoginTenantDirectoryDto {
+  return isRecord(value);
+}
+
+function isLoginTenant(value: unknown): value is LoginTenant {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  const { id, displayName, realm } = value;
+  return (
+    isNonBlankString(id) &&
+    isNonBlankString(displayName) &&
+    isNonBlankString(realm) &&
+    REALM_PATTERN.test(realm)
+  );
+}
+
+export function toLoginTenants(dto: unknown): LoginTenant[] {
+  if (!isLoginTenantDirectoryDto(dto)) {
+    throw new Error(INVALID_DIRECTORY_ERROR);
+  }
+
+  const { tenants } = dto;
+  if (!Array.isArray(tenants) || !tenants.every(isLoginTenant)) {
+    throw new Error(INVALID_DIRECTORY_ERROR);
+  }
+
+  const ids = new Set<string>();
+  const realms = new Set<string>();
+  for (const tenant of tenants) {
+    if (ids.has(tenant.id) || realms.has(tenant.realm)) {
+      throw new Error(INVALID_DIRECTORY_ERROR);
+    }
+    ids.add(tenant.id);
+    realms.add(tenant.realm);
+  }
+
+  return tenants.map(({ id, displayName, realm }) => ({ id, displayName, realm }));
+}

--- a/services/frontend/src/domain/login-tenant/loginTenant.repository.ts
+++ b/services/frontend/src/domain/login-tenant/loginTenant.repository.ts
@@ -1,0 +1,17 @@
+import type { AxiosInstance } from 'axios';
+import { toLoginTenants } from './loginTenant.mapper';
+import type { LoginTenantDirectoryDto } from './loginTenant.mapper';
+import type { LoginTenant } from './loginTenant.types';
+
+export interface LoginTenantRepository {
+  list(): Promise<LoginTenant[]>;
+}
+
+export function createLoginTenantRepository(http: AxiosInstance): LoginTenantRepository {
+  return {
+    async list() {
+      const response = await http.get<LoginTenantDirectoryDto>('/api/login/tenants');
+      return toLoginTenants(response.data);
+    },
+  };
+}

--- a/services/frontend/src/domain/login-tenant/loginTenant.types.ts
+++ b/services/frontend/src/domain/login-tenant/loginTenant.types.ts
@@ -1,0 +1,5 @@
+export interface LoginTenant {
+  id: string;
+  displayName: string;
+  realm: string;
+}

--- a/services/frontend/src/features/access-code/AccessCodeScreen.tsx
+++ b/services/frontend/src/features/access-code/AccessCodeScreen.tsx
@@ -13,6 +13,7 @@ import { AppHeader } from '@/ui/patterns/AppHeader';
 import { CODE_LENGTH, normalizeCode } from '@/lib/accessCode';
 import { CodeInput } from '@/ui/patterns/CodeInput';
 import { ScreenShell } from '@/ui/patterns/ScreenShell';
+import { StartPageFooter } from '@/ui/patterns/StartPageFooter';
 
 export function AccessCodeScreen() {
   const { t } = useTranslation();
@@ -89,31 +90,12 @@ export function AccessCodeScreen() {
             to="/login"
             className="text-note font-normal tracking-link text-fg-link underline underline-offset-2 transition-colors duration-200 hover:text-fg-link-hover"
           >
-            Neuer Admin-Login
-          </Link>
-          <Link
-            to="/admin"
-            className="text-note font-normal tracking-link text-fg-link underline underline-offset-2 transition-colors duration-200 hover:text-fg-link-hover"
-          >
-            {t('accessCode.adminLogin')}
+            {t('admin.tenantLogin.title')}
           </Link>
         </div>
       </div>
 
-      <footer className="relative start-1/2 mt-auto w-screen shrink-0 -translate-x-1/2 bg-white shadow-[0_-2px_6px_rgba(0,0,0,0.08)] rtl:translate-x-1/2">
-        <div className="mx-auto grid w-full max-w-app grid-cols-2 items-center gap-x-4 px-5 py-6 sm:gap-x-12 sm:px-8 lg:gap-x-28 lg:px-12">
-          <img
-            src="/assets/Foerdermittelgeber.png"
-            alt="Fördermittelgeber"
-            className="h-auto w-full max-w-[389px] justify-self-start"
-          />
-          <img
-            src="/assets/Stadt.png"
-            alt="Stadt Kassel"
-            className="h-auto w-full max-w-[388px] justify-self-end"
-          />
-        </div>
-      </footer>
+      <StartPageFooter />
     </ScreenShell>
   );
 }

--- a/services/frontend/src/features/access-code/__tests__/AccessCodeScreen.test.tsx
+++ b/services/frontend/src/features/access-code/__tests__/AccessCodeScreen.test.tsx
@@ -70,9 +70,9 @@ describe('AccessCodeScreen', () => {
     expect(screen.getAllByRole('textbox')[0]).toHaveValue('Z');
   });
 
-  it('offers the admin login link', () => {
+  it('offers the tenant login chooser link', () => {
     renderWithProviders(tree());
-    expect(screen.getByRole('link', { name: 'Admin-Login' })).toHaveAttribute('href', '/admin');
+    expect(screen.getByRole('link', { name: 'Login' })).toHaveAttribute('href', '/login');
   });
 
   it('keeps both funding logos side by side in the start-page footer', () => {

--- a/services/frontend/src/features/admin/__tests__/adminEntryLink.test.tsx
+++ b/services/frontend/src/features/admin/__tests__/adminEntryLink.test.tsx
@@ -4,16 +4,17 @@ import { renderWithProviders } from '@/test/renderWithProviders';
 import { AccessCodeScreen } from '@/features/access-code/AccessCodeScreen';
 
 describe('the admin entry link', () => {
-  it('keeps both temporary administrative entrypoints reachable', async () => {
+  it('offers only the tenant login chooser from the start page', async () => {
     renderWithProviders(<AccessCodeScreen />, { locale: 'de' });
 
-    expect(await screen.findByRole('link', { name: 'Admin-Login' })).toHaveAttribute(
-      'href',
-      '/admin'
-    );
-    expect(screen.getByRole('link', { name: 'Neuer Admin-Login' })).toHaveAttribute(
+    expect(await screen.findByRole('link', { name: 'Login' })).toHaveAttribute(
       'href',
       '/login'
     );
+    expect(screen.getAllByRole('link')).toHaveLength(1);
+    expect(screen.queryByRole('link', { name: 'Admin-Login' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Neuer Admin-Login' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /Studio/i })).not.toBeInTheDocument();
+    expect(document.querySelector('a[href="/admin"]')).toBeNull();
   });
 });

--- a/services/frontend/src/features/admin/__tests__/adminSessionFlow.test.tsx
+++ b/services/frontend/src/features/admin/__tests__/adminSessionFlow.test.tsx
@@ -1,10 +1,16 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { renderWithProviders } from '@/test/renderWithProviders';
 import { installFakeClipboard } from '@/test/fakeClipboard';
 import { readConfig } from '@/app/config/env';
 import { AppRoutes } from '@/app/router/AppRoutes';
+
+vi.mock('@/app/auth/keycloak', () => ({
+  requireKeycloakLogin: vi.fn().mockResolvedValue(true),
+  getAdminAccessToken: vi.fn().mockResolvedValue('tenant-token'),
+  logoutFromKeycloak: vi.fn().mockResolvedValue(undefined),
+}));
 
 const services = { config: readConfig({}) };
 
@@ -14,22 +20,22 @@ const signIn = async () => {
   await userEvent.click(screen.getByRole('button', { name: 'Anmelden' }));
 };
 
-const renderApp = async () => {
+const renderApp = async (route: string) => {
   renderWithProviders(<AppRoutes />, {
-    route: '/admin',
+    route,
     locale: 'de',
     services,
   });
 
-  await signIn();
+  if (route === '/admin') await signIn();
 };
 
-describe('the admin session flow', () => {
+describe.each(['/admin', '/login/tenant-kassel'])('the admin session flow at %s', (route) => {
   beforeEach(() => sessionStorage.clear());
 
   it('creates a session, hands out the invite, and enters the conversation', async () => {
     installFakeClipboard();
-    await renderApp();
+    await renderApp(route);
 
     await userEvent.click(await screen.findByRole('button', { name: 'Neues Gespräch starten' }));
 
@@ -47,7 +53,7 @@ describe('the admin session flow', () => {
   });
 
   it('re-enters a session that is still open', async () => {
-    await renderApp();
+    await renderApp(route);
 
     await userEvent.click(
       await screen.findByRole('button', { name: 'Gespräch AR000001 fortsetzen' })
@@ -57,7 +63,7 @@ describe('the admin session flow', () => {
   });
 
   it('leaves a completed session alone', async () => {
-    await renderApp();
+    await renderApp(route);
 
     // Waiting on the rows, not the heading: the heading renders before the
     // query answers, and "no button for TR000001" is only meaningful once the
@@ -67,7 +73,7 @@ describe('the admin session flow', () => {
   });
 
   it('drops the open session when the admin signs out', async () => {
-    await renderApp();
+    await renderApp(route);
 
     await userEvent.click(
       await screen.findByRole('button', { name: 'Gespräch AR000001 fortsetzen' })
@@ -77,8 +83,11 @@ describe('the admin session flow', () => {
     await userEvent.click(screen.getByRole('button', { name: 'Benutzerkonto' }));
     await userEvent.click(screen.getByRole('button', { name: 'Abmelden' }));
 
-    // Signing out returns to the legacy admin login and drops the active session.
-    expect(await screen.findByRole('heading', { name: 'Code eingeben' })).toBeInTheDocument();
+    if (route === '/admin') {
+      expect(await screen.findByRole('heading', { name: 'Code eingeben' })).toBeInTheDocument();
+    } else {
+      expect(await screen.findByRole('link', { name: 'Stadt Kassel' })).toBeInTheDocument();
+    }
     expect(screen.queryByRole('status')).not.toBeInTheDocument();
   });
 });

--- a/services/frontend/src/features/admin/__tests__/adminSessionFlow.test.tsx
+++ b/services/frontend/src/features/admin/__tests__/adminSessionFlow.test.tsx
@@ -10,6 +10,7 @@ vi.mock('@/app/auth/keycloak', () => ({
   requireKeycloakLogin: vi.fn().mockResolvedValue(true),
   getAdminAccessToken: vi.fn().mockResolvedValue('tenant-token'),
   logoutFromKeycloak: vi.fn().mockResolvedValue(undefined),
+  subscribeToKeycloakExpiration: () => () => {},
 }));
 
 const services = { config: readConfig({}) };

--- a/services/frontend/src/features/login/TenantLoginScreen.tsx
+++ b/services/frontend/src/features/login/TenantLoginScreen.tsx
@@ -1,0 +1,98 @@
+import { useQuery } from '@tanstack/react-query';
+import { Link, useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { useFeedback } from '@/app/providers/feedback';
+import { useScreenLocale } from '@/app/providers/locale';
+import { useServices } from '@/app/providers/services';
+import { AppHeader } from '@/ui/patterns/AppHeader';
+import { ScreenShell } from '@/ui/patterns/ScreenShell';
+import { StartPageFooter } from '@/ui/patterns/StartPageFooter';
+import { Button } from '@/ui/primitives/Button';
+
+const collator = new Intl.Collator('de', { sensitivity: 'base' });
+
+export function TenantLoginScreen() {
+  const { t } = useTranslation();
+  const { openFeedback } = useFeedback();
+  const { loginTenant } = useServices();
+  const navigate = useNavigate();
+
+  useScreenLocale('de');
+
+  const tenants = useQuery({
+    queryKey: ['login-tenants'],
+    queryFn: () => loginTenant.list(),
+  });
+  const ordered = [...(tenants.data ?? [])].sort(
+    (left, right) =>
+      collator.compare(left.displayName, right.displayName) || left.id.localeCompare(right.id)
+  );
+
+  return (
+    <ScreenShell>
+      <AppHeader
+        onBack={() => void navigate('/')}
+        onHome={() => void navigate('/')}
+        onFeedback={openFeedback}
+        showNavigation={false}
+      />
+
+      <main className="flex w-full flex-1 flex-col px-5 pb-10 pt-content-top">
+        <div className="mx-auto w-full max-w-sm">
+          <h1 className="mb-4 text-center text-title font-bold leading-tight tracking-title text-fg-strong">
+            {t('admin.tenantLogin.title')}
+          </h1>
+          <p className="mb-10 text-center text-body leading-prose tracking-prose text-fg-body">
+            {t('admin.tenantLogin.instruction')}
+          </p>
+
+          {tenants.isPending && (
+            <div className="flex justify-center">
+              <span
+                role="status"
+                aria-label={t('admin.tenantLogin.loading')}
+                className="size-8 animate-spin rounded-full border-4 border-accent-15 border-t-accent"
+              />
+            </div>
+          )}
+
+          {tenants.isError && (
+            <div className="flex flex-col items-center gap-4">
+              <p role="alert" className="text-center text-note text-fg-muted">
+                {t('admin.tenantLogin.unavailable')}
+              </p>
+              <Button
+                variant="compact"
+                className="bg-accent text-accent-on"
+                onClick={() => void tenants.refetch()}
+              >
+                {t('admin.tenantLogin.retry')}
+              </Button>
+            </div>
+          )}
+
+          {tenants.isSuccess && ordered.length === 0 && (
+            <p className="text-center text-note text-fg-muted">{t('admin.tenantLogin.empty')}</p>
+          )}
+
+          {tenants.isSuccess && ordered.length > 0 && (
+            <ul className="flex flex-col gap-3">
+              {ordered.map((tenant) => (
+                <li key={tenant.id}>
+                  <Link
+                    to={`/login/${encodeURIComponent(tenant.id)}`}
+                    className="flex w-full rounded-row border border-border-card bg-surface-card px-4 py-3 text-item font-medium leading-tight tracking-item text-fg-strong transition-colors duration-150 hover:bg-surface-row-hover active:bg-surface-row-active focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+                  >
+                    {tenant.displayName}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </main>
+
+      <StartPageFooter />
+    </ScreenShell>
+  );
+}

--- a/services/frontend/src/features/login/__tests__/TenantLoginScreen.test.tsx
+++ b/services/frontend/src/features/login/__tests__/TenantLoginScreen.test.tsx
@@ -1,0 +1,97 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '@/test/renderWithProviders';
+import type { LoginTenant } from '@/domain/login-tenant/loginTenant.types';
+import { TenantLoginScreen } from '@/features/login/TenantLoginScreen';
+
+function renderScreen(list: () => Promise<LoginTenant[]>) {
+  return renderWithProviders(<TenantLoginScreen />, {
+    locale: 'de',
+    services: { loginTenant: { list } },
+  });
+}
+
+describe('TenantLoginScreen', () => {
+  it('shows loading feedback while the tenant directory is pending', () => {
+    renderScreen(() => new Promise<LoginTenant[]>(() => undefined));
+
+    expect(screen.getByRole('heading', { name: 'Login' })).toBeInTheDocument();
+    expect(screen.getByText('Bitte wählen Sie Ihre Abteilung oder Organisation aus der Liste aus.')).toBeInTheDocument();
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+
+  it('explains when no organisation is available without offering a tenant', async () => {
+    renderScreen(async () => []);
+
+    expect(await screen.findByText('Derzeit sind keine Organisationen verfügbar.')).toBeInTheDocument();
+    expect(screen.queryAllByRole('link')).toHaveLength(0);
+  });
+
+  it('offers a retry after the directory request fails', async () => {
+    const list = vi
+      .fn<() => Promise<LoginTenant[]>>()
+      .mockRejectedValueOnce(new Error('directory unavailable'))
+      .mockResolvedValueOnce([
+        { id: 'tenant-kassel', displayName: 'Stadt Kassel', realm: 'kassel-ssf-2025' },
+      ]);
+
+    renderScreen(list);
+
+    expect(
+      await screen.findByText('Die Liste der Organisationen ist derzeit nicht verfügbar.')
+    ).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Erneut versuchen' }));
+
+    expect(await screen.findByRole('link', { name: 'Stadt Kassel' })).toHaveAttribute(
+      'href',
+      '/login/tenant-kassel'
+    );
+    expect(list).toHaveBeenCalledTimes(2);
+  });
+
+  it('orders accessible tenant links in German without displaying internal identifiers', async () => {
+    renderScreen(async () => [
+      { id: 'tenant:kassel', displayName: 'Stadt Kassel', realm: 'kassel-ssf-2025' },
+      { id: 'tenant-amter-b', displayName: 'Ämter', realm: 'amter-b-ssf-2025' },
+      { id: 'tenant-fulda', displayName: 'Amt Fulda', realm: 'fulda-ssf-2025' },
+      { id: 'tenant-amter-a', displayName: 'Ämter', realm: 'amter-a-ssf-2025' },
+    ]);
+
+    expect(
+      await screen.findAllByRole('link', { name: 'Ämter' })
+    ).toHaveLength(2);
+
+    const links = screen.getAllByRole('link');
+    expect(links.map((link) => link.textContent)).toEqual([
+      'Amt Fulda',
+      'Ämter',
+      'Ämter',
+      'Stadt Kassel',
+    ]);
+    expect(links.map((link) => link.getAttribute('href'))).toEqual([
+      '/login/tenant-fulda',
+      '/login/tenant-amter-a',
+      '/login/tenant-amter-b',
+      '/login/tenant%3Akassel',
+    ]);
+    expect(screen.queryByText('tenant:kassel')).not.toBeInTheDocument();
+    expect(screen.queryByText('kassel-ssf-2025')).not.toBeInTheDocument();
+  });
+
+  it('retains the shared header and branded funding footer', async () => {
+    renderScreen(async () => []);
+
+    expect(screen.getByRole('banner')).toHaveClass('bg-white');
+    expect(screen.getByRole('img', { name: 'Smart Speech Flow' })).toHaveAttribute(
+      'src',
+      '/assets/Logo.png'
+    );
+
+    await screen.findByText('Derzeit sind keine Organisationen verfügbar.');
+    const funding = screen.getByRole('img', { name: 'Fördermittelgeber' });
+    const city = screen.getByRole('img', { name: 'Stadt Kassel' });
+    expect(funding.closest('footer')).toContainElement(city);
+  });
+});

--- a/services/frontend/src/i18n/locales/de.json
+++ b/services/frontend/src/i18n/locales/de.json
@@ -96,6 +96,14 @@
       "invalidEmail": "Bitte eine gültige E-Mail-Adresse eingeben.",
       "invalidCredentials": "Ungültige Anmeldedaten."
     },
+    "tenantLogin": {
+      "title": "Login",
+      "instruction": "Bitte wählen Sie Ihre Abteilung oder Organisation aus der Liste aus.",
+      "empty": "Derzeit sind keine Organisationen verfügbar.",
+      "unavailable": "Die Liste der Organisationen ist derzeit nicht verfügbar.",
+      "retry": "Erneut versuchen",
+      "loading": "Organisationen werden geladen"
+    },
     "menu": {
       "open": "Benutzerkonto",
       "changePassword": "Passwort ändern",

--- a/services/frontend/src/i18n/locales/en.json
+++ b/services/frontend/src/i18n/locales/en.json
@@ -96,6 +96,14 @@
       "invalidEmail": "Please enter a valid email address.",
       "invalidCredentials": "Invalid credentials."
     },
+    "tenantLogin": {
+      "title": "Login",
+      "instruction": "Please select your department or organisation from the list.",
+      "empty": "There are currently no organisations available.",
+      "unavailable": "The list of organisations is currently unavailable.",
+      "retry": "Try again",
+      "loading": "Loading organisations"
+    },
     "menu": {
       "open": "User account",
       "changePassword": "Change password",

--- a/services/frontend/src/test/handlers.ts
+++ b/services/frontend/src/test/handlers.ts
@@ -3,6 +3,15 @@ import { http, HttpResponse } from 'msw';
 export const SESSION_ID = 'A1B2C3D4';
 
 export const handlers = [
+  http.get('*/api/login/tenants', () =>
+    HttpResponse.json({
+      tenants: [
+        { id: 'tenant-fulda', displayName: 'Amt Fulda', realm: 'fulda-ssf-2025' },
+        { id: 'tenant-kassel', displayName: 'Stadt Kassel', realm: 'kassel-ssf-2025' },
+      ],
+    })
+  ),
+
   http.get('*/api/health/summary', () =>
     HttpResponse.json({
       status: 'success',

--- a/services/frontend/src/ui/patterns/StartPageFooter.tsx
+++ b/services/frontend/src/ui/patterns/StartPageFooter.tsx
@@ -1,0 +1,18 @@
+export function StartPageFooter() {
+  return (
+    <footer className="relative start-1/2 mt-auto w-screen shrink-0 -translate-x-1/2 bg-white shadow-[0_-2px_6px_rgba(0,0,0,0.08)] rtl:translate-x-1/2">
+      <div className="mx-auto grid w-full max-w-app grid-cols-2 items-center gap-x-4 px-5 py-6 sm:gap-x-12 sm:px-8 lg:gap-x-28 lg:px-12">
+        <img
+          src="/assets/Foerdermittelgeber.png"
+          alt="Fördermittelgeber"
+          className="h-auto w-full max-w-[389px] justify-self-start"
+        />
+        <img
+          src="/assets/Stadt.png"
+          alt="Stadt Kassel"
+          className="h-auto w-full max-w-[388px] justify-self-end"
+        />
+      </div>
+    </footer>
+  );
+}

--- a/services/studio_mock/app.py
+++ b/services/studio_mock/app.py
@@ -28,6 +28,13 @@ RuntimeErrorCode = Literal[
     "runtime_configuration_unavailable",
 ]
 
+DirectoryErrorCode = Literal[
+    "service_authentication_invalid",
+    "service_action_forbidden",
+    "tenant_not_found",
+    "admin_login_directory_unavailable",
+]
+
 
 class RuntimeError(BaseModel):
     """The nested error object defined by the Studio V1 contract."""
@@ -45,6 +52,26 @@ class RuntimeErrorEnvelope(BaseModel):
 
     contract_version: str = Field(alias="contractVersion")
     error: RuntimeError
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class DirectoryError(BaseModel):
+    """The nested error object for the login-directory V1 contract."""
+
+    code: DirectoryErrorCode
+    message: str
+    retryable: bool
+    correlation_id: str = Field(alias="correlationId")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class DirectoryErrorEnvelope(BaseModel):
+    """The V1 error envelope returned by the login-directory endpoint."""
+
+    contract_version: str = Field(alias="contractVersion")
+    error: DirectoryError
 
     model_config = ConfigDict(populate_by_name=True)
 
@@ -79,7 +106,9 @@ class LocaleResponse(BaseModel):
     """A localized V1 runtime configuration entry."""
 
     locale: str
-    authenticated_home_explanation_html: str = Field(alias="authenticatedHomeExplanationHtml")
+    authenticated_home_explanation_html: str = Field(
+        alias="authenticatedHomeExplanationHtml"
+    )
     guest_explanation_html: str = Field(alias="guestExplanationHtml")
     conversation_content_storage_question_html: str | None = Field(
         alias="conversationContentStorageQuestionHtml"
@@ -119,6 +148,26 @@ class RuntimeConfigurationResponse(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
 
+class AdminLoginTenantResponse(BaseModel):
+    """A public administrative tenant entry in the V1 login directory."""
+
+    id: str
+    display_name: str = Field(alias="displayName")
+    realm: str
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class AdminLoginDirectoryResponse(BaseModel):
+    """The successful tenant-unbound Studio login-directory V1 response."""
+
+    contract_version: str = Field(alias="contractVersion")
+    directory_revision: str = Field(alias="directoryRevision")
+    tenants: list[AdminLoginTenantResponse]
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
 _ERROR_RESPONSES = {
     401: {
         "model": RuntimeErrorEnvelope,
@@ -139,6 +188,22 @@ _ERROR_RESPONSES = {
     503: {
         "model": RuntimeErrorEnvelope,
         "description": "Runtime configuration is unavailable.",
+    },
+}
+
+_DIRECTORY_ERROR_RESPONSES = {
+    401: {
+        "model": DirectoryErrorEnvelope,
+        "description": "Service authentication failed.",
+    },
+    403: {
+        "model": DirectoryErrorEnvelope,
+        "description": "Service permission is missing.",
+    },
+    404: {"model": DirectoryErrorEnvelope, "description": "The request is malformed."},
+    503: {
+        "model": DirectoryErrorEnvelope,
+        "description": "Login directory is unavailable.",
     },
 }
 
@@ -187,6 +252,19 @@ _TENANT_CONFIGURATION_TEMPLATES: dict[str, dict[str, Any]] = {
     },
 }
 
+_LOGIN_DIRECTORY_TENANTS = [
+    {
+        "id": "tenant-kassel",
+        "displayName": "Stadt Kassel",
+        "realm": "kassel-ssf-2025",
+    },
+    {
+        "id": "tenant-fulda",
+        "displayName": "Stadt Fulda",
+        "realm": "fulda-ssf-2025",
+    },
+]
+
 
 def _revision(payload: dict[str, Any]) -> str:
     """Return the V1 SHA-256 revision for a canonical JSON payload."""
@@ -208,6 +286,16 @@ def _configuration_for(tenant_id: str) -> dict[str, Any]:
     return configuration
 
 
+def _login_directory() -> dict[str, Any]:
+    """Return the deterministic V1 login directory for all ready tenants."""
+    directory = {
+        "contractVersion": _CONTRACT_VERSION,
+        "tenants": deepcopy(_LOGIN_DIRECTORY_TENANTS),
+    }
+    directory["directoryRevision"] = _revision(directory)
+    return directory
+
+
 def _error_response(
     status_code: int,
     code: RuntimeErrorCode,
@@ -216,6 +304,28 @@ def _error_response(
     message: str = _UNAVAILABLE_MESSAGE,
 ) -> JSONResponse:
     """Return the stable Studio V1 error envelope without tenant content."""
+    return JSONResponse(
+        status_code=status_code,
+        content={
+            "contractVersion": _CONTRACT_VERSION,
+            "error": {
+                "code": code,
+                "message": message,
+                "retryable": retryable,
+                "correlationId": correlation_id,
+            },
+        },
+    )
+
+
+def _directory_error_response(
+    status_code: int,
+    code: DirectoryErrorCode,
+    correlation_id: str,
+    retryable: bool,
+    message: str = _UNAVAILABLE_MESSAGE,
+) -> JSONResponse:
+    """Return a stable V1 error envelope for the tenant-unbound directory."""
     return JSONResponse(
         status_code=status_code,
         content={
@@ -247,7 +357,10 @@ def runtime_configuration(
     """Return deterministic V1 data for authorized Studio service callers."""
     if authorization not in {_AUTHORIZED_TOKEN, _UNAUTHORIZED_TOKEN}:
         return _error_response(
-            401, "service_authentication_invalid", x_correlation_id or "unavailable", False
+            401,
+            "service_authentication_invalid",
+            x_correlation_id or "unavailable",
+            False,
         )
     if authorization == _UNAUTHORIZED_TOKEN:
         return _error_response(
@@ -260,7 +373,9 @@ def runtime_configuration(
         or x_tenant_id is not None
         or request.url.query
     ):
-        return _error_response(404, "tenant_not_found", x_correlation_id or "unavailable", False)
+        return _error_response(
+            404, "tenant_not_found", x_correlation_id or "unavailable", False
+        )
     scenario_errors: dict[str, tuple[int, RuntimeErrorCode, bool]] = {
         "suspended": (409, "tenant_suspended", False),
         "plugin-inactive": (409, "ssf_plugin_inactive", False),
@@ -270,10 +385,55 @@ def runtime_configuration(
         status_code, code, retryable = scenario_errors[x_mock_scenario]
         return _error_response(status_code, code, x_correlation_id, retryable)
     if x_mock_scenario == "unavailable":
-        return _error_response(503, "runtime_configuration_unavailable", x_correlation_id, True)
+        return _error_response(
+            503, "runtime_configuration_unavailable", x_correlation_id, True
+        )
     if x_studio_tenant_id not in _TENANT_CONFIGURATION_TEMPLATES:
         return _error_response(404, "tenant_not_found", x_correlation_id, False)
     return _configuration_for(x_studio_tenant_id)
+
+
+@app.get(
+    "/internal/plugins/ssf/v1/admin-login-tenants",
+    response_model=AdminLoginDirectoryResponse,
+    responses=_DIRECTORY_ERROR_RESPONSES,
+)
+def admin_login_tenants(
+    request: Request,
+    authorization: str | None = Header(default=None),
+    x_correlation_id: str | None = Header(default=None),
+    x_studio_tenant_id: str | None = Header(default=None, include_in_schema=False),
+    x_studio_instance_id: str | None = Header(default=None, include_in_schema=False),
+    x_tenant_id: str | None = Header(default=None, include_in_schema=False),
+    x_mock_scenario: str | None = Header(default=None),
+) -> dict[str, Any] | JSONResponse:
+    """Return ready tenants for authorized, tenant-unbound service callers."""
+    if authorization not in {_AUTHORIZED_TOKEN, _UNAUTHORIZED_TOKEN}:
+        return _directory_error_response(
+            401,
+            "service_authentication_invalid",
+            x_correlation_id or "unavailable",
+            False,
+        )
+    if authorization == _UNAUTHORIZED_TOKEN:
+        return _directory_error_response(
+            403, "service_action_forbidden", x_correlation_id or "unavailable", False
+        )
+    if (
+        not x_correlation_id
+        or x_studio_tenant_id is not None
+        or x_studio_instance_id is not None
+        or x_tenant_id is not None
+        or request.url.query
+    ):
+        return _directory_error_response(
+            404, "tenant_not_found", x_correlation_id or "unavailable", False
+        )
+    if x_mock_scenario == "unavailable":
+        return _directory_error_response(
+            503, "admin_login_directory_unavailable", x_correlation_id, True
+        )
+    return _login_directory()
 
 
 def _custom_openapi() -> dict[str, Any]:
@@ -281,17 +441,23 @@ def _custom_openapi() -> dict[str, Any]:
     if app.openapi_schema:
         return app.openapi_schema
     schema = get_openapi(title=app.title, version=app.version, routes=app.routes)
-    parameters = schema["paths"]["/internal/plugins/ssf/v1/runtime-configuration"]["get"][
-        "parameters"
-    ]
-    for parameter in parameters:
-        if parameter["in"] == "header" and parameter["name"] in {
+    required_headers_by_path = {
+        "/internal/plugins/ssf/v1/runtime-configuration": {
             "authorization",
             "x-studio-tenant-id",
             "x-correlation-id",
-        }:
-            parameter["required"] = True
-            parameter["schema"] = {"type": "string"}
+        },
+        "/internal/plugins/ssf/v1/admin-login-tenants": {
+            "authorization",
+            "x-correlation-id",
+        },
+    }
+    for path, header_names in required_headers_by_path.items():
+        parameters = schema["paths"][path]["get"]["parameters"]
+        for parameter in parameters:
+            if parameter["in"] == "header" and parameter["name"] in header_names:
+                parameter["required"] = True
+                parameter["schema"] = {"type": "string"}
     app.openapi_schema = schema
     return app.openapi_schema
 

--- a/tests/operations/test_keycloak_realm.py
+++ b/tests/operations/test_keycloak_realm.py
@@ -1,16 +1,31 @@
 import json
 from pathlib import Path
 
+import yaml
 
-REALM_PATH = Path("deploy/production/keycloak/ssf-realm.json")
+
+DEVELOPMENT_REALM_PATH = Path("deploy/production/keycloak/ssf-realm.json")
+DEVELOPMENT_COMPOSE_PATH = Path("docker-compose.yml")
 
 
-def test_ssf_realm_provisions_a_public_pkce_client_for_the_frontend():
-    realm = json.loads(REALM_PATH.read_text())
+def test_development_compose_imports_only_the_local_realm_fixture():
+    keycloak = yaml.safe_load(DEVELOPMENT_COMPOSE_PATH.read_text())["services"][
+        "keycloak"
+    ]
+
+    assert "--import-realm" in keycloak["command"]
+    assert keycloak["volumes"] == [
+        "./deploy/production/keycloak/ssf-realm.json:/opt/keycloak/data/import/ssf-realm.json:ro"
+    ]
+
+
+def test_development_realm_provisions_a_secretless_public_pkce_client():
+    realm = json.loads(DEVELOPMENT_REALM_PATH.read_text())
 
     assert realm["realm"] == "ssf"
     client = next(client for client in realm["clients"] if client["clientId"] == "ssf-frontend")
     assert client["publicClient"] is True
+    assert "secret" not in client
     assert client["standardFlowEnabled"] is True
     assert client["implicitFlowEnabled"] is False
     assert client["directAccessGrantsEnabled"] is False

--- a/tests/operations/test_production_compose.py
+++ b/tests/operations/test_production_compose.py
@@ -4,6 +4,8 @@ import yaml
 
 
 COMPOSE_PATH = Path("deploy/production/docker-compose.production.yml")
+ENV_EXAMPLE_PATH = Path("deploy/production/production.env.example")
+DEVELOPMENT_COMPOSE_PATH = Path("docker-compose.yml")
 
 
 def load_production_compose():
@@ -57,18 +59,81 @@ def test_production_compose_preserves_the_existing_prometheus_volume():
     assert compose["volumes"]["prometheus-data"]["external"] is True
 
 
-def test_keycloak_realm_mount_resolves_to_the_versioned_file():
-    keycloak = load_production_compose()["services"]["keycloak"]
-    realm_mount = next(
-        volume
-        for volume in keycloak["volumes"]
-        if volume.endswith(":/opt/keycloak/data/import/ssf-realm.json:ro")
-    )
-    source = (COMPOSE_PATH.parent / realm_mount.split(":", maxsplit=1)[0]).resolve()
-    expected_source = Path("deploy/production/keycloak/ssf-realm.json").resolve()
+def _environment_by_name(service):
+    return {
+        entry.split("=", maxsplit=1)[0]: entry.split("=", maxsplit=1)[1]
+        for entry in service["environment"]
+    }
 
-    assert source == expected_source
-    assert source.is_file()
+
+def _load_env_example():
+    return {
+        line.split("=", maxsplit=1)[0]: line.split("=", maxsplit=1)[1]
+        for line in ENV_EXAMPLE_PATH.read_text().splitlines()
+        if line and not line.startswith("#")
+    }
+
+
+def test_production_gateway_uses_studio_backed_multi_realm_configuration():
+    gateway = load_production_compose()["services"]["api_gateway"]
+    environment = _environment_by_name(gateway)
+
+    assert environment["KEYCLOAK_BASE_URL"] == (
+        "${KEYCLOAK_BASE_URL:-https://auth.dialog.kassel.de}"
+    )
+    assert environment["KEYCLOAK_AUDIENCE"] == "${KEYCLOAK_AUDIENCE:-ssf-frontend}"
+    assert environment["KEYCLOAK_REQUIRED_ROLE"] == "${KEYCLOAK_REQUIRED_ROLE:-ssf-user}"
+    assert environment["STUDIO_RUNTIME_CONFIGURATION_BASE_URL"] == (
+        "${STUDIO_RUNTIME_CONFIGURATION_BASE_URL:-https://studio.dialog.kassel.de}"
+    )
+    assert environment["STUDIO_RUNTIME_TOKEN_URL"] == "${STUDIO_RUNTIME_TOKEN_URL:?required}"
+    assert environment["STUDIO_RUNTIME_CLIENT_ID"] == "${STUDIO_RUNTIME_CLIENT_ID:-ssf-runtime}"
+    assert environment["STUDIO_RUNTIME_AUDIENCE"] == (
+        "${STUDIO_RUNTIME_AUDIENCE:-sva-studio-ssf-runtime}"
+    )
+    assert environment["STUDIO_RUNTIME_CLIENT_SECRET"] == (
+        "${STUDIO_RUNTIME_CLIENT_SECRET:?required}"
+    )
+    assert environment["STUDIO_LOGIN_DIRECTORY_CACHE_SECONDS"] == (
+        "${STUDIO_LOGIN_DIRECTORY_CACHE_SECONDS:-60}"
+    )
+    assert "KEYCLOAK_ISSUER" not in environment
+
+
+def test_production_example_documents_tenant_login_configuration_without_secrets():
+    environment = _load_env_example()
+
+    assert environment["KEYCLOAK_BASE_URL"] == "https://auth.dialog.kassel.de"
+    assert environment["KEYCLOAK_AUDIENCE"] == "ssf-frontend"
+    assert environment["KEYCLOAK_REQUIRED_ROLE"] == "ssf-user"
+    assert environment["STUDIO_RUNTIME_CONFIGURATION_BASE_URL"] == (
+        "https://studio.dialog.kassel.de"
+    )
+    assert environment["STUDIO_RUNTIME_CLIENT_ID"] == "ssf-runtime"
+    assert environment["STUDIO_RUNTIME_AUDIENCE"] == "sva-studio-ssf-runtime"
+    assert environment["STUDIO_LOGIN_DIRECTORY_CACHE_SECONDS"] == "60"
+    assert environment["STUDIO_RUNTIME_CLIENT_SECRET"] == ""
+    assert "STUDIO_RUNTIME_TOKEN_URL" in environment
+    assert "KEYCLOAK_ISSUER" not in environment
+
+
+def test_production_keycloak_does_not_import_the_development_realm():
+    keycloak = load_production_compose()["services"]["keycloak"]
+
+    assert "--import-realm" not in keycloak["command"]
+    assert all(
+        "/opt/keycloak/data/import" not in volume
+        for volume in keycloak.get("volumes", [])
+    )
+
+
+def test_frontend_build_receives_public_multi_realm_configuration():
+    compose = yaml.safe_load(DEVELOPMENT_COMPOSE_PATH.read_text())
+    build_args = compose["services"]["frontend"]["build"]["args"]
+
+    assert build_args["VITE_KEYCLOAK_URL"] == "https://auth.dialog.kassel.de"
+    assert build_args["VITE_KEYCLOAK_CLIENT_ID"] == "ssf-frontend"
+    assert "VITE_KEYCLOAK_REALM" not in build_args
 
 
 def test_recovery_unit_relies_on_docker_restart_policies_without_compose_reconciliation():

--- a/tests/operations/test_production_compose.py
+++ b/tests/operations/test_production_compose.py
@@ -100,6 +100,28 @@ def test_production_gateway_uses_studio_backed_multi_realm_configuration():
     assert "KEYCLOAK_ISSUER" not in environment
 
 
+def test_production_routes_match_the_trusted_frontend_and_keycloak_origins():
+    services = load_production_compose()["services"]
+    gateway_environment = _environment_by_name(services["api_gateway"])
+    keycloak = services["keycloak"]
+
+    assert gateway_environment["CLIENT_BASE_URL"] == "https://dialog.kassel.de"
+    assert gateway_environment["KEYCLOAK_BASE_URL"] == (
+        "${KEYCLOAK_BASE_URL:-https://auth.dialog.kassel.de}"
+    )
+    assert keycloak["environment"]["KC_HOSTNAME"] == (
+        "https://auth.dialog.kassel.de"
+    )
+    assert (
+        "traefik.http.routers.keycloak.rule=Host(`auth.dialog.kassel.de`)"
+        in keycloak["labels"]
+    )
+    assert (
+        "traefik.http.routers.frontend.rule=Host(`dialog.kassel.de`)"
+        in services["frontend"]["labels"]
+    )
+
+
 def test_production_example_documents_tenant_login_configuration_without_secrets():
     environment = _load_env_example()
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,29 +1,72 @@
+import asyncio
 import json
-import sys
 from datetime import datetime, timedelta, timezone
-from pathlib import Path
 
 import jwt
 import pytest
 from cryptography.hazmat.primitives.asymmetric import rsa
+from fastapi import Depends, FastAPI
 from fastapi.testclient import TestClient
 from jwt.algorithms import RSAAlgorithm
 
-ROOT_DIR = Path(__file__).resolve().parents[3]
-if str(ROOT_DIR) not in sys.path:
-    sys.path.insert(0, str(ROOT_DIR))
-
 from services.api_gateway.app import app
-from services.api_gateway.auth import _key_cache
+from services.api_gateway.auth import _key_cache, get_auth_login_directory_provider
+from services.api_gateway.studio_login_directory import StudioLoginDirectoryService
+from services.api_gateway.studio_login_directory_client import (
+    StudioLoginDirectory,
+    StudioLoginDirectoryClientError,
+)
+from services.api_gateway.tenant_context import (
+    StudioTenantContext,
+    require_studio_tenant_context,
+)
 
 client = TestClient(app)
-
-ISSUER = "https://auth.example.test/realms/ssf"
+BASE_URL = "https://auth.example.test"
+KASSEL_ISSUER = f"{BASE_URL}/realms/kassel-ssf-2025"
+FULDA_ISSUER = f"{BASE_URL}/realms/fulda-ssf-2025"
 AUDIENCE = "ssf-frontend"
+REVISION = f"sha256:{'a' * 64}"
+DIRECTORY = StudioLoginDirectory.model_validate(
+    {
+        "contractVersion": "1.0",
+        "directoryRevision": REVISION,
+        "tenants": [
+            {
+                "id": "tenant-kassel",
+                "displayName": "Kassel",
+                "realm": "kassel-ssf-2025",
+            },
+            {"id": "tenant-fulda", "displayName": "Fulda", "realm": "fulda-ssf-2025"},
+        ],
+    }
+)
+
+
+class DirectoryFetcher:
+    unavailable = False
+    directory = DIRECTORY
+
+    async def fetch(self, correlation_id):
+        if self.unavailable:
+            raise StudioLoginDirectoryClientError("unavailable", retryable=True)
+        return self.directory
 
 
 @pytest.fixture(autouse=True)
-def clear_cached_keys():
+def auth_environment(monkeypatch):
+    _key_cache.entries.clear()
+    monkeypatch.setenv("KEYCLOAK_BASE_URL", BASE_URL)
+    monkeypatch.setenv("KEYCLOAK_ISSUER", KASSEL_ISSUER)
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", AUDIENCE)
+    monkeypatch.setenv("KEYCLOAK_REQUIRED_ROLE", "ssf-user")
+    monkeypatch.setenv("SSF_ENABLE_LEGACY_ADMIN_ACCESS", "false")
+    service = StudioLoginDirectoryService(DirectoryFetcher(), cache_seconds=60)
+    app.dependency_overrides[get_auth_login_directory_provider] = (
+        lambda: lambda: service
+    )
+    yield service
+    app.dependency_overrides.pop(get_auth_login_directory_provider, None)
     _key_cache.entries.clear()
 
 
@@ -32,26 +75,44 @@ def signing_key():
     return rsa.generate_private_key(public_exponent=65537, key_size=2048)
 
 
-def access_token(signing_key, *, roles, audience=AUDIENCE, issuer=ISSUER):
-    return jwt.encode(
-        {
-            "sub": "operator-1",
-            "iss": issuer,
-            "aud": audience,
-            "exp": datetime.now(timezone.utc) + timedelta(minutes=5),
-            "realm_access": {"roles": roles},
-        },
+def access_token(signing_key, **overrides):
+    claims = {
+        "sub": "operator-1",
+        "iss": KASSEL_ISSUER,
+        "aud": AUDIENCE,
+        "exp": datetime.now(timezone.utc) + timedelta(minutes=5),
+        "realm_access": {"roles": ["ssf-user"]},
+        "studio_tenant_id": "tenant-kassel",
+        "ssf_authorization_revision": REVISION,
+    }
+    claims.update(overrides)
+    claims = {key: value for key, value in claims.items() if value is not None}
+    if isinstance(claims.get("exp"), datetime):
+        claims["exp"] = int(claims["exp"].timestamp())
+    return jwt.api_jws.encode(
+        json.dumps(claims).encode(),
         signing_key,
         algorithm="RS256",
         headers={"kid": "test-key"},
     )
 
 
-def mock_keycloak(monkeypatch, signing_key):
+def mock_keycloak(
+    monkeypatch,
+    signing_key,
+    *,
+    metadata_override=None,
+    jwk_override=None,
+    redirect_suffix=None,
+):
     jwk = json.loads(RSAAlgorithm.to_jwk(signing_key.public_key()))
     jwk["kid"] = "test-key"
+    jwk.update(jwk_override or {})
+    calls = []
 
     class Response:
+        is_redirect = False
+
         def __init__(self, body):
             self.body = body
 
@@ -61,68 +122,263 @@ def mock_keycloak(monkeypatch, signing_key):
         def json(self):
             return self.body
 
-    def get(url, timeout):
+    def get(url, timeout, **kwargs):
         assert timeout == 5
+        assert kwargs.get("allow_redirects") is False
+        calls.append(url)
+        if redirect_suffix and url.endswith(redirect_suffix):
+            response = Response({})
+            response.is_redirect = True
+            return response
         if url.endswith("/.well-known/openid-configuration"):
-            return Response({"jwks_uri": "https://auth.example.test/jwks"})
-        assert url == "https://auth.example.test/jwks"
+            issuer = url.removesuffix("/.well-known/openid-configuration")
+            metadata = {
+                "issuer": issuer,
+                "jwks_uri": f"{issuer}/protocol/openid-connect/certs",
+            }
+            metadata.update(metadata_override or {})
+            return Response(metadata)
         return Response({"keys": [jwk]})
 
     monkeypatch.setattr("requests.get", get)
-    monkeypatch.setenv("KEYCLOAK_ISSUER", ISSUER)
-    monkeypatch.setenv("KEYCLOAK_AUDIENCE", AUDIENCE)
-    monkeypatch.setenv("KEYCLOAK_REQUIRED_ROLE", "ssf-user")
+    return calls
+
+
+def request_with_token(token):
+    return client.get(
+        "/api/admin/session/history", headers={"Authorization": f"Bearer {token}"}
+    )
 
 
 def test_admin_endpoints_reject_requests_without_a_bearer_token():
-    response = client.get("/api/admin/session/history")
-
-    assert response.status_code == 401
+    assert client.get("/api/admin/session/history").status_code == 401
 
 
-def test_admin_endpoints_reject_valid_tokens_without_the_ssf_user_role(monkeypatch, signing_key):
-    mock_keycloak(monkeypatch, signing_key)
-
-    response = client.get(
-        "/api/admin/session/history",
-        headers={"Authorization": f"Bearer {access_token(signing_key, roles=[])}"},
+@pytest.mark.parametrize(
+    "issuer, tenant_id",
+    [
+        (KASSEL_ISSUER, "tenant-kassel"),
+        (FULDA_ISSUER, "tenant-fulda"),
+    ],
+)
+def test_admin_endpoints_accept_each_allowlisted_realm(
+    monkeypatch, signing_key, issuer, tenant_id
+):
+    calls = mock_keycloak(monkeypatch, signing_key)
+    response = request_with_token(
+        access_token(signing_key, iss=issuer, studio_tenant_id=tenant_id)
     )
-
-    assert response.status_code == 403
-
-
-def test_admin_endpoints_accept_valid_ssf_user_tokens(monkeypatch, signing_key):
-    mock_keycloak(monkeypatch, signing_key)
-
-    response = client.get(
-        "/api/admin/session/history",
-        headers={"Authorization": f"Bearer {access_token(signing_key, roles=['ssf-user'])}"},
-    )
-
     assert response.status_code == 200
+    assert calls == [
+        f"{issuer}/.well-known/openid-configuration",
+        f"{issuer}/protocol/openid-connect/certs",
+    ]
 
 
-def test_admin_endpoints_accept_legacy_access_only_when_transition_is_enabled(
-    monkeypatch,
+@pytest.mark.parametrize(
+    "issuer",
+    [
+        f"{BASE_URL}/realms/unknown",
+        "https://auth.example.test.evil.test/realms/kassel-ssf-2025",
+        f"{BASE_URL}/auth/realms/kassel-ssf-2025",
+        f"{KASSEL_ISSUER}/",
+        f"{KASSEL_ISSUER}?other=realm",
+        None,
+        [KASSEL_ISSUER],
+    ],
+)
+def test_unadmitted_issuers_are_rejected_without_oidc_network_access(
+    monkeypatch, signing_key, issuer
+):
+    calls = mock_keycloak(monkeypatch, signing_key)
+    response = request_with_token(access_token(signing_key, iss=issuer))
+    assert response.status_code == 401
+    assert calls == []
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"studio_tenant_id": "tenant-fulda"},
+        {"studio_tenant_id": None},
+        {"studio_tenant_id": ["tenant-kassel"]},
+        {"ssf_authorization_revision": None},
+        {"ssf_authorization_revision": f"sha256:{'A' * 64}"},
+        {"ssf_authorization_revision": f"sha256:{'a' * 64}\n"},
+        {"ssf_authorization_revision": [REVISION]},
+        {"aud": "other-app"},
+        {"exp": datetime.now(timezone.utc) - timedelta(minutes=1)},
+        {"exp": None},
+    ],
+)
+def test_signed_claims_must_be_valid_and_bound_to_the_realm(
+    monkeypatch, signing_key, overrides
+):
+    mock_keycloak(monkeypatch, signing_key)
+    assert request_with_token(access_token(signing_key, **overrides)).status_code == 401
+
+
+def test_invalid_signature_is_rejected(monkeypatch, signing_key):
+    mock_keycloak(monkeypatch, signing_key)
+    other_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    assert request_with_token(access_token(other_key)).status_code == 401
+
+
+def test_non_rsa_jwk_fails_closed(monkeypatch, signing_key):
+    mock_keycloak(monkeypatch, signing_key, jwk_override={"kty": "EC"})
+    assert request_with_token(access_token(signing_key)).status_code == 401
+
+
+@pytest.mark.parametrize(
+    "realm_access", [{"roles": []}, None, [], {"roles": "ssf-user"}]
+)
+def test_missing_or_malformed_role_is_rejected(monkeypatch, signing_key, realm_access):
+    mock_keycloak(monkeypatch, signing_key)
+    assert (
+        request_with_token(
+            access_token(signing_key, realm_access=realm_access)
+        ).status_code
+        == 403
+    )
+
+
+@pytest.mark.parametrize(
+    "metadata_override",
+    [
+        {"issuer": FULDA_ISSUER},
+        {"issuer": None},
+        {"jwks_uri": "https://attacker.test/jwks"},
+        {"jwks_uri": f"{FULDA_ISSUER}/protocol/openid-connect/certs"},
+    ],
+)
+def test_discovery_must_match_the_admitted_issuer_before_fetching_keys(
+    monkeypatch, signing_key, metadata_override
+):
+    calls = mock_keycloak(monkeypatch, signing_key, metadata_override=metadata_override)
+    assert request_with_token(access_token(signing_key)).status_code == 401
+    assert calls == [f"{KASSEL_ISSUER}/.well-known/openid-configuration"]
+
+
+@pytest.mark.parametrize("redirect_suffix", ["openid-configuration", "certs"])
+def test_oidc_redirects_are_rejected(monkeypatch, signing_key, redirect_suffix):
+    mock_keycloak(monkeypatch, signing_key, redirect_suffix=redirect_suffix)
+    assert request_with_token(access_token(signing_key)).status_code == 401
+
+
+def test_cached_signing_keys_do_not_admit_a_removed_realm(monkeypatch, signing_key):
+    now = [0]
+    fetcher = DirectoryFetcher()
+    service = StudioLoginDirectoryService(
+        fetcher, cache_seconds=60, clock=lambda: now[0]
+    )
+    app.dependency_overrides[get_auth_login_directory_provider] = (
+        lambda: lambda: service
+    )
+    calls = mock_keycloak(monkeypatch, signing_key)
+    token = access_token(signing_key)
+    assert request_with_token(token).status_code == 200
+
+    now[0] = 61
+    fetcher.directory = DIRECTORY.model_copy(update={"tenants": ()})
+    calls.clear()
+    assert request_with_token(token).status_code == 401
+    assert calls == []
+
+
+@pytest.mark.parametrize("previously_cached", [False, True])
+def test_unavailable_or_expired_directory_fails_closed(
+    monkeypatch, signing_key, previously_cached
+):
+    now = [0]
+    fetcher = DirectoryFetcher()
+    service = StudioLoginDirectoryService(
+        fetcher, cache_seconds=60, clock=lambda: now[0]
+    )
+    if previously_cached:
+        asyncio.run(service.get("prime-cache"))
+        now[0] = 61
+    fetcher.unavailable = True
+    app.dependency_overrides[get_auth_login_directory_provider] = (
+        lambda: lambda: service
+    )
+    calls = mock_keycloak(monkeypatch, signing_key)
+    assert request_with_token(access_token(signing_key)).status_code == 503
+    assert calls == []
+
+
+def test_tenant_dependency_receives_verified_claims_from_async_auth(
+    monkeypatch, signing_key, auth_environment
+):
+    mock_keycloak(monkeypatch, signing_key)
+    tenant_app = FastAPI()
+    tenant_app.dependency_overrides[get_auth_login_directory_provider] = (
+        lambda: lambda: auth_environment
+    )
+
+    @tenant_app.get("/tenant")
+    async def tenant(
+        context: StudioTenantContext = Depends(require_studio_tenant_context),
+    ):
+        return {
+            "tenant_id": context.tenant_id,
+            "revision": context.authorization_revision,
+        }
+
+    token = access_token(signing_key, iss=FULDA_ISSUER, studio_tenant_id="tenant-fulda")
+    response = TestClient(tenant_app).get(
+        "/tenant", headers={"Authorization": f"Bearer {token}"}
+    )
+    assert response.status_code == 200
+    assert response.json() == {"tenant_id": "tenant-fulda", "revision": REVISION}
+
+
+@pytest.mark.parametrize("configured", [False, True])
+def test_legacy_access_works_without_available_studio_directory(
+    monkeypatch, configured
 ):
     monkeypatch.setenv("SSF_ENABLE_LEGACY_ADMIN_ACCESS", "true")
     monkeypatch.setenv("SSF_LEGACY_ADMIN_ACCESS_CODE", "transition-code")
-
+    if configured:
+        fetcher = DirectoryFetcher()
+        fetcher.unavailable = True
+        service = StudioLoginDirectoryService(fetcher, cache_seconds=60)
+        app.dependency_overrides[get_auth_login_directory_provider] = (
+            lambda: lambda: service
+        )
+    else:
+        app.dependency_overrides.pop(get_auth_login_directory_provider)
+        monkeypatch.delenv("STUDIO_RUNTIME_CONFIGURATION_BASE_URL", raising=False)
     response = client.get(
-        "/api/admin/session/history",
-        headers={"X-SSF-Legacy-Access": "transition-code"},
+        "/api/admin/session/history", headers={"X-SSF-Legacy-Access": "transition-code"}
     )
-
     assert response.status_code == 200
 
 
 def test_admin_endpoints_reject_legacy_access_after_transition_is_disabled(monkeypatch):
-    monkeypatch.setenv("SSF_ENABLE_LEGACY_ADMIN_ACCESS", "false")
     monkeypatch.setenv("SSF_LEGACY_ADMIN_ACCESS_CODE", "transition-code")
-
     response = client.get(
-        "/api/admin/session/history",
-        headers={"X-SSF-Legacy-Access": "transition-code"},
+        "/api/admin/session/history", headers={"X-SSF-Legacy-Access": "transition-code"}
     )
-
     assert response.status_code == 401
+
+
+@pytest.mark.parametrize(
+    "base_url",
+    [
+        f"{BASE_URL}/auth",
+        f"{BASE_URL}?realm=ssf",
+        "https://user:pass@auth.example.test",
+    ],
+)
+def test_non_origin_keycloak_base_url_is_rejected(monkeypatch, signing_key, base_url):
+    monkeypatch.setenv("KEYCLOAK_BASE_URL", base_url)
+    calls = mock_keycloak(monkeypatch, signing_key)
+    assert request_with_token(access_token(signing_key)).status_code == 401
+    assert calls == []
+
+
+def test_base_url_trailing_slash_is_normalized(monkeypatch, signing_key):
+    monkeypatch.setenv("KEYCLOAK_BASE_URL", f"{BASE_URL}/")
+    monkeypatch.setenv("KEYCLOAK_ISSUER", "https://obsolete.test/realms/ssf")
+    mock_keycloak(monkeypatch, signing_key)
+    assert request_with_token(access_token(signing_key)).status_code == 200

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -16,10 +16,7 @@ from services.api_gateway.studio_login_directory_client import (
     StudioLoginDirectory,
     StudioLoginDirectoryClientError,
 )
-from services.api_gateway.tenant_context import (
-    StudioTenantContext,
-    require_studio_tenant_context,
-)
+from services.api_gateway.tenant_context import StudioTenantContext, require_studio_tenant_context
 
 client = TestClient(app)
 BASE_URL = "https://auth.example.test"
@@ -62,9 +59,7 @@ def auth_environment(monkeypatch):
     monkeypatch.setenv("KEYCLOAK_REQUIRED_ROLE", "ssf-user")
     monkeypatch.setenv("SSF_ENABLE_LEGACY_ADMIN_ACCESS", "false")
     service = StudioLoginDirectoryService(DirectoryFetcher(), cache_seconds=60)
-    app.dependency_overrides[get_auth_login_directory_provider] = (
-        lambda: lambda: service
-    )
+    app.dependency_overrides[get_auth_login_directory_provider] = lambda: lambda: service
     yield service
     app.dependency_overrides.pop(get_auth_login_directory_provider, None)
     _key_cache.entries.clear()
@@ -145,9 +140,7 @@ def mock_keycloak(
 
 
 def request_with_token(token):
-    return client.get(
-        "/api/admin/session/history", headers={"Authorization": f"Bearer {token}"}
-    )
+    return client.get("/api/admin/session/history", headers={"Authorization": f"Bearer {token}"})
 
 
 def test_admin_endpoints_reject_requests_without_a_bearer_token():
@@ -161,13 +154,9 @@ def test_admin_endpoints_reject_requests_without_a_bearer_token():
         (FULDA_ISSUER, "tenant-fulda"),
     ],
 )
-def test_admin_endpoints_accept_each_allowlisted_realm(
-    monkeypatch, signing_key, issuer, tenant_id
-):
+def test_admin_endpoints_accept_each_allowlisted_realm(monkeypatch, signing_key, issuer, tenant_id):
     calls = mock_keycloak(monkeypatch, signing_key)
-    response = request_with_token(
-        access_token(signing_key, iss=issuer, studio_tenant_id=tenant_id)
-    )
+    response = request_with_token(access_token(signing_key, iss=issuer, studio_tenant_id=tenant_id))
     assert response.status_code == 200
     assert calls == [
         f"{issuer}/.well-known/openid-configuration",
@@ -211,9 +200,7 @@ def test_unadmitted_issuers_are_rejected_without_oidc_network_access(
         {"exp": None},
     ],
 )
-def test_signed_claims_must_be_valid_and_bound_to_the_realm(
-    monkeypatch, signing_key, overrides
-):
+def test_signed_claims_must_be_valid_and_bound_to_the_realm(monkeypatch, signing_key, overrides):
     mock_keycloak(monkeypatch, signing_key)
     assert request_with_token(access_token(signing_key, **overrides)).status_code == 401
 
@@ -229,16 +216,11 @@ def test_non_rsa_jwk_fails_closed(monkeypatch, signing_key):
     assert request_with_token(access_token(signing_key)).status_code == 401
 
 
-@pytest.mark.parametrize(
-    "realm_access", [{"roles": []}, None, [], {"roles": "ssf-user"}]
-)
+@pytest.mark.parametrize("realm_access", [{"roles": []}, None, [], {"roles": "ssf-user"}])
 def test_missing_or_malformed_role_is_rejected(monkeypatch, signing_key, realm_access):
     mock_keycloak(monkeypatch, signing_key)
     assert (
-        request_with_token(
-            access_token(signing_key, realm_access=realm_access)
-        ).status_code
-        == 403
+        request_with_token(access_token(signing_key, realm_access=realm_access)).status_code == 403
     )
 
 
@@ -268,12 +250,8 @@ def test_oidc_redirects_are_rejected(monkeypatch, signing_key, redirect_suffix):
 def test_cached_signing_keys_do_not_admit_a_removed_realm(monkeypatch, signing_key):
     now = [0]
     fetcher = DirectoryFetcher()
-    service = StudioLoginDirectoryService(
-        fetcher, cache_seconds=60, clock=lambda: now[0]
-    )
-    app.dependency_overrides[get_auth_login_directory_provider] = (
-        lambda: lambda: service
-    )
+    service = StudioLoginDirectoryService(fetcher, cache_seconds=60, clock=lambda: now[0])
+    app.dependency_overrides[get_auth_login_directory_provider] = lambda: lambda: service
     calls = mock_keycloak(monkeypatch, signing_key)
     token = access_token(signing_key)
     assert request_with_token(token).status_code == 200
@@ -286,21 +264,15 @@ def test_cached_signing_keys_do_not_admit_a_removed_realm(monkeypatch, signing_k
 
 
 @pytest.mark.parametrize("previously_cached", [False, True])
-def test_unavailable_or_expired_directory_fails_closed(
-    monkeypatch, signing_key, previously_cached
-):
+def test_unavailable_or_expired_directory_fails_closed(monkeypatch, signing_key, previously_cached):
     now = [0]
     fetcher = DirectoryFetcher()
-    service = StudioLoginDirectoryService(
-        fetcher, cache_seconds=60, clock=lambda: now[0]
-    )
+    service = StudioLoginDirectoryService(fetcher, cache_seconds=60, clock=lambda: now[0])
     if previously_cached:
         asyncio.run(service.get("prime-cache"))
         now[0] = 61
     fetcher.unavailable = True
-    app.dependency_overrides[get_auth_login_directory_provider] = (
-        lambda: lambda: service
-    )
+    app.dependency_overrides[get_auth_login_directory_provider] = lambda: lambda: service
     calls = mock_keycloak(monkeypatch, signing_key)
     assert request_with_token(access_token(signing_key)).status_code == 503
     assert calls == []
@@ -325,26 +297,20 @@ def test_tenant_dependency_receives_verified_claims_from_async_auth(
         }
 
     token = access_token(signing_key, iss=FULDA_ISSUER, studio_tenant_id="tenant-fulda")
-    response = TestClient(tenant_app).get(
-        "/tenant", headers={"Authorization": f"Bearer {token}"}
-    )
+    response = TestClient(tenant_app).get("/tenant", headers={"Authorization": f"Bearer {token}"})
     assert response.status_code == 200
     assert response.json() == {"tenant_id": "tenant-fulda", "revision": REVISION}
 
 
 @pytest.mark.parametrize("configured", [False, True])
-def test_legacy_access_works_without_available_studio_directory(
-    monkeypatch, configured
-):
+def test_legacy_access_works_without_available_studio_directory(monkeypatch, configured):
     monkeypatch.setenv("SSF_ENABLE_LEGACY_ADMIN_ACCESS", "true")
     monkeypatch.setenv("SSF_LEGACY_ADMIN_ACCESS_CODE", "transition-code")
     if configured:
         fetcher = DirectoryFetcher()
         fetcher.unavailable = True
         service = StudioLoginDirectoryService(fetcher, cache_seconds=60)
-        app.dependency_overrides[get_auth_login_directory_provider] = (
-            lambda: lambda: service
-        )
+        app.dependency_overrides[get_auth_login_directory_provider] = lambda: lambda: service
     else:
         app.dependency_overrides.pop(get_auth_login_directory_provider)
         monkeypatch.delenv("STUDIO_RUNTIME_CONFIGURATION_BASE_URL", raising=False)

--- a/tests/test_login_directory_route.py
+++ b/tests/test_login_directory_route.py
@@ -1,0 +1,137 @@
+"""Public API tests for the browser-safe Studio tenant directory."""
+
+from uuid import UUID
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import services.api_gateway.studio_login_directory as directory_module
+from services.api_gateway.routes import login
+from services.api_gateway.studio_login_directory import (
+    StudioLoginDirectoryConfigurationError,
+    get_studio_login_directory_service,
+)
+from services.api_gateway.studio_login_directory_client import (
+    StudioLoginDirectory,
+    StudioLoginDirectoryClientError,
+)
+from services.api_gateway.studio_runtime_token import StudioTokenError
+
+REVISION = f"sha256:{'a' * 64}"
+
+
+def directory(*, empty: bool = False) -> StudioLoginDirectory:
+    return StudioLoginDirectory.model_validate(
+        {
+            "contractVersion": "1.0",
+            "directoryRevision": REVISION,
+            "tenants": (
+                []
+                if empty
+                else [
+                    {
+                        "id": "tenant-kassel",
+                        "displayName": "Stadt Kassel",
+                        "realm": "kassel-ssf-2025",
+                        "privateStudioField": "must-not-leak",
+                    }
+                ]
+            ),
+            "privateDirectoryField": "must-not-leak",
+        }
+    )
+
+
+class StubDirectoryService:
+    def __init__(self, outcome: StudioLoginDirectory | Exception) -> None:
+        self.outcome = outcome
+        self.correlation_ids: list[str] = []
+
+    async def get(self, correlation_id: str) -> StudioLoginDirectory:
+        self.correlation_ids.append(correlation_id)
+        if isinstance(self.outcome, Exception):
+            raise self.outcome
+        return self.outcome
+
+
+def route_client(service: StubDirectoryService) -> TestClient:
+    app = FastAPI()
+    app.include_router(login.router)
+    app.dependency_overrides[get_studio_login_directory_service] = lambda: service
+    return TestClient(app)
+
+
+def test_returns_only_browser_safe_tenant_fields_without_authorization() -> None:
+    service = StubDirectoryService(directory())
+
+    response = route_client(service).get(
+        "/api/login/tenants",
+        headers={"X-Correlation-Id": "correlation-1"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "tenants": [
+            {
+                "id": "tenant-kassel",
+                "displayName": "Stadt Kassel",
+                "realm": "kassel-ssf-2025",
+            }
+        ]
+    }
+    assert service.correlation_ids == ["correlation-1"]
+
+
+def test_generates_a_correlation_id_when_the_header_is_absent() -> None:
+    service = StubDirectoryService(directory(empty=True))
+
+    response = route_client(service).get("/api/login/tenants")
+
+    assert response.status_code == 200
+    assert response.json() == {"tenants": []}
+    assert len(service.correlation_ids) == 1
+    assert str(UUID(service.correlation_ids[0])) == service.correlation_ids[0]
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [
+        StudioLoginDirectoryClientError("studio_login_directory_network_error", retryable=True),
+        StudioTokenError("studio_token_network_error", retryable=True),
+        StudioLoginDirectoryConfigurationError("studio_login_directory_configuration_invalid"),
+    ],
+)
+def test_classified_directory_failures_return_the_same_neutral_503(
+    failure: Exception,
+) -> None:
+    response = route_client(StubDirectoryService(failure)).get("/api/login/tenants")
+
+    assert response.status_code == 503
+    assert response.json() == {"detail": "The login directory is temporarily unavailable"}
+    assert str(failure) not in response.text
+
+
+def test_dependency_factory_converts_configuration_failures_to_neutral_503(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_to_build() -> None:
+        raise StudioLoginDirectoryConfigurationError("studio_login_directory_configuration_invalid")
+
+    monkeypatch.setattr(directory_module, "_build_studio_login_directory_service", fail_to_build)
+    app = FastAPI()
+    app.include_router(login.router)
+
+    response = TestClient(app, raise_server_exceptions=False).get("/api/login/tenants")
+
+    assert response.status_code == 503
+    assert response.json() == {"detail": "The login directory is temporarily unavailable"}
+
+
+def test_production_app_registers_the_login_directory_as_a_public_route() -> None:
+    from services.api_gateway.app import app
+
+    response = TestClient(app, raise_server_exceptions=False).get("/api/login/tenants")
+
+    assert response.status_code == 503
+    assert response.json() == {"detail": "The login directory is temporarily unavailable"}

--- a/tests/test_login_directory_route.py
+++ b/tests/test_login_directory_route.py
@@ -104,9 +104,7 @@ def test_rejects_a_malformed_correlation_id(correlation_id: str) -> None:
     )
 
     assert response.status_code == 400
-    assert response.json() == {
-        "detail": "A valid X-Correlation-Id is required when supplied"
-    }
+    assert response.json() == {"detail": "A valid X-Correlation-Id is required when supplied"}
     assert service.correlation_ids == []
 
 

--- a/tests/test_login_directory_route.py
+++ b/tests/test_login_directory_route.py
@@ -94,6 +94,22 @@ def test_generates_a_correlation_id_when_the_header_is_absent() -> None:
     assert str(UUID(service.correlation_ids[0])) == service.correlation_ids[0]
 
 
+@pytest.mark.parametrize("correlation_id", ["x" * 129, "correlation-\x7f"])
+def test_rejects_a_malformed_correlation_id(correlation_id: str) -> None:
+    service = StubDirectoryService(directory(empty=True))
+
+    response = route_client(service).get(
+        "/api/login/tenants",
+        headers={"X-Correlation-Id": correlation_id},
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {
+        "detail": "A valid X-Correlation-Id is required when supplied"
+    }
+    assert service.correlation_ids == []
+
+
 @pytest.mark.parametrize(
     "failure",
     [

--- a/tests/test_studio_login_directory.py
+++ b/tests/test_studio_login_directory.py
@@ -3,6 +3,7 @@
 import asyncio
 
 import pytest
+from pydantic import ValidationError
 
 from services.api_gateway.studio_login_directory import StudioLoginDirectoryService
 from services.api_gateway.studio_login_directory_client import (
@@ -127,6 +128,59 @@ async def test_concurrent_callers_share_one_refresh() -> None:
 
 
 @pytest.mark.asyncio
+async def test_concurrent_callers_share_one_failed_refresh_then_a_later_call_retries() -> None:
+    clock = MutableClock()
+    original = directory()
+    refreshed = directory(REVISION_B)
+    failure = StudioLoginDirectoryClientError(
+        "studio_login_directory_network_error", retryable=True
+    )
+    fetch_started = asyncio.Event()
+    allow_failure = asyncio.Event()
+
+    class FailingRefreshClient:
+        def __init__(self) -> None:
+            self.correlation_ids: list[str] = []
+
+        async def fetch(self, correlation_id: str) -> StudioLoginDirectory:
+            self.correlation_ids.append(correlation_id)
+            if len(self.correlation_ids) == 1:
+                return original
+            if len(self.correlation_ids) == 2:
+                fetch_started.set()
+                await allow_failure.wait()
+                raise failure
+            return refreshed
+
+    client = FailingRefreshClient()
+    service = StudioLoginDirectoryService(client, cache_seconds=60, clock=clock)
+
+    assert await service.get("correlation-1") is original
+    clock.now = 60
+
+    first_task = asyncio.create_task(service.get("correlation-2"))
+    await fetch_started.wait()
+    second_task = asyncio.create_task(service.get("correlation-3"))
+    await asyncio.sleep(0)
+    allow_failure.set()
+
+    first_result, second_result = await asyncio.gather(
+        first_task, second_task, return_exceptions=True
+    )
+
+    assert first_result is failure
+    assert second_result is failure
+    assert client.correlation_ids == ["correlation-1", "correlation-2"]
+
+    assert await service.get("correlation-4") is refreshed
+    assert client.correlation_ids == [
+        "correlation-1",
+        "correlation-2",
+        "correlation-4",
+    ]
+
+
+@pytest.mark.asyncio
 async def test_request_at_ttl_expiry_refreshes_the_directory() -> None:
     clock = MutableClock()
     original = directory()
@@ -148,9 +202,27 @@ async def test_valid_empty_directory_is_cached() -> None:
     client = StubDirectoryClient(empty)
     service = StudioLoginDirectoryService(client, cache_seconds=60, clock=clock)
 
-    assert (await service.get("correlation-1")).tenants == []
+    assert (await service.get("correlation-1")).tenants == ()
     clock.now = 1
-    assert (await service.get("correlation-2")).tenants == []
+    assert (await service.get("correlation-2")).tenants == ()
+    assert client.correlation_ids == ["correlation-1"]
+
+
+@pytest.mark.asyncio
+async def test_cached_directory_cannot_be_mutated_by_a_consumer() -> None:
+    expected = directory()
+    client = StubDirectoryClient(expected)
+    service = StudioLoginDirectoryService(client, cache_seconds=60, clock=MutableClock())
+
+    first = await service.get("correlation-1")
+
+    with pytest.raises(AttributeError):
+        getattr(first.tenants, "clear")()
+    with pytest.raises(ValidationError):
+        first.tenants[0].display_name = "Poisoned tenant"
+
+    second = await service.get("correlation-2")
+    assert second.tenants[0].display_name == "Stadt Kassel"
     assert client.correlation_ids == ["correlation-1"]
 
 

--- a/tests/test_studio_login_directory.py
+++ b/tests/test_studio_login_directory.py
@@ -1,0 +1,180 @@
+"""Behavior tests for the bounded Studio login-directory cache."""
+
+import asyncio
+
+import pytest
+
+from services.api_gateway.studio_login_directory import StudioLoginDirectoryService
+from services.api_gateway.studio_login_directory_client import (
+    StudioLoginDirectory,
+    StudioLoginDirectoryClientError,
+)
+
+REVISION_A = f"sha256:{'a' * 64}"
+REVISION_B = f"sha256:{'b' * 64}"
+
+
+def directory(
+    revision: str = REVISION_A,
+    *,
+    tenants: list[dict[str, str]] | None = None,
+) -> StudioLoginDirectory:
+    return StudioLoginDirectory.model_validate(
+        {
+            "contractVersion": "1.0",
+            "directoryRevision": revision,
+            "tenants": (
+                tenants
+                if tenants is not None
+                else [
+                    {
+                        "id": "tenant-kassel",
+                        "displayName": "Stadt Kassel",
+                        "realm": "kassel-ssf-2025",
+                    }
+                ]
+            ),
+        }
+    )
+
+
+class MutableClock:
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def __call__(self) -> float:
+        return self.now
+
+
+class StubDirectoryClient:
+    def __init__(self, *outcomes: StudioLoginDirectory | Exception) -> None:
+        self.outcomes = list(outcomes)
+        self.correlation_ids: list[str] = []
+
+    async def fetch(self, correlation_id: str) -> StudioLoginDirectory:
+        self.correlation_ids.append(correlation_id)
+        outcome = self.outcomes.pop(0)
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+
+@pytest.mark.asyncio
+async def test_first_request_fetches_and_caches_the_validated_directory() -> None:
+    expected = directory()
+    client = StubDirectoryClient(expected)
+    service = StudioLoginDirectoryService(client, cache_seconds=60, clock=MutableClock())
+
+    result = await service.get("correlation-1")
+
+    assert result is expected
+    assert client.correlation_ids == ["correlation-1"]
+
+
+@pytest.mark.asyncio
+async def test_request_within_ttl_reuses_the_cached_directory() -> None:
+    clock = MutableClock()
+    expected = directory()
+    client = StubDirectoryClient(expected)
+    service = StudioLoginDirectoryService(client, cache_seconds=60, clock=clock)
+
+    first = await service.get("correlation-1")
+    clock.now = 59.999
+    second = await service.get("correlation-2")
+
+    assert first is expected
+    assert second is expected
+    assert client.correlation_ids == ["correlation-1"]
+
+
+@pytest.mark.asyncio
+async def test_concurrent_callers_share_one_refresh() -> None:
+    clock = MutableClock()
+    original = directory()
+    refreshed = directory(REVISION_B)
+    fetch_started = asyncio.Event()
+    allow_fetch = asyncio.Event()
+
+    class BlockingClient:
+        def __init__(self) -> None:
+            self.correlation_ids: list[str] = []
+
+        async def fetch(self, correlation_id: str) -> StudioLoginDirectory:
+            self.correlation_ids.append(correlation_id)
+            if len(self.correlation_ids) == 1:
+                return original
+            fetch_started.set()
+            await allow_fetch.wait()
+            return refreshed
+
+    client = BlockingClient()
+    service = StudioLoginDirectoryService(client, cache_seconds=60, clock=clock)
+
+    assert await service.get("correlation-1") is original
+    clock.now = 60
+
+    first_task = asyncio.create_task(service.get("correlation-2"))
+    await fetch_started.wait()
+    second_task = asyncio.create_task(service.get("correlation-3"))
+    await asyncio.sleep(0)
+    allow_fetch.set()
+
+    first_result, second_result = await asyncio.gather(first_task, second_task)
+
+    assert first_result is refreshed
+    assert second_result is refreshed
+    assert client.correlation_ids == ["correlation-1", "correlation-2"]
+
+
+@pytest.mark.asyncio
+async def test_request_at_ttl_expiry_refreshes_the_directory() -> None:
+    clock = MutableClock()
+    original = directory()
+    refreshed = directory(REVISION_B)
+    client = StubDirectoryClient(original, refreshed)
+    service = StudioLoginDirectoryService(client, cache_seconds=60, clock=clock)
+
+    assert await service.get("correlation-1") is original
+    clock.now = 60
+
+    assert await service.get("correlation-2") is refreshed
+    assert client.correlation_ids == ["correlation-1", "correlation-2"]
+
+
+@pytest.mark.asyncio
+async def test_valid_empty_directory_is_cached() -> None:
+    clock = MutableClock()
+    empty = directory(tenants=[])
+    client = StubDirectoryClient(empty)
+    service = StudioLoginDirectoryService(client, cache_seconds=60, clock=clock)
+
+    assert (await service.get("correlation-1")).tenants == []
+    clock.now = 1
+    assert (await service.get("correlation-2")).tenants == []
+    assert client.correlation_ids == ["correlation-1"]
+
+
+@pytest.mark.asyncio
+async def test_failed_refresh_does_not_serve_or_extend_expired_data() -> None:
+    clock = MutableClock()
+    original = directory()
+    refreshed = directory(REVISION_B)
+    failure = StudioLoginDirectoryClientError(
+        "studio_login_directory_network_error", retryable=True
+    )
+    client = StubDirectoryClient(original, failure, refreshed)
+    service = StudioLoginDirectoryService(client, cache_seconds=60, clock=clock)
+
+    assert await service.get("correlation-1") is original
+    clock.now = 60
+
+    with pytest.raises(StudioLoginDirectoryClientError) as caught:
+        await service.get("correlation-2")
+
+    assert caught.value is failure
+    assert await service.get("correlation-3") is refreshed
+    assert client.correlation_ids == [
+        "correlation-1",
+        "correlation-2",
+        "correlation-3",
+    ]

--- a/tests/test_studio_login_directory_client.py
+++ b/tests/test_studio_login_directory_client.py
@@ -1,0 +1,288 @@
+"""Contract tests for the Studio administrative login-directory V1 client."""
+
+from copy import deepcopy
+from typing import Any, Mapping
+
+import pytest
+
+from services.api_gateway.studio_login_directory_client import (
+    DIRECTORY_PATH,
+    DirectoryHttpResponse,
+    StudioLoginDirectoryClient,
+    StudioLoginDirectoryClientError,
+)
+
+REVISION = f"sha256:{'a' * 64}"
+
+
+def valid_directory() -> dict[str, object]:
+    return {
+        "contractVersion": "1.0",
+        "directoryRevision": REVISION,
+        "tenants": [
+            {
+                "id": "tenant-kassel",
+                "displayName": "Stadt Kassel",
+                "realm": "kassel-ssf-2025",
+            }
+        ],
+    }
+
+
+class StubTokenProvider:
+    async def get_token(self) -> str:
+        return "service-token"
+
+
+class StubTransport:
+    def __init__(self, response: DirectoryHttpResponse) -> None:
+        self.response = response
+        self.calls: list[tuple[str, Mapping[str, str], float]] = []
+
+    async def get(
+        self, url: str, headers: Mapping[str, str], timeout_seconds: float
+    ) -> DirectoryHttpResponse:
+        self.calls.append((url, headers, timeout_seconds))
+        return self.response
+
+
+def client(
+    response: DirectoryHttpResponse,
+) -> tuple[StudioLoginDirectoryClient, StubTransport]:
+    transport = StubTransport(response)
+    return (
+        StudioLoginDirectoryClient(
+            "https://studio.test",
+            StubTokenProvider(),
+            transport=transport,
+            timeout_seconds=2.0,
+        ),
+        transport,
+    )
+
+
+@pytest.mark.asyncio
+async def test_accepts_valid_directory_and_sends_tenant_unbound_request() -> None:
+    directory_client, transport = client(DirectoryHttpResponse(200, valid_directory()))
+
+    directory = await directory_client.fetch("correlation-1")
+
+    assert directory.directory_revision == REVISION
+    assert directory.tenants[0].model_dump(by_alias=True) == {
+        "id": "tenant-kassel",
+        "displayName": "Stadt Kassel",
+        "realm": "kassel-ssf-2025",
+    }
+    assert transport.calls == [
+        (
+            f"https://studio.test{DIRECTORY_PATH}",
+            {
+                "Authorization": "Bearer service-token",
+                "X-Correlation-Id": "correlation-1",
+            },
+            2.0,
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_accepts_an_empty_tenant_directory() -> None:
+    payload = valid_directory()
+    payload["tenants"] = []
+    directory_client, _ = client(DirectoryHttpResponse(200, payload))
+
+    directory = await directory_client.fetch("correlation-1")
+
+    assert directory.tenants == []
+
+
+@pytest.mark.asyncio
+async def test_accepts_unknown_optional_v1_fields() -> None:
+    payload = valid_directory()
+    payload["optionalDirectoryField"] = {"enabled": True}
+    tenants = payload["tenants"]
+    assert isinstance(tenants, list)
+    tenant = tenants[0]
+    assert isinstance(tenant, dict)
+    tenant["optionalTenantField"] = "value"
+    directory_client, _ = client(DirectoryHttpResponse(200, payload))
+
+    directory = await directory_client.fetch("correlation-1")
+
+    assert directory.contract_version == "1.0"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        lambda payload: payload.update(contractVersion="2.0"),
+        lambda payload: payload.update(directoryRevision="sha256:INVALID"),
+        lambda payload: payload["tenants"][0].update(id="tenant kassel"),
+        lambda payload: payload["tenants"][0].update(realm="kassel/unsafe"),
+        lambda payload: payload.update(
+            tenants=[payload["tenants"][0], deepcopy(payload["tenants"][0])]
+        ),
+        lambda payload: payload.update(
+            tenants=[
+                payload["tenants"][0],
+                {
+                    "id": "tenant-fulda",
+                    "displayName": "Stadt Fulda",
+                    "realm": "kassel-ssf-2025",
+                },
+            ]
+        ),
+        lambda payload: payload["tenants"][0].update(displayName=""),
+    ],
+)
+async def test_rejects_invalid_known_directory_fields(mutate: Any) -> None:
+    payload = valid_directory()
+    mutate(payload)
+    directory_client, _ = client(DirectoryHttpResponse(200, payload))
+
+    with pytest.raises(StudioLoginDirectoryClientError) as caught:
+        await directory_client.fetch("correlation-1")
+
+    assert caught.value.code == "studio_login_directory_response_invalid"
+    assert caught.value.retryable is False
+    assert caught.value.status == 200
+
+
+@pytest.mark.asyncio
+async def test_rejects_a_non_object_success_payload() -> None:
+    directory_client, _ = client(DirectoryHttpResponse(200, ["Studio secret"]))  # type: ignore[arg-type]
+
+    with pytest.raises(StudioLoginDirectoryClientError) as caught:
+        await directory_client.fetch("correlation-1")
+
+    assert caught.value.code == "studio_login_directory_response_invalid"
+    assert "Studio secret" not in str(caught.value)
+
+
+@pytest.mark.asyncio
+async def test_rejects_correlation_id_control_characters_before_transport() -> None:
+    directory_client, transport = client(DirectoryHttpResponse(200, valid_directory()))
+
+    with pytest.raises(ValueError):
+        await directory_client.fetch("correlation-1\r\nX-Forged: true")
+
+    assert transport.calls == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("status", "code", "retryable"),
+    [
+        (401, "service_authentication_invalid", False),
+        (403, "service_action_forbidden", False),
+        (503, "admin_login_directory_unavailable", True),
+    ],
+)
+async def test_preserves_stable_error_retryability(status: int, code: str, retryable: bool) -> None:
+    directory_client, _ = client(
+        DirectoryHttpResponse(
+            status,
+            {
+                "contractVersion": "1.0",
+                "error": {
+                    "code": code,
+                    "message": "Directory is unavailable.",
+                    "retryable": retryable,
+                    "correlationId": "correlation-1",
+                },
+            },
+        )
+    )
+
+    with pytest.raises(StudioLoginDirectoryClientError) as caught:
+        await directory_client.fetch("correlation-1")
+
+    assert caught.value.code == code
+    assert caught.value.retryable is retryable
+    assert caught.value.status == status
+
+
+@pytest.mark.asyncio
+async def test_rejects_malformed_error_envelopes_and_unexpected_statuses_without_studio_content() -> (
+    None
+):
+    malformed_error_client, _ = client(DirectoryHttpResponse(401, {"error": "Studio secret"}))
+    wrong_error_code_client, _ = client(
+        DirectoryHttpResponse(
+            403,
+            {
+                "contractVersion": "1.0",
+                "error": {
+                    "code": "unexpected_code",
+                    "message": "Studio secret",
+                    "retryable": False,
+                    "correlationId": "correlation-1",
+                },
+            },
+        )
+    )
+    unexpected_status_client, _ = client(DirectoryHttpResponse(502, {"secret": "Studio secret"}))
+
+    with pytest.raises(StudioLoginDirectoryClientError) as malformed_error:
+        await malformed_error_client.fetch("correlation-1")
+    with pytest.raises(StudioLoginDirectoryClientError) as wrong_error_code:
+        await wrong_error_code_client.fetch("correlation-1")
+    with pytest.raises(StudioLoginDirectoryClientError) as unexpected_status:
+        await unexpected_status_client.fetch("correlation-1")
+
+    assert malformed_error.value.code == "studio_login_directory_error_invalid"
+    assert wrong_error_code.value.code == "studio_login_directory_error_invalid"
+    assert unexpected_status.value.code == "studio_login_directory_unexpected_status"
+    for error in (
+        malformed_error.value,
+        wrong_error_code.value,
+        unexpected_status.value,
+    ):
+        assert "Studio secret" not in str(error)
+
+
+@pytest.mark.asyncio
+async def test_rejects_invalid_service_token_before_transport() -> None:
+    class InvalidTokenProvider:
+        async def get_token(self) -> str:
+            return "service-token\r\nX-Forged: true"
+
+    transport = StubTransport(DirectoryHttpResponse(200, valid_directory()))
+    directory_client = StudioLoginDirectoryClient(
+        "https://studio.test", InvalidTokenProvider(), transport=transport
+    )
+
+    with pytest.raises(StudioLoginDirectoryClientError) as caught:
+        await directory_client.fetch("correlation-1")
+
+    assert caught.value.code == "studio_login_directory_token_invalid"
+    assert caught.value.retryable is False
+    assert transport.calls == []
+
+
+@pytest.mark.asyncio
+async def test_classifies_transport_timeout_as_retryable_network_error() -> None:
+    class TimeoutTransport:
+        async def get(
+            self, url: str, headers: Mapping[str, str], timeout_seconds: float
+        ) -> DirectoryHttpResponse:
+            raise TimeoutError("Studio secret")
+
+    directory_client = StudioLoginDirectoryClient(
+        "https://studio.test", StubTokenProvider(), transport=TimeoutTransport()
+    )
+
+    with pytest.raises(StudioLoginDirectoryClientError) as caught:
+        await directory_client.fetch("correlation-1")
+
+    assert caught.value.code == "studio_login_directory_network_error"
+    assert caught.value.retryable is True
+    assert caught.value.__cause__ is None
+
+
+def test_rejects_base_urls_that_could_change_the_fixed_directory_path() -> None:
+    with pytest.raises(ValueError):
+        StudioLoginDirectoryClient("https://studio.test/prefix", StubTokenProvider())
+    with pytest.raises(ValueError):
+        StudioLoginDirectoryClient("https://user:secret@studio.test", StubTokenProvider())

--- a/tests/test_studio_login_directory_client.py
+++ b/tests/test_studio_login_directory_client.py
@@ -93,7 +93,7 @@ async def test_accepts_an_empty_tenant_directory() -> None:
 
     directory = await directory_client.fetch("correlation-1")
 
-    assert directory.tenants == []
+    assert directory.tenants == ()
 
 
 @pytest.mark.asyncio

--- a/tests/test_studio_runtime_configuration_mock.py
+++ b/tests/test_studio_runtime_configuration_mock.py
@@ -11,6 +11,7 @@ from services.studio_mock.app import app
 
 CLIENT = TestClient(app)
 PATH = "/internal/plugins/ssf/v1/runtime-configuration"
+DIRECTORY_PATH = "/internal/plugins/ssf/v1/admin-login-tenants"
 AUTHORIZED_TOKEN = "Bearer studio-mock-authorized-token"
 UNAUTHORIZED_TOKEN = "Bearer studio-mock-unauthorized-token"
 
@@ -102,11 +103,17 @@ def test_rejects_service_token_without_runtime_configuration_permission() -> Non
 def test_rejects_missing_tenant_and_correlation_headers() -> None:
     missing_tenant = CLIENT.get(
         PATH,
-        headers={"Authorization": AUTHORIZED_TOKEN, "X-Correlation-Id": "test-correlation-id"},
+        headers={
+            "Authorization": AUTHORIZED_TOKEN,
+            "X-Correlation-Id": "test-correlation-id",
+        },
     )
     missing_correlation = CLIENT.get(
         PATH,
-        headers={"Authorization": AUTHORIZED_TOKEN, "X-Studio-Tenant-Id": "tenant-kassel"},
+        headers={
+            "Authorization": AUTHORIZED_TOKEN,
+            "X-Studio-Tenant-Id": "tenant-kassel",
+        },
     )
 
     assert missing_tenant.status_code == 404
@@ -210,3 +217,106 @@ def test_openapi_documents_required_v1_headers_and_success_contract() -> None:
     }
     asset_definition = schema["components"]["schemas"]["BrandingAssetResponse"]
     assert {"url", "alternativeText"} <= set(asset_definition["properties"])
+
+
+def _directory_headers(**additional: str) -> dict[str, str]:
+    return {
+        "Authorization": AUTHORIZED_TOKEN,
+        "X-Correlation-Id": "test-correlation-id",
+        **additional,
+    }
+
+
+def test_returns_deterministic_v1_login_directory_for_authorized_service() -> None:
+    first = CLIENT.get(DIRECTORY_PATH, headers=_directory_headers())
+    second = CLIENT.get(DIRECTORY_PATH, headers=_directory_headers())
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert first.json() == second.json()
+    payload = first.json()
+    assert payload == {
+        "contractVersion": "1.0",
+        "directoryRevision": payload["directoryRevision"],
+        "tenants": [
+            {
+                "id": "tenant-kassel",
+                "displayName": "Stadt Kassel",
+                "realm": "kassel-ssf-2025",
+            },
+            {
+                "id": "tenant-fulda",
+                "displayName": "Stadt Fulda",
+                "realm": "fulda-ssf-2025",
+            },
+        ],
+    }
+    revision = payload.pop("directoryRevision")
+    expected_revision = hashlib.sha256(
+        json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode()
+    ).hexdigest()
+    assert revision == f"sha256:{expected_revision}"
+
+
+def test_login_directory_requires_authorization_and_correlation_id() -> None:
+    missing_token = CLIENT.get(DIRECTORY_PATH, headers={"X-Correlation-Id": "test-correlation-id"})
+    missing_correlation = CLIENT.get(DIRECTORY_PATH, headers={"Authorization": AUTHORIZED_TOKEN})
+
+    assert missing_token.status_code == 401
+    assert missing_token.json()["error"]["code"] == "service_authentication_invalid"
+    assert missing_correlation.status_code != 200
+
+
+def test_login_directory_rejects_tenant_selectors_and_supports_service_scenarios() -> None:
+    selector_responses = [
+        CLIENT.get(
+            DIRECTORY_PATH,
+            headers=_directory_headers(**{"X-Studio-Tenant-Id": "tenant-kassel"}),
+        ),
+        CLIENT.get(
+            DIRECTORY_PATH,
+            headers=_directory_headers(**{"X-Studio-Instance-Id": "tenant-kassel"}),
+        ),
+        CLIENT.get(
+            DIRECTORY_PATH,
+            headers=_directory_headers(**{"X-Tenant-Id": "tenant-kassel"}),
+        ),
+        CLIENT.get(
+            DIRECTORY_PATH,
+            params={"tenantId": "tenant-kassel"},
+            headers=_directory_headers(),
+        ),
+    ]
+    forbidden = CLIENT.get(
+        DIRECTORY_PATH, headers=_directory_headers(Authorization=UNAUTHORIZED_TOKEN)
+    )
+    unavailable = CLIENT.get(
+        DIRECTORY_PATH, headers=_directory_headers(**{"X-Mock-Scenario": "unavailable"})
+    )
+
+    assert all(response.status_code != 200 for response in selector_responses)
+    assert forbidden.status_code == 403
+    assert forbidden.json()["error"]["code"] == "service_action_forbidden"
+    assert unavailable.status_code == 503
+    assert unavailable.json()["error"]["code"] == "admin_login_directory_unavailable"
+
+
+def test_openapi_documents_login_directory_contract_and_required_headers() -> None:
+    schema = CLIENT.get("/openapi.json").json()
+    operation = schema["paths"][DIRECTORY_PATH]["get"]
+    headers = {
+        parameter["name"]: parameter
+        for parameter in operation["parameters"]
+        if parameter["in"] == "header"
+    }
+
+    for header_name in ("authorization", "x-correlation-id"):
+        assert headers[header_name]["required"] is True
+        assert headers[header_name]["schema"] == {"type": "string"}
+    assert "x-studio-tenant-id" not in headers
+    success_schema = operation["responses"]["200"]["content"]["application/json"]["schema"]
+    assert success_schema["$ref"].endswith("AdminLoginDirectoryResponse")
+    response_definition = schema["components"]["schemas"]["AdminLoginDirectoryResponse"]
+    assert {"contractVersion", "directoryRevision", "tenants"} <= set(
+        response_definition["properties"]
+    )

--- a/tests/test_tenant_context.py
+++ b/tests/test_tenant_context.py
@@ -62,6 +62,7 @@ def _tenant_test_client() -> TestClient:
     }
 
     @app.api_route("/tenant-operation", methods=["GET", "POST"])
+    @app.get("/tenant-operation/{studio_tenant_id}")
     async def tenant_operation(
         context: StudioTenantContext = Depends(require_studio_tenant_context),
     ) -> dict[str, str]:
@@ -75,6 +76,12 @@ def test_dependency_uses_only_the_validated_claim() -> None:
 
     assert response.status_code == 200
     assert response.json() == {"tenant_id": "tenant-kassel"}
+
+
+def test_dependency_rejects_path_tenant_selectors() -> None:
+    response = _tenant_test_client().get("/tenant-operation/tenant-berlin")
+
+    assert response.status_code == 400
 
 
 @pytest.mark.parametrize(
@@ -97,7 +104,9 @@ def test_dependency_rejects_browser_controlled_tenant_selectors(
     request_kwargs: dict[str, Any],
 ) -> None:
     client = _tenant_test_client()
-    method = client.post if {"json", "content"}.intersection(request_kwargs) else client.get
+    method = (
+        client.post if {"json", "content"}.intersection(request_kwargs) else client.get
+    )
 
     response = method("/tenant-operation", **request_kwargs)
 


### PR DESCRIPTION
## Description

Add a tenant-selection login flow backed by the SVA Studio directory. The gateway validates allowlisted Keycloak realms, and the frontend routes staff through `/login` and `/login/:tenantId` while keeping `/admin` as the separate legacy entrypoint.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change (deployment configuration replaces fixed realm settings)
- [x] 📝 Documentation update
- [x] ✅ Test update
- [x] 🔧 Build/CI configuration change
- [x] 🔒 Security fix

## Related Issues

No linked issue.

## Changes Made

- Consume, validate, cache, and expose Studio's public admin-login tenant directory.
- Validate bearer tokens against the selected allowlisted realm, pinned discovery metadata/JWKS, and signed tenant/revision claims.
- Add the alphabetical tenant chooser, tenant-qualified Keycloak login, refresh recovery, and per-tenant browser query isolation.
- Align production origins and remove the fixed production realm import.
- Document Studio provisioning, smoke-test, and tenant-isolation rollout gates.

## Testing

### Test Coverage

- [x] All existing tests pass (`pytest`)
- [x] New tests added for this change
- [ ] Manual testing completed
- [x] Integration tests pass where local dependencies are available
- [ ] Load tests pass (not run)

### How to Test

```bash
/root/projects/ssf-backend/.venv/bin/pytest -q -o log_cli=false
cd services/frontend
npm test
npm run lint
npm run build
npm run fallow:audit
```

Fresh verification before PR creation:

- Backend: 1,251 passed, 62 skipped.
- Frontend: 562 passed.
- Frontend lint, production build, and Fallow audit passed.
- Operations: 16 passed.
- `openspec validate add-keycloak-admin-authentication --strict` passed.

## Checklist

### Code Quality

- [x] Code follows the project's style guidelines
- [x] Self-review of code completed
- [x] Code is commented where necessary
- [x] Pre-commit hooks pass

### Testing

- [x] Tests added/updated for new functionality
- [x] All tests pass locally
- [x] Test coverage maintained or improved

### Documentation

- [x] Documentation updated
- [x] API/deployment documentation updated
- [ ] CHANGELOG.md updated
- [x] Migration requirements documented in deployment notes

### Dependencies

- [x] No new dependencies added

### Security

- [x] No sensitive data exposed
- [x] Security best practices followed
- [x] Input validation added where needed

## Performance Impact

- [x] No material performance impact; directory and JWKS lookups are cached.

## Breaking Changes

Deployments must replace fixed `KEYCLOAK_ISSUER`/`VITE_KEYCLOAK_REALM` settings with the documented Keycloak base URL, public client ID, and Studio runtime directory credentials.

## Deployment Notes

- [x] Requires configuration changes
- [x] Requires service restart
- [x] Studio must provision every listed realm and signed claims before enablement.
- [x] Production rollout remains blocked until deployed two-realm smoke tests and the separate `add-multi-tenant-operations` isolation tests pass.

## Reviewer Checklist

- [ ] Code quality acceptable
- [ ] Tests are comprehensive
- [ ] Documentation is clear
- [ ] No security concerns
- [ ] CI/CD passes
- [ ] Ready to merge
