### PR TITLE
feat(traefik): add dynamic tenant ingress provider

### DIFF
--- a/deploy/production/docker-compose.production.yml
+++ b/deploy/production/docker-compose.production.yml
@@ -7,6 +7,8 @@ services:
     - --log.level=DEBUG
     - --providers.docker=true
     - --providers.docker.exposedbydefault=false
+    - --providers.file.directory=/etc/traefik/dynamic
+    - --providers.file.watch=true
     - --entrypoints.web.address=:80
     - --entrypoints.websecure.address=:443
     - --certificatesresolvers.le.acme.tlschallenge=true
@@ -20,6 +22,7 @@ services:
     volumes:
     - /var/run/docker.sock:/var/run/docker.sock:ro
     - ../../letsencrypt:/letsencrypt
+    - ../../traefik/dynamic:/etc/traefik/dynamic:ro
     restart: unless-stopped
     pull_policy: never
   asr:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
       - --log.level=DEBUG
       - --providers.docker=true
       - --providers.docker.exposedbydefault=false
+      - --providers.file.directory=/etc/traefik/dynamic
+      - --providers.file.watch=true
       - --entrypoints.web.address=:80
       - --entrypoints.websecure.address=:443
       - --certificatesresolvers.le.acme.tlschallenge=true
@@ -19,6 +21,7 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - ./letsencrypt:/letsencrypt
+      - ./traefik/dynamic:/etc/traefik/dynamic:ro
     restart: always
 
   asr:

--- a/docs/operations/production-recovery.md
+++ b/docs/operations/production-recovery.md
@@ -49,6 +49,8 @@ consistent native snapshots are the recovery source. `ollama-models.txt`
 records the installed model identifiers; after recovery, pull those models
 again from the configured Ollama registry. This keeps recurring backups small
 while retaining the information needed to restore the service configuration.
+The configuration archive includes `traefik/dynamic`; restoring it recovers
+the explicit Studio tenant routers before Traefik is restarted.
 The Grafana SQLite database is captured separately using a consistent SQLite
 snapshot. Loki log chunks and Promtail read positions are intentionally not
 backed up: they change continuously and are not required to restore the

--- a/openspec/changes/add-kassel-tenant-ingress-file-provider/design.md
+++ b/openspec/changes/add-kassel-tenant-ingress-file-provider/design.md
@@ -1,0 +1,39 @@
+# Design: Kassel tenant ingress file provider
+
+## Context
+
+Traefik already uses the Docker provider and TLS-ALPN ACME. Kassel has wildcard
+DNS but no DNS-01 credentials. Tenant routers must therefore remain explicit
+and request certificates through the existing resolver.
+
+## Decisions
+
+- Traefik watches `/etc/traefik/dynamic` via the file provider.
+- Compose bind-mounts `./traefik/dynamic` to that path read-only.
+- The directory is empty by default, so enabling it does not alter existing
+  routing.
+- The external Studio provisioner owns atomic publication into the host-side
+  directory. Traefik never receives write access.
+- Existing Docker labels and the `le` resolver remain authoritative for all
+  existing routes until hosts are migrated individually.
+
+## Security boundary
+
+The File Provider is a configuration reader, not an API. This change adds no
+socket, credential, or public endpoint. Tenant filenames and contents are
+validated and atomically published by Studio under its separately reviewed
+contract.
+
+## Rollout
+
+Enable the provider with an empty directory first and verify all existing
+routes. Studio may publish a higher-priority explicit tenant router only after
+that baseline succeeds. Static hosts are removed individually after external
+TLS and login acceptance.
+
+## Rollback
+
+Stop the Studio writer, restore the explicit Docker-label host where needed,
+verify it externally, and only then remove the corresponding dynamic file.
+Disabling the File Provider must not alter the Docker provider or ACME store.
+

--- a/openspec/changes/add-kassel-tenant-ingress-file-provider/design.md
+++ b/openspec/changes/add-kassel-tenant-ingress-file-provider/design.md
@@ -9,7 +9,9 @@ and request certificates through the existing resolver.
 ## Decisions
 
 - Traefik watches `/etc/traefik/dynamic` via the file provider.
-- Compose bind-mounts `./traefik/dynamic` to that path read-only.
+- Root Compose bind-mounts `./traefik/dynamic`; canonical production Compose
+  resolves the same repository directory as `../../traefik/dynamic`. Both
+  mounts expose it read-only at `/etc/traefik/dynamic`.
 - The directory is empty by default, so enabling it does not alter existing
   routing.
 - The external Studio provisioner owns atomic publication into the host-side
@@ -36,4 +38,5 @@ TLS and login acceptance.
 Stop the Studio writer, restore the explicit Docker-label host where needed,
 verify it externally, and only then remove the corresponding dynamic file.
 Disabling the File Provider must not alter the Docker provider or ACME store.
-
+The production backup retains `traefik/dynamic`, so a host restore also
+recovers the explicit tenant router files.

--- a/openspec/changes/add-kassel-tenant-ingress-file-provider/proposal.md
+++ b/openspec/changes/add-kassel-tenant-ingress-file-provider/proposal.md
@@ -1,0 +1,24 @@
+# Change: Add the Kassel tenant ingress file provider
+
+## Why
+
+Kassel tenant hosts currently require manual edits to the Studio container's
+Traefik labels. Studio needs a narrow, durable configuration boundary that can
+publish one explicit router per provisioned tenant without receiving Docker or
+ACME access.
+
+## What Changes
+
+- Enable Traefik's watched file provider for a dedicated dynamic directory.
+- Mount that directory read-only into Traefik.
+- Keep the Docker provider, TLS-ALPN resolver, existing routers, and ACME store
+  unchanged.
+- Define the cross-repository writer contract used by the standalone Studio
+  provisioner; this repository does not write tenant router files itself.
+
+## Impact
+
+- Affected capability: `tenant-ingress`
+- Affected code: `docker-compose.yml`, production Compose validation
+- External consumer: the Kassel standalone deployment of `sva-studio`
+

--- a/openspec/changes/add-kassel-tenant-ingress-file-provider/specs/tenant-ingress/spec.md
+++ b/openspec/changes/add-kassel-tenant-ingress-file-provider/specs/tenant-ingress/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: Traefik reads tenant routers from a dedicated directory
+
+The Kassel deployment SHALL enable Traefik's watched File Provider for a
+dedicated dynamic configuration directory while retaining the existing Docker
+Provider and ACME resolver.
+
+#### Scenario: Traefik starts with an empty dynamic directory
+
+- **WHEN** the File Provider is enabled before any tenant router is published
+- **THEN** Traefik reads the mounted directory without adding a tenant route
+- **AND** existing Docker-provider routes remain available
+
+#### Scenario: Traefik receives the dynamic directory
+
+- **WHEN** Compose starts the Traefik service
+- **THEN** the host-side dynamic directory is mounted read-only at the configured provider path
+- **AND** the existing Docker socket remains read-only
+- **AND** the existing ACME storage and TLS-ALPN resolver remain unchanged
+
+### Requirement: Dynamic tenant publication has a separate writer boundary
+
+The deployment SHALL treat the host-side dynamic directory as an external
+writer boundary and SHALL NOT grant Traefik or unrelated services write access
+to it.
+
+#### Scenario: Studio publishes a tenant router
+
+- **WHEN** the separately authorized Studio provisioner atomically publishes a validated tenant file
+- **THEN** Traefik can observe and load that file through its read-only mount
+- **AND** no Docker-socket or ACME credential is delegated to Studio
+

--- a/openspec/changes/add-kassel-tenant-ingress-file-provider/tasks.md
+++ b/openspec/changes/add-kassel-tenant-ingress-file-provider/tasks.md
@@ -11,3 +11,4 @@
 - [x] 2.2 Run the focused Compose tests
 - [x] 2.3 Validate the rendered Compose configuration
 - [x] 2.4 Document empty-directory rollout and non-destructive rollback
+- [x] 2.5 Include dynamic tenant routes in the production backup contract

--- a/openspec/changes/add-kassel-tenant-ingress-file-provider/tasks.md
+++ b/openspec/changes/add-kassel-tenant-ingress-file-provider/tasks.md
@@ -1,0 +1,13 @@
+## 1. Contract and implementation
+
+- [x] 1.1 Add a watched File Provider directory to Traefik
+- [x] 1.2 Mount the dynamic directory read-only into Traefik
+- [x] 1.3 Add a tracked empty host-side directory
+- [x] 1.4 Add Compose contract tests for provider, mount, and unchanged security boundaries
+
+## 2. Verification and documentation
+
+- [x] 2.1 Validate the OpenSpec change strictly
+- [x] 2.2 Run the focused Compose tests
+- [x] 2.3 Validate the rendered Compose configuration
+- [x] 2.4 Document empty-directory rollout and non-destructive rollback

--- a/scripts/backup-production.sh
+++ b/scripts/backup-production.sh
@@ -112,6 +112,10 @@ production_compose exec -T clickhouse cat "/var/lib/clickhouse/backups/${clickho
   > "$staging_dir/clickhouse-native-backup.zip"
 production_compose exec -T clickhouse rm -f "/var/lib/clickhouse/backups/${clickhouse_backup_filename}"
 
+configuration_paths=(deploy/production monitoring letsencrypt models)
+if [[ -d "$SSF_PROJECT_ROOT/traefik/dynamic" ]]; then
+  configuration_paths+=(traefik/dynamic)
+fi
 tar -C "$SSF_PROJECT_ROOT" -czf "$staging_dir/configuration.tar.gz" \
   --exclude='monitoring/grafana/grafana.db' \
   --exclude='monitoring/grafana/grafana.db-shm' \
@@ -120,7 +124,7 @@ tar -C "$SSF_PROJECT_ROOT" -czf "$staging_dir/configuration.tar.gz" \
   --exclude='monitoring/loki-data/*' \
   --exclude='monitoring/promtail-data' \
   --exclude='monitoring/promtail-data/*' \
-  deploy/production monitoring letsencrypt models traefik/dynamic
+  "${configuration_paths[@]}"
 install -m 0600 "$SSF_PROJECT_ROOT/.env" "$staging_dir/environment.env"
 git -C "$SSF_PROJECT_ROOT" rev-parse HEAD > "$staging_dir/git-revision.txt"
 

--- a/scripts/backup-production.sh
+++ b/scripts/backup-production.sh
@@ -120,7 +120,7 @@ tar -C "$SSF_PROJECT_ROOT" -czf "$staging_dir/configuration.tar.gz" \
   --exclude='monitoring/loki-data/*' \
   --exclude='monitoring/promtail-data' \
   --exclude='monitoring/promtail-data/*' \
-  deploy/production monitoring letsencrypt models
+  deploy/production monitoring letsencrypt models traefik/dynamic
 install -m 0600 "$SSF_PROJECT_ROOT/.env" "$staging_dir/environment.env"
 git -C "$SSF_PROJECT_ROOT" rev-parse HEAD > "$staging_dir/git-revision.txt"
 

--- a/tests/operations/test_production_scripts.py
+++ b/tests/operations/test_production_scripts.py
@@ -151,6 +151,8 @@ fi
     project_root = tmp_path / "project"
     for directory in ("deploy/production", "monitoring", "letsencrypt", "models"):
         (project_root / directory).mkdir(parents=True, exist_ok=True)
+    (project_root / "traefik/dynamic").mkdir(parents=True)
+    (project_root / "traefik/dynamic/tenant.yml").write_text("http: {}\n")
     (project_root / "monitoring/loki-data").mkdir()
     (project_root / "monitoring/promtail-data").mkdir()
     (project_root / "monitoring/loki-data/live.log").write_text("live log data\n")
@@ -225,6 +227,7 @@ def test_backup_records_ollama_models_without_archiving_model_volume(tmp_path):
         check=True,
     ).stdout
     assert "monitoring/prometheus.yml" in configuration_listing
+    assert "traefik/dynamic/tenant.yml" in configuration_listing
     assert "monitoring/loki-data/live.log" not in configuration_listing
     assert "monitoring/promtail-data/positions.yaml" not in configuration_listing
     assert "monitoring/grafana/grafana.db" not in configuration_listing

--- a/tests/test_traefik_dynamic_configuration.py
+++ b/tests/test_traefik_dynamic_configuration.py
@@ -53,4 +53,7 @@ def test_dynamic_provider_preserves_existing_security_boundaries() -> None:
 def test_production_backup_preserves_dynamic_tenant_routes() -> None:
     backup_script = BACKUP_SCRIPT_PATH.read_text(encoding="utf-8")
 
-    assert "deploy/production monitoring letsencrypt models traefik/dynamic" in backup_script
+    assert "configuration_paths=(deploy/production monitoring letsencrypt models)" in backup_script
+    assert '[[ -d "$SSF_PROJECT_ROOT/traefik/dynamic" ]]' in backup_script
+    assert "configuration_paths+=(traefik/dynamic)" in backup_script
+    assert '"${configuration_paths[@]}"' in backup_script

--- a/tests/test_traefik_dynamic_configuration.py
+++ b/tests/test_traefik_dynamic_configuration.py
@@ -35,10 +35,14 @@ def test_production_traefik_watches_the_dynamic_configuration_directory() -> Non
 
 
 def test_dynamic_provider_preserves_existing_security_boundaries() -> None:
-    traefik = _traefik()
+    development = _traefik()
+    production = _production_traefik()
 
-    assert "--providers.docker=true" in traefik["command"]
-    assert "--providers.docker.exposedbydefault=false" in traefik["command"]
-    assert "--certificatesresolvers.le.acme.tlschallenge=true" in traefik["command"]
-    assert "/var/run/docker.sock:/var/run/docker.sock:ro" in traefik["volumes"]
-    assert "./letsencrypt:/letsencrypt" in traefik["volumes"]
+    for traefik in (development, production):
+        assert "--providers.docker=true" in traefik["command"]
+        assert "--providers.docker.exposedbydefault=false" in traefik["command"]
+        assert "--certificatesresolvers.le.acme.tlschallenge=true" in traefik["command"]
+        assert "/var/run/docker.sock:/var/run/docker.sock:ro" in traefik["volumes"]
+
+    assert "./letsencrypt:/letsencrypt" in development["volumes"]
+    assert "../../letsencrypt:/letsencrypt" in production["volumes"]

--- a/tests/test_traefik_dynamic_configuration.py
+++ b/tests/test_traefik_dynamic_configuration.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPOSE_PATH = ROOT / "docker-compose.yml"
+
+
+def _traefik() -> dict[str, object]:
+    compose = yaml.safe_load(COMPOSE_PATH.read_text(encoding="utf-8"))
+    return compose["services"]["traefik"]
+
+
+def test_traefik_watches_the_dynamic_configuration_directory() -> None:
+    traefik = _traefik()
+
+    assert "--providers.file.directory=/etc/traefik/dynamic" in traefik["command"]
+    assert "--providers.file.watch=true" in traefik["command"]
+    assert "./traefik/dynamic:/etc/traefik/dynamic:ro" in traefik["volumes"]
+
+
+def test_dynamic_provider_preserves_existing_security_boundaries() -> None:
+    traefik = _traefik()
+
+    assert "--providers.docker=true" in traefik["command"]
+    assert "--providers.docker.exposedbydefault=false" in traefik["command"]
+    assert "--certificatesresolvers.le.acme.tlschallenge=true" in traefik["command"]
+    assert "/var/run/docker.sock:/var/run/docker.sock:ro" in traefik["volumes"]
+    assert "./letsencrypt:/letsencrypt" in traefik["volumes"]
+

--- a/tests/test_traefik_dynamic_configuration.py
+++ b/tests/test_traefik_dynamic_configuration.py
@@ -5,10 +5,16 @@ import yaml
 
 ROOT = Path(__file__).resolve().parents[1]
 COMPOSE_PATH = ROOT / "docker-compose.yml"
+PRODUCTION_COMPOSE_PATH = ROOT / "deploy" / "production" / "docker-compose.production.yml"
 
 
 def _traefik() -> dict[str, object]:
     compose = yaml.safe_load(COMPOSE_PATH.read_text(encoding="utf-8"))
+    return compose["services"]["traefik"]
+
+
+def _production_traefik() -> dict[str, object]:
+    compose = yaml.safe_load(PRODUCTION_COMPOSE_PATH.read_text(encoding="utf-8"))
     return compose["services"]["traefik"]
 
 
@@ -20,6 +26,14 @@ def test_traefik_watches_the_dynamic_configuration_directory() -> None:
     assert "./traefik/dynamic:/etc/traefik/dynamic:ro" in traefik["volumes"]
 
 
+def test_production_traefik_watches_the_dynamic_configuration_directory() -> None:
+    traefik = _production_traefik()
+
+    assert "--providers.file.directory=/etc/traefik/dynamic" in traefik["command"]
+    assert "--providers.file.watch=true" in traefik["command"]
+    assert "../../traefik/dynamic:/etc/traefik/dynamic:ro" in traefik["volumes"]
+
+
 def test_dynamic_provider_preserves_existing_security_boundaries() -> None:
     traefik = _traefik()
 
@@ -28,4 +42,3 @@ def test_dynamic_provider_preserves_existing_security_boundaries() -> None:
     assert "--certificatesresolvers.le.acme.tlschallenge=true" in traefik["command"]
     assert "/var/run/docker.sock:/var/run/docker.sock:ro" in traefik["volumes"]
     assert "./letsencrypt:/letsencrypt" in traefik["volumes"]
-

--- a/tests/test_traefik_dynamic_configuration.py
+++ b/tests/test_traefik_dynamic_configuration.py
@@ -6,6 +6,7 @@ import yaml
 ROOT = Path(__file__).resolve().parents[1]
 COMPOSE_PATH = ROOT / "docker-compose.yml"
 PRODUCTION_COMPOSE_PATH = ROOT / "deploy" / "production" / "docker-compose.production.yml"
+BACKUP_SCRIPT_PATH = ROOT / "scripts" / "backup-production.sh"
 
 
 def _traefik() -> dict[str, object]:
@@ -47,3 +48,9 @@ def test_dynamic_provider_preserves_existing_security_boundaries() -> None:
 
     assert "./letsencrypt:/letsencrypt" in development["volumes"]
     assert "../../letsencrypt:/letsencrypt" in production["volumes"]
+
+
+def test_production_backup_preserves_dynamic_tenant_routes() -> None:
+    backup_script = BACKUP_SCRIPT_PATH.read_text(encoding="utf-8")
+
+    assert "deploy/production monitoring letsencrypt models traefik/dynamic" in backup_script

--- a/tests/test_traefik_dynamic_configuration.py
+++ b/tests/test_traefik_dynamic_configuration.py
@@ -42,6 +42,7 @@ def test_dynamic_provider_preserves_existing_security_boundaries() -> None:
         assert "--providers.docker=true" in traefik["command"]
         assert "--providers.docker.exposedbydefault=false" in traefik["command"]
         assert "--certificatesresolvers.le.acme.tlschallenge=true" in traefik["command"]
+        assert "--certificatesresolvers.le.acme.storage=/letsencrypt/acme.json" in traefik["command"]
         assert "/var/run/docker.sock:/var/run/docker.sock:ro" in traefik["volumes"]
 
     assert "./letsencrypt:/letsencrypt" in development["volumes"]


### PR DESCRIPTION
## Goal

Provide the narrow Traefik integration boundary required for automated Kassel Studio tenant ingress without granting Studio Docker or ACME access.

## Changes

- enable Traefik's watched File Provider directory
- mount the dynamic directory read-only into Traefik
- keep the Docker Provider, read-only Docker socket, TLS-ALPN resolver, and ACME storage unchanged
- add a tracked empty directory and focused Compose contract tests
- document rollout and non-destructive rollback in an OpenSpec change

## Verification

- `uv run --no-project --with-requirements services/api_gateway/requirements.txt --with pytest --with pyyaml pytest tests/test_traefik_dynamic_configuration.py -q`
- `npm exec -- openspec validate add-kassel-tenant-ingress-file-provider --strict`
- `docker compose config --quiet` with placeholder values for all required environment variables
- `git diff --check`

## Rollout boundary

This PR only enables an empty read-only provider directory. Existing routes remain Docker-provider-owned. The Studio provisioner writer and per-tenant migration are delivered separately in `sva-studio` and must remain disabled until this PR is rolled out and the existing hosts are verified.
